### PR TITLE
feat: add Anthropic official model name mapping for Claude Code compatibility

### DIFF
--- a/src/server/handlers/claude.js
+++ b/src/server/handlers/claude.js
@@ -110,23 +110,23 @@ export const createClaudeResponse = (id, model, content, reasoning, reasoningSig
  */
 export const handleClaudeRequest = async (req, res, isStream) => {
   const { messages, model, system, tools, ...rawParams } = req.body;
-  
+
   try {
     if (!messages) {
       return res.status(400).json(buildClaudeErrorPayload({ message: 'messages is required' }, 400));
     }
-    
+
     const token = await tokenManager.getToken();
     if (!token) {
       throw new Error('没有可用的token，请运行 npm run login 获取token');
     }
-    
+
     // 使用统一参数规范化模块处理 Claude 格式参数
     const parameters = normalizeClaudeParameters(rawParams);
-    
+
     const isImageModel = model.includes('-image');
     const requestBody = generateClaudeRequestBody(messages, model, parameters, tools, system, token);
-    
+
     if (isImageModel) {
       prepareImageRequest(requestBody);
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -54,8 +54,54 @@ export function cleanParameters(obj) {
   return cleaned;
 }
 
-// ==================== 模型映射 ====================
+// ==================== Model Mapping ====================
+// Map Anthropic official model names to Antigravity model names
+// Supports Claude Code and other clients that use official Anthropic model naming
 export function modelMapping(modelName) {
+  // Dynamic matching for Anthropic official model name formats:
+  // - claude-{type}-{major}-{minor}-{date} (e.g., claude-sonnet-4-5-20250929)
+  // - claude-{type}-{major}-{date} (e.g., claude-sonnet-4-20250514)
+  // - claude-{major}-{minor}-{type}-{date} (e.g., claude-3-5-sonnet-20241022)
+  // - claude-{major}-{type}-{date} (e.g., claude-3-opus-20240229)
+  // - claude-{version}-{type}-latest (e.g., claude-3-5-sonnet-latest)
+
+  // Pattern 1: claude-{type}-{version}-{date} (Claude 4+ format)
+  // e.g., claude-sonnet-4-5-20250929, claude-opus-4-20250514
+  const pattern1 = modelName.match(/^claude-(sonnet|opus|haiku)-\d+(-\d+)?-\d{8}$/);
+  if (pattern1) {
+    const type = pattern1[1];
+    if (type === 'opus') return 'claude-opus-4-5-thinking';
+    return 'claude-sonnet-4-5';
+  }
+
+  // Pattern 2: claude-{major}-{minor}-{type}-{date} (Claude 3.x format)
+  // e.g., claude-3-5-sonnet-20241022, claude-3-5-haiku-20241022
+  const pattern2 = modelName.match(/^claude-\d+-\d+-(sonnet|opus|haiku)-\d{8}$/);
+  if (pattern2) {
+    const type = pattern2[1];
+    if (type === 'opus') return 'claude-opus-4-5-thinking';
+    return 'claude-sonnet-4-5';
+  }
+
+  // Pattern 3: claude-{major}-{type}-{date} (Claude 3 format)
+  // e.g., claude-3-opus-20240229, claude-3-sonnet-20240229
+  const pattern3 = modelName.match(/^claude-\d+-(sonnet|opus|haiku)-\d{8}$/);
+  if (pattern3) {
+    const type = pattern3[1];
+    if (type === 'opus') return 'claude-opus-4-5-thinking';
+    return 'claude-sonnet-4-5';
+  }
+
+  // Pattern 4: claude-{version}-{type}-latest
+  // e.g., claude-3-5-sonnet-latest, claude-3-opus-latest
+  const pattern4 = modelName.match(/^claude-(\d+-)?(.+)-latest$/);
+  if (pattern4) {
+    const remainder = pattern4[2];
+    if (remainder.includes('opus')) return 'claude-opus-4-5-thinking';
+    return 'claude-sonnet-4-5';
+  }
+
+  // Original logic (kept for backward compatibility)
   if (modelName === 'claude-sonnet-4-5-thinking') return 'claude-sonnet-4-5';
   if (modelName === 'claude-opus-4-5') return 'claude-opus-4-5-thinking';
   if (modelName === 'gemini-2.5-flash-thinking') return 'gemini-2.5-flash';


### PR DESCRIPTION
## Summary

- Add dynamic regex-based model name mapping to support Claude Code and other clients that use official Anthropic model naming conventions
- Enables seamless integration with Claude Code CLI tool

Fixes #82

## Changes

Enhanced modelMapping() function with 4 regex patterns to handle all Anthropic model name formats.

### Mapping Rules

- opus models -> claude-opus-4-5-thinking
- sonnet/haiku models -> claude-sonnet-4-5

## Test Plan

- [x] Test with Claude Code CLI tool
- [x] Verify backward compatibility with existing model names

🤖 Generated with [Claude Code](https://claude.com/claude-code)