### PR TITLE
feat: support configurable 429/503 retry delay intervals

### DIFF
--- a/API.md
+++ b/API.md
@@ -269,17 +269,25 @@ curl http://localhost:8045/v1/chat/completions \
 所有 429/503 重试次数仅通过服务端配置控制（503 仅重试 MODEL_CAPACITY_EXHAUSTED 容量不足错误）：
 
 - 全局默认重试次数（服务端配置）：
-  - 文件：`config.json` 中的 `other.retryTimes`
+  - 文件：`config.json` 中的：
+    - `other.retryTimes`：最大重试次数
+    - `other.retryFirstDelayMinMs`：首次重试最小等待（ms）
+    - `other.retryStepMinMs`：每轮重试额外递增等待（ms）
   - 示例：
     ```json
     "other": {
       "timeout": 300000,
       "retryTimes": 3,
+      "retryFirstDelayMinMs": 0,
+      "retryStepMinMs": 0,
       "skipProjectIdFetch": false,
       "useNativeAxios": false
     }
     ```
-  - 服务器始终使用这里配置的值作为 429/503 时的重试次数（默认 3 次）。
+  - 服务器始终使用这里配置作为 429/503 重试策略：
+    - 默认 `retryTimes=3`
+    - 默认 `retryFirstDelayMinMs=0`（不额外抬高首轮下限）
+    - 默认 `retryStepMinMs=0`（不额外递增）
 
 ### 思维链响应格式
 

--- a/config.json.example
+++ b/config.json.example
@@ -44,6 +44,8 @@
   "other": {
     "timeout": 300000,
     "retryTimes": 10,
+    "retryFirstDelayMinMs": 0,
+    "retryStepMinMs": 0,
     "forceIPv4": false,
     "skipProjectIdFetch": false,
     "useNativeAxios": false,

--- a/public/index.html
+++ b/public/index.html
@@ -656,6 +656,18 @@
                                                 <input type="number" name="RETRY_TIMES" placeholder="0">
                                             </div>
                                         </div>
+                                        <div class="form-row-inline">
+                                            <div class="form-group compact">
+                                                <label>重试首轮最小等待(ms) <span class="help-tip"
+                                                        data-tooltip="429/503 首次重试的最小等待下限；0 表示不额外抬高">?</span></label>
+                                                <input type="number" name="RETRY_FIRST_DELAY_MIN_MS" placeholder="0">
+                                            </div>
+                                            <div class="form-group compact">
+                                                <label>重试每轮递增等待(ms) <span class="help-tip"
+                                                        data-tooltip="每次后续重试在最小等待下限上额外增加的毫秒数">?</span></label>
+                                                <input type="number" name="RETRY_STEP_MIN_MS" placeholder="0">
+                                            </div>
+                                        </div>
 
                                         <div class="form-row-inline">
                                             <div class="form-group compact">

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -144,6 +144,8 @@ async function loadConfig() {
             if (json.other) {
                 if (form.elements['TIMEOUT']) form.elements['TIMEOUT'].value = json.other.timeout ?? '';
                 if (form.elements['RETRY_TIMES']) form.elements['RETRY_TIMES'].value = json.other.retryTimes ?? '';
+                if (form.elements['RETRY_FIRST_DELAY_MIN_MS']) form.elements['RETRY_FIRST_DELAY_MIN_MS'].value = json.other.retryFirstDelayMinMs ?? '';
+                if (form.elements['RETRY_STEP_MIN_MS']) form.elements['RETRY_STEP_MIN_MS'].value = json.other.retryStepMinMs ?? '';
                 if (form.elements['SKIP_PROJECT_ID_FETCH']) form.elements['SKIP_PROJECT_ID_FETCH'].checked = json.other.skipProjectIdFetch || false;
                 if (form.elements['USE_NATIVE_AXIOS']) form.elements['USE_NATIVE_AXIOS'].checked = json.other.useNativeAxios !== false;
                 if (form.elements['USE_CONTEXT_SYSTEM_PROMPT']) form.elements['USE_CONTEXT_SYSTEM_PROMPT'].checked = json.other.useContextSystemPrompt || false;
@@ -324,6 +326,14 @@ async function saveConfig(e) {
             else if (key === 'RETRY_TIMES') {
                 const num = parseInt(value);
                 jsonConfig.other.retryTimes = Number.isNaN(num) ? undefined : num;
+            }
+            else if (key === 'RETRY_FIRST_DELAY_MIN_MS') {
+                const num = parseInt(value);
+                jsonConfig.other.retryFirstDelayMinMs = Number.isNaN(num) ? undefined : num;
+            }
+            else if (key === 'RETRY_STEP_MIN_MS') {
+                const num = parseInt(value);
+                jsonConfig.other.retryStepMinMs = Number.isNaN(num) ? undefined : num;
             }
             else if (key === 'SKIP_PROJECT_ID_FETCH' || key === 'USE_NATIVE_AXIOS' || key === 'USE_CONTEXT_SYSTEM_PROMPT' || key === 'MERGE_SYSTEM_PROMPT' || key === 'OFFICIAL_PROMPT_POSITION' || key === 'PASS_SIGNATURE_TO_CLIENT' || key === 'USE_FALLBACK_SIGNATURE' || key === 'CACHE_ALL_SIGNATURES' || key === 'CACHE_TOOL_SIGNATURES' || key === 'CACHE_IMAGE_SIGNATURES' || key === 'CACHE_THINKING' || key === 'FAKE_NON_STREAM') {
                 // 跳过，已在上面处理

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -11,6 +11,8 @@ import {
   DEFAULT_HEARTBEAT_INTERVAL,
   DEFAULT_TIMEOUT,
   DEFAULT_RETRY_TIMES,
+  DEFAULT_RETRY_FIRST_DELAY_MIN_MS,
+  DEFAULT_RETRY_STEP_MIN_MS,
   DEFAULT_MAX_REQUEST_SIZE,
   DEFAULT_MAX_IMAGES,
   MODEL_LIST_CACHE_TTL,
@@ -333,6 +335,12 @@ export function buildConfig(jsonConfig) {
     forceIPv4: jsonConfig.other?.forceIPv4 === true,
     timeout: jsonConfig.other?.timeout || DEFAULT_TIMEOUT,
     retryTimes: Number.isFinite(jsonConfig.other?.retryTimes) ? jsonConfig.other.retryTimes : DEFAULT_RETRY_TIMES,
+    retryFirstDelayMinMs: Number.isFinite(jsonConfig.other?.retryFirstDelayMinMs)
+      ? Math.max(0, jsonConfig.other.retryFirstDelayMinMs)
+      : DEFAULT_RETRY_FIRST_DELAY_MIN_MS,
+    retryStepMinMs: Number.isFinite(jsonConfig.other?.retryStepMinMs)
+      ? Math.max(0, jsonConfig.other.retryStepMinMs)
+      : DEFAULT_RETRY_STEP_MIN_MS,
     proxy: getProxyConfig(),
     // 反代系统提示词（从 .env 读取，可在前端修改，空字符串代表不使用）
     systemInstruction: process.env.SYSTEM_INSTRUCTION ?? '',

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -77,6 +77,20 @@ export const DEFAULT_TIMEOUT = 300000;
 export const DEFAULT_RETRY_TIMES = 3;
 
 /**
+ * 429/503 重试首轮最小等待（毫秒）
+ * 0 表示不额外抬高首轮下限（仍会应用上游显式延迟与默认退避逻辑）
+ * @type {number}
+ */
+export const DEFAULT_RETRY_FIRST_DELAY_MIN_MS = 0;
+
+/**
+ * 429/503 重试每轮额外增加的最小等待（毫秒）
+ * 0 表示不开启递增下限
+ * @type {number}
+ */
+export const DEFAULT_RETRY_STEP_MIN_MS = 0;
+
+/**
  * 默认最大请求体大小
  * @type {string}
  */

--- a/src/server/stream.js
+++ b/src/server/stream.js
@@ -223,25 +223,41 @@ function getUpstreamRetryDelayMs(error) {
   return bestMs;
 }
 
-function computeBackoffMs(attempt, explicitDelayMs) {
+function computeBackoffMs(attempt, explicitDelayMs, retryConfig = {}, randomFn = Math.random) {
   // attempt starts from 0 for first call; on first retry attempt=1
   const maxMs = 20_000;
   const hasExplicit = Number.isFinite(explicitDelayMs) && explicitDelayMs !== null;
   const baseMs = hasExplicit ? Math.max(0, Math.floor(explicitDelayMs)) : 500;
   const exp = Math.min(maxMs, Math.floor(baseMs * Math.pow(2, Math.max(0, attempt - 1))));
 
+  const firstDelayMinMsRaw = hasExplicit ? 0 : 500;
+  const firstDelayMinMs = Number.isFinite(retryConfig?.firstDelayMinMs)
+    ? Math.max(0, Math.floor(retryConfig.firstDelayMinMs))
+    : firstDelayMinMsRaw;
+  const stepMinMs = Number.isFinite(retryConfig?.stepMinMs)
+    ? Math.max(0, Math.floor(retryConfig.stepMinMs))
+    : 0;
+  const progressiveMinMs = firstDelayMinMs + Math.max(0, attempt - 1) * stepMinMs;
+
   // Add small jitter to spread bursts (±20%)
-  const jitterFactor = 0.8 + Math.random() * 0.4;
+  const randomCandidate = typeof randomFn === 'function' ? randomFn() : 0.5;
+  const randomValue = Number.isFinite(randomCandidate) ? randomCandidate : 0.5;
+  const jitterFactor = 0.8 + Math.max(0, Math.min(1, randomValue)) * 0.4;
   const expJittered = Math.max(0, Math.floor(exp * jitterFactor));
 
   if (hasExplicit) {
     // Add a small safety buffer to avoid retrying slightly too early
     const buffered = Math.max(0, Math.floor(explicitDelayMs + 50));
-    return Math.min(maxMs, Math.max(expJittered, buffered));
+    return Math.min(maxMs, Math.max(expJittered, buffered, progressiveMinMs));
   }
 
   // Fallback: at least 0.5s for the first retry
-  return Math.min(maxMs, Math.max(500, expJittered));
+  return Math.min(maxMs, Math.max(500, expJittered, progressiveMinMs));
+}
+
+// 仅供测试使用
+export function __test_computeBackoffMs(attempt, explicitDelayMs, retryConfig = {}, randomFn = () => 0.5) {
+  return computeBackoffMs(attempt, explicitDelayMs, retryConfig, randomFn);
 }
 
 /**
@@ -331,6 +347,10 @@ export async function with429Retry(fn, maxRetries, options = {}, legacyOnAttempt
 
   const retries = Number.isFinite(maxRetries) && maxRetries > 0 ? Math.floor(maxRetries) : 0;
   const cooldownThreshold = config.quota?.longCooldownThreshold || LONG_COOLDOWN_THRESHOLD;
+  const retryDelayConfig = {
+    firstDelayMinMs: config.retryFirstDelayMinMs,
+    stepMinMs: config.retryStepMinMs
+  };
   let attempt = 0;
 
   // 首次执行 + 最多 retries 次重试
@@ -392,7 +412,7 @@ export async function with429Retry(fn, maxRetries, options = {}, legacyOnAttempt
         // 短时间等待，正常重试
         if (attempt < retries) {
           const nextAttempt = attempt + 1;
-          const waitMs = computeBackoffMs(nextAttempt, explicitDelayMs);
+          const waitMs = computeBackoffMs(nextAttempt, explicitDelayMs, retryDelayConfig);
           logger.warn(
             `${loggerPrefix}收到 ${errorType}，等待 ${waitMs}ms 后进行第 ${nextAttempt} 次重试（共 ${retries} 次）` +
             (explicitDelayMs !== null ? `（上游提示≈${explicitDelayMs}ms）` : '')

--- a/test/test-retry-backoff-config.js
+++ b/test/test-retry-backoff-config.js
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { __test_computeBackoffMs } from '../src/server/stream.js';
+
+const fixedRandom = () => 0.5; // jitterFactor = 1.0
+
+// Case 1: explicit delay uses upstream hint + safety buffer by default
+{
+  const wait = __test_computeBackoffMs(1, 300, {}, fixedRandom);
+  assert.strictEqual(wait, 350);
+}
+
+// Case 2: configurable first retry minimum delay floor
+{
+  const wait = __test_computeBackoffMs(1, 300, { firstDelayMinMs: 3000, stepMinMs: 2000 }, fixedRandom);
+  assert.strictEqual(wait, 3000);
+}
+
+// Case 3: configurable per-attempt incremental floor
+{
+  const wait = __test_computeBackoffMs(2, 300, { firstDelayMinMs: 3000, stepMinMs: 2000 }, fixedRandom);
+  assert.strictEqual(wait, 5000);
+}
+
+// Case 4: no explicit delay still respects configured floors
+{
+  const wait = __test_computeBackoffMs(1, null, { firstDelayMinMs: 2000, stepMinMs: 1000 }, fixedRandom);
+  assert.strictEqual(wait, 2000);
+}
+
+console.log('test-retry-backoff-config passed');


### PR DESCRIPTION
## Summary
- add configurable retry delay floors for 429/503 retries
- support two new config fields: `other.retryFirstDelayMinMs` and `other.retryStepMinMs`
- wire new fields through backend config parser and web config page
- update API docs and example config
- add deterministic unit test for retry backoff behavior

## Why
Issue #143 requests customizable retry interval behavior:
- customize first retry delay
- customize incremental delay between retries

This PR keeps existing behavior by default while allowing explicit tuning.

## Changes
- `src/constants/index.js`: add defaults for new retry delay settings
- `src/config/config.js`: parse and sanitize retry delay settings
- `src/server/stream.js`: apply configurable progressive minimum delay in retry backoff
- `public/index.html`: add inputs for retry delay settings
- `public/js/config.js`: load/save new settings
- `config.json.example`: add new keys under `other`
- `API.md`: document new retry settings
- `test/test-retry-backoff-config.js`: add backoff config tests

## Backward compatibility
- defaults are `0` for both new fields, so existing deployments keep current retry timing unless configured

## Verification
- `node --check src/server/stream.js`
- `node --check src/config/config.js`
- `node --check public/js/config.js`
- `node --check test/test-retry-backoff-config.js`
- `node test/test-retry-backoff-config.js`

Fixes #143
