### PR TITLE
fix: prevent claude budget_tokens/max_tokens conflict

### DIFF
--- a/src/utils/parameterNormalizer.js
+++ b/src/utils/parameterNormalizer.js
@@ -160,12 +160,32 @@ export function toGenerationConfig(normalized, enableThinking, actualModelName) 
     }
   }
 
+  const maxOutputTokens = normalized.max_tokens || normalized.max_completion_tokens;
+
+  // Claude 的 thinking.budget_tokens 必须严格小于 max_tokens，否则会返回 400
+  if (actualEnableThinking && actualModelName && actualModelName.includes('claude')) {
+    const numericMaxOutputTokens = Number(maxOutputTokens);
+    const numericThinkingBudget = Number(thinkingBudget);
+
+    if (Number.isFinite(numericMaxOutputTokens) &&
+      Number.isFinite(numericThinkingBudget) &&
+      numericThinkingBudget >= numericMaxOutputTokens) {
+      if (numericMaxOutputTokens <= 1024) {
+        // 无法同时满足 Claude 的预算约束，降级为关闭 thinking
+        actualEnableThinking = false;
+        thinkingBudget = 0;
+      } else {
+        thinkingBudget = Math.max(1024, numericMaxOutputTokens - 1);
+      }
+    }
+  }
+
   const generationConfig = {
     topP: normalized.top_p,
     topK: normalized.top_k,
     temperature: normalized.temperature,
     candidateCount: 1,
-    maxOutputTokens: normalized.max_tokens || normalized.max_completion_tokens,
+    maxOutputTokens,
     thinkingConfig: {
       includeThoughts: actualEnableThinking,
       thinkingBudget: thinkingBudget

--- a/test/test-thinking-budget-guard.js
+++ b/test/test-thinking-budget-guard.js
@@ -1,0 +1,39 @@
+import assert from 'assert';
+import { generateGenerationConfig } from '../src/utils/utils.js';
+
+function buildConfig({ max_tokens, thinking_budget, reasoning_effort, model = 'claude-sonnet-4-5', enableThinking = true } = {}) {
+  return generateGenerationConfig({
+    max_tokens,
+    thinking_budget,
+    reasoning_effort,
+    temperature: 1,
+    top_p: 0.9,
+    top_k: 50
+  }, enableThinking, model);
+}
+
+// Case 1: reasoning_effort=high maps to 32000, but must be clamped under max_tokens.
+{
+  const cfg = buildConfig({ max_tokens: 4096, reasoning_effort: 'high' });
+  assert.strictEqual(cfg.maxOutputTokens, 4096);
+  assert.strictEqual(cfg.thinkingConfig.includeThoughts, true);
+  assert.strictEqual(cfg.thinkingConfig.thinkingBudget, 4095);
+}
+
+// Case 2: explicit thinking_budget larger than max_tokens should be clamped.
+{
+  const cfg = buildConfig({ max_tokens: 2000, thinking_budget: 5000 });
+  assert.strictEqual(cfg.maxOutputTokens, 2000);
+  assert.strictEqual(cfg.thinkingConfig.includeThoughts, true);
+  assert.strictEqual(cfg.thinkingConfig.thinkingBudget, 1999);
+}
+
+// Case 3: when max_tokens is too small (<=1024), thinking is disabled to avoid upstream 400.
+{
+  const cfg = buildConfig({ max_tokens: 1024, thinking_budget: 1024 });
+  assert.strictEqual(cfg.maxOutputTokens, 1024);
+  assert.strictEqual(cfg.thinkingConfig.includeThoughts, false);
+  assert.strictEqual(cfg.thinkingConfig.thinkingBudget, 0);
+}
+
+console.log('test-thinking-budget-guard passed');


### PR DESCRIPTION
## 问题
在 Claude 思考模式下，当 `thinking_budget`（或 `reasoning_effort` 映射后的预算）大于等于 `max_tokens` 时，会触发上游 400：

- `max_tokens must be greater than thinking.budget_tokens`

对应 issue: #150

## 根因
参数转换阶段没有保证 `thinkingBudget < maxOutputTokens`。

## 修复
在 `toGenerationConfig` 中为 Claude 增加保护逻辑：

1. 当 `thinkingBudget >= maxOutputTokens` 且 `maxOutputTokens > 1024`：
- 自动将预算收敛到 `maxOutputTokens - 1`

2. 当 `maxOutputTokens <= 1024` 且无法满足 Claude 约束：
- 自动关闭 thinking（`includeThoughts=false`, `thinkingBudget=0`）避免请求直接 400

## 新增测试
`test/test-thinking-budget-guard.js`
- Case 1: `reasoning_effort=high` + `max_tokens=4096` -> budget 收敛到 4095
- Case 2: `thinking_budget=5000` + `max_tokens=2000` -> budget 收敛到 1999
- Case 3: `max_tokens=1024` + `thinking_budget=1024` -> 自动关闭 thinking

## 本地验证
- `node --check src/utils/parameterNormalizer.js`
- `node --check test/test-thinking-budget-guard.js`
- `node test/test-thinking-budget-guard.js`

Closes #150
