### PR TITLE
fix: filter internal models from exposed model lists

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -27,6 +27,7 @@ import { getUpstreamStatus, readUpstreamErrorBody, isCallerDoesNotHavePermission
 import { createStreamLineProcessor } from './streamLineProcessor.js';
 import { runAxiosSseStream, runNativeSseStream, postJsonAndParse } from './geminiTransport.js';
 import { parseGeminiCandidateParts, toOpenAIUsage } from './geminiResponseParser.js';
+import { isModelUserFacing, toOpenAIModelItem } from '../utils/modelVisibility.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -87,10 +88,8 @@ const DEFAULT_MODELS = Object.freeze([
   'gemini-2.5-pro',
   'gemini-2.5-flash',
   'gemini-3-pro-low',
-  'chat_20706',
   'rev19-uic3-1p',
-  'gpt-oss-120b-medium',
-  'chat_23310'
+  'gpt-oss-120b-medium'
 ]);
 
 // 生成默认模型列表响应
@@ -98,12 +97,9 @@ function getDefaultModelList() {
   const created = Math.floor(Date.now() / 1000);
   return {
     object: 'list',
-    data: DEFAULT_MODELS.map(id => ({
-      id,
-      object: 'model',
-      created,
-      owned_by: 'google'
-    }))
+    data: DEFAULT_MODELS
+      .filter(id => isModelUserFacing(id))
+      .map(id => toOpenAIModelItem(id, created))
   };
 }
 
@@ -270,23 +266,28 @@ export async function getAvailableModels() {
   }
 
   const created = Math.floor(Date.now() / 1000);
-  const modelList = Object.keys(data.models || {}).map(id => ({
-    id,
-    object: 'model',
-    created,
-    owned_by: 'google'
-  }));
+  const rawModelEntries = Object.entries(data.models || {});
+  const hiddenUpstreamModelIds = [];
+  const modelList = [];
+
+  for (const [id, modelData] of rawModelEntries) {
+    if (!isModelUserFacing(id, modelData)) {
+      hiddenUpstreamModelIds.push(id);
+      continue;
+    }
+    modelList.push(toOpenAIModelItem(id, created));
+  }
+
+  if (hiddenUpstreamModelIds.length > 0) {
+    logger.info(`模型列表过滤了 ${hiddenUpstreamModelIds.length} 个内部/不可用模型`);
+  }
 
   // 添加默认模型（如果 API 返回的列表中没有）
   const existingIds = new Set(modelList.map(m => m.id));
   for (const defaultModel of DEFAULT_MODELS) {
+    if (!isModelUserFacing(defaultModel)) continue;
     if (!existingIds.has(defaultModel)) {
-      modelList.push({
-        id: defaultModel,
-        object: 'model',
-        created,
-        owned_by: 'google'
-      });
+      modelList.push(toOpenAIModelItem(defaultModel, created));
     }
   }
 

--- a/src/utils/modelVisibility.js
+++ b/src/utils/modelVisibility.js
@@ -1,0 +1,39 @@
+const HIDDEN_MODEL_IDS = new Set([
+  'tab_flash_lite_preview'
+]);
+
+const HIDDEN_MODEL_PREFIXES = [
+  'chat_'
+];
+
+function isMarkedInternal(modelData) {
+  if (!modelData || typeof modelData !== 'object') return false;
+
+  if (modelData.isInternal === true || modelData.is_internal === true) {
+    return true;
+  }
+
+  const visibility = String(modelData.visibility || modelData.lifecycle || '').trim().toLowerCase();
+  return visibility === 'internal';
+}
+
+export function isModelUserFacing(modelId, modelData = null) {
+  if (typeof modelId !== 'string') return false;
+  const normalizedId = modelId.trim();
+  if (!normalizedId) return false;
+
+  if (HIDDEN_MODEL_IDS.has(normalizedId)) return false;
+  if (HIDDEN_MODEL_PREFIXES.some(prefix => normalizedId.startsWith(prefix))) return false;
+  if (isMarkedInternal(modelData)) return false;
+
+  return true;
+}
+
+export function toOpenAIModelItem(modelId, created, owner = 'google') {
+  return {
+    id: modelId,
+    object: 'model',
+    created,
+    owned_by: owner
+  };
+}

--- a/test/test-model-visibility.js
+++ b/test/test-model-visibility.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { isModelUserFacing, toOpenAIModelItem } from '../src/utils/modelVisibility.js';
+
+// Internal/hidden model ids should be filtered out.
+assert.strictEqual(isModelUserFacing('tab_flash_lite_preview'), false);
+assert.strictEqual(isModelUserFacing('chat_20706'), false);
+
+// Explicit internal flags from upstream metadata should be filtered out.
+assert.strictEqual(isModelUserFacing('gemini-2.5-pro', { isInternal: true }), false);
+assert.strictEqual(isModelUserFacing('gemini-2.5-pro', { is_internal: true }), false);
+assert.strictEqual(isModelUserFacing('gemini-2.5-pro', { visibility: 'INTERNAL' }), false);
+
+// Regular model ids should remain available.
+assert.strictEqual(isModelUserFacing('gemini-2.5-pro'), true);
+assert.strictEqual(isModelUserFacing('claude-sonnet-4-5'), true);
+
+// Empty/invalid ids should be rejected.
+assert.strictEqual(isModelUserFacing(''), false);
+assert.strictEqual(isModelUserFacing('   '), false);
+assert.strictEqual(isModelUserFacing(null), false);
+
+// Model list item format should stay OpenAI-compatible.
+const created = 123456;
+assert.deepStrictEqual(toOpenAIModelItem('gemini-2.5-pro', created), {
+  id: 'gemini-2.5-pro',
+  object: 'model',
+  created,
+  owned_by: 'google'
+});
+
+console.log('test-model-visibility passed');


### PR DESCRIPTION
## Summary
- filter internal/non-user-facing models out of exposed model lists
- hide known non-chat/internal ids such as `tab_flash_lite_preview` and `chat_*`
- honor upstream internal flags (`isInternal` / `is_internal` / `visibility=internal`)
- keep OpenAI-compatible model item format via shared helper
- add regression tests for model visibility filtering

## Why
Issue #147 reports that `tab_flash_lite_preview` appears but cannot be used and returns `INVALID_ARGUMENT`.

This PR avoids exposing internal or unsupported model ids in model lists, so clients won't select unusable entries.

## Changes
- `src/utils/modelVisibility.js`
  - add `isModelUserFacing(modelId, modelData)`
  - add `toOpenAIModelItem(...)`
- `src/api/client.js`
  - apply model filtering to upstream model list
  - apply the same filtering to default fallback models
  - remove internal `chat_*` entries from fallback default model array
- `test/test-model-visibility.js`
  - add coverage for internal IDs, internal flags, and formatting

## Verification
- `node --check src/api/client.js`
- `node --check src/utils/modelVisibility.js`
- `node --check test/test-model-visibility.js`
- `node test/test-model-visibility.js`

Fixes #147
