### PR TITLE
fix: 添加环境变量同步脚本到 Docker 启动流程

### DIFF
--- a/Dockerfile.binary
+++ b/Dockerfile.binary
@@ -31,8 +31,37 @@ RUN mkdir -p /app/data /app/public/images
 # 复制 .env.example 为默认 .env
 RUN cp /app/.env.example /app/.env
 
+# 创建启动脚本：同步环境变量到 .env 文件
+RUN cat > /app/entrypoint.sh << 'EOF'
+#!/bin/sh
+# 同步环境变量到 .env 文件
+ENV_FILE="/app/.env"
+
+# 需要同步的环境变量列表
+KEYS="API_KEY ADMIN_USERNAME ADMIN_PASSWORD JWT_SECRET PROXY SYSTEM_INSTRUCTION IMAGE_BASE_URL"
+
+for key in $KEYS; do
+  value=$(eval echo \$$key)
+  if [ -n "$value" ]; then
+    # 检查是否已存在该配置
+    if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+      # 替换现有配置
+      sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+    else
+      # 添加新配置
+      echo "${key}=${value}" >> "$ENV_FILE"
+    fi
+    echo "✓ 已同步环境变量: ${key}"
+  fi
+done
+
+# 启动应用
+exec /app/antigravity
+EOF
+RUN chmod +x /app/entrypoint.sh
+
 # 暴露端口
 EXPOSE 8045
 
 # 启动应用
-CMD ["/app/antigravity"]
+CMD ["/app/entrypoint.sh"]


### PR DESCRIPTION
- 创建 entrypoint.sh 脚本同步环境变量到 .env 文件
- 支持 API_KEY, ADMIN_USERNAME, ADMIN_PASSWORD, JWT_SECRET, PROXY, SYSTEM_INSTRUCTION, IMAGE_BASE_URL