### PR TITLE
feat: retry when 503 no capacity

### DIFF
--- a/API.md
+++ b/API.md
@@ -264,9 +264,9 @@ curl http://localhost:8045/v1/chat/completions \
   }'
 ```
 
-### 429 自动重试配置
+### 429/503 自动重试配置
 
-所有 429 重试次数仅通过服务端配置控制：
+所有 429/503 重试次数仅通过服务端配置控制（503 仅重试 MODEL_CAPACITY_EXHAUSTED 容量不足错误）：
 
 - 全局默认重试次数（服务端配置）：
   - 文件：`config.json` 中的 `other.retryTimes`
@@ -279,7 +279,7 @@ curl http://localhost:8045/v1/chat/completions \
       "useNativeAxios": false
     }
     ```
-  - 服务器始终使用这里配置的值作为 429 时的重试次数（默认 3 次）。
+  - 服务器始终使用这里配置的值作为 429/503 时的重试次数（默认 3 次）。
 
 ### 思维链响应格式
 

--- a/public/index.html
+++ b/public/index.html
@@ -652,7 +652,7 @@
                                                 <input type="number" name="TIMEOUT" placeholder="300000">
                                             </div>
                                             <div class="form-group compact">
-                                                <label>429重试次数</label>
+                                                <label>429/503重试次数</label>
                                                 <input type="number" name="RETRY_TIMES" placeholder="0">
                                             </div>
                                         </div>


### PR DESCRIPTION
retry when returning no capacity error `{ "error": { "code": 503, "message": "No capacity available for model claude-opus-4-5-thinking on the server", "status": "UNAVAILABLE", "details": [ { "@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "MODEL_CAPACITY_EXHAUSTED", "domain": "cloudcode-pa.googleapis.com", "metadata": { "model": "claude-opus-4-5-thinking" } } ] } } `