### PR TITLE
添加代理池,开发者文档,批量获取认证url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,7 @@ dist/
 gcli2api/
 plans/geminicli-implementation-plan.md
 
+# 临时笔记
+getQ.md
+
 security.json

--- a/API.md
+++ b/API.md
@@ -136,6 +136,7 @@ curl http://localhost:8045/v1/chat/completions \
 ```
 
 **响应示例**：
+
 ```json
 {
   "choices": [{
@@ -148,23 +149,24 @@ curl http://localhost:8045/v1/chat/completions \
 ```
 
 **注意**：
+
 - 生成的图片会保存到 `public/images/` 目录
 - 需要配置 `IMAGE_BASE_URL` 环境变量以返回正确的图片 URL
 
 ## 请求参数说明
 
-| 参数 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `model` | string | ✅ | 模型名称 |
-| `messages` | array | ✅ | 对话消息列表 |
-| `stream` | boolean | ❌ | 是否流式响应，默认 false |
-| `temperature` | number | ❌ | 温度参数，默认 1 |
-| `top_p` | number | ❌ | Top P 参数，默认 1 |
-| `top_k` | number | ❌ | Top K 参数，默认 50 |
-| `max_tokens` | number | ❌ | 最大 token 数，默认 32000 |
-| `thinking_budget` | number | ❌ | 思考预算（仅对思考模型生效），可为 0 或 1024-32000，默认 1024（0 表示关闭思考预算限制） |
-| `reasoning_effort` | string | ❌ | 思维链强度（OpenAI 格式），可选值：`low`(1024)、`medium`(16000)、`high`(32000) |
-| `tools` | array | ❌ | 工具列表（Function Calling） |
+| 参数               | 类型    | 必填 | 说明                                                                                    |
+| ------------------ | ------- | ---- | --------------------------------------------------------------------------------------- |
+| `model`            | string  | ✅    | 模型名称                                                                                |
+| `messages`         | array   | ✅    | 对话消息列表                                                                            |
+| `stream`           | boolean | ❌    | 是否流式响应，默认 false                                                                |
+| `temperature`      | number  | ❌    | 温度参数，默认 1                                                                        |
+| `top_p`            | number  | ❌    | Top P 参数，默认 1                                                                      |
+| `top_k`            | number  | ❌    | Top K 参数，默认 50                                                                     |
+| `max_tokens`       | number  | ❌    | 最大 token 数，默认 32000                                                               |
+| `thinking_budget`  | number  | ❌    | 思考预算（仅对思考模型生效），可为 0 或 1024-32000，默认 1024（0 表示关闭思考预算限制） |
+| `reasoning_effort` | string  | ❌    | 思维链强度（OpenAI 格式），可选值：`low`(1024)、`medium`(16000)、`high`(32000)          |
+| `tools`            | array   | ❌    | 工具列表（Function Calling）                                                            |
 
 ## 响应格式
 
@@ -206,13 +208,13 @@ data: [DONE]
 
 API 返回标准的 HTTP 状态码：
 
-| 状态码 | 说明 |
-|--------|------|
-| 200 | 请求成功 |
-| 400 | 请求参数错误 |
-| 401 | API Key 无效 |
-| 429 | 请求过于频繁 |
-| 500 | 服务器内部错误 |
+| 状态码 | 说明           |
+| ------ | -------------- |
+| 200    | 请求成功       |
+| 400    | 请求参数错误   |
+| 401    | API Key 无效   |
+| 429    | 请求过于频繁   |
+| 500    | 服务器内部错误 |
 
 错误响应格式：
 
@@ -244,11 +246,11 @@ curl http://localhost:8045/v1/chat/completions \
   }'
 ```
 
-| reasoning_effort | thinking_budget | 说明 |
-|-----------------|-----------------|------|
-| `low` | 1024 | 快速响应，适合简单问题（默认） |
-| `medium` | 16000 | 平衡模式 |
-| `high` | 32000 | 深度思考，适合复杂推理 |
+| reasoning_effort | thinking_budget | 说明                           |
+| ---------------- | --------------- | ------------------------------ |
+| `low`            | 1024            | 快速响应，适合简单问题（默认） |
+| `medium`         | 16000           | 平衡模式                       |
+| `high`           | 32000           | 深度思考，适合复杂推理         |
 
 ### 使用 thinking_budget（直接数值）
 
@@ -271,6 +273,7 @@ curl http://localhost:8045/v1/chat/completions \
 - 全局默认重试次数（服务端配置）：
   - 文件：`config.json` 中的 `other.retryTimes`
   - 示例：
+
     ```json
     "other": {
       "timeout": 300000,
@@ -279,6 +282,7 @@ curl http://localhost:8045/v1/chat/completions \
       "useNativeAxios": false
     }
     ```
+
   - 服务器始终使用这里配置的值作为 429/503 时的重试次数（默认 3 次）。
 
 ### 思维链响应格式
@@ -286,6 +290,7 @@ curl http://localhost:8045/v1/chat/completions \
 思维链内容通过 `reasoning_content` 字段输出（兼容 DeepSeek 格式）：
 
 **非流式响应**：
+
 ```json
 {
   "choices": [{
@@ -299,6 +304,7 @@ curl http://localhost:8045/v1/chat/completions \
 ```
 
 **流式响应**：
+
 ```
 data: {"choices":[{"delta":{"reasoning_content":"让我"}}]}
 data: {"choices":[{"delta":{"reasoning_content":"思考..."}}]}
@@ -349,13 +355,13 @@ curl http://localhost:8045/sdapi/v1/img2img \
 
 ### 其他 SD API 端点
 
-| 端点 | 说明 |
-|------|------|
+| 端点                      | 说明                   |
+| ------------------------- | ---------------------- |
 | `GET /sdapi/v1/sd-models` | 获取可用的图片生成模型 |
-| `GET /sdapi/v1/options` | 获取当前选项 |
-| `GET /sdapi/v1/samplers` | 获取可用的采样器 |
-| `GET /sdapi/v1/upscalers` | 获取可用的放大器 |
-| `GET /sdapi/v1/progress` | 获取生成进度 |
+| `GET /sdapi/v1/options`   | 获取当前选项           |
+| `GET /sdapi/v1/samplers`  | 获取可用的采样器       |
+| `GET /sdapi/v1/upscalers` | 获取可用的放大器       |
+| `GET /sdapi/v1/progress`  | 获取生成进度           |
 
 ## 管理 API
 
@@ -407,6 +413,7 @@ curl "http://localhost:8045/admin/tokens/REFRESH_TOKEN/quotas?refresh=true" \
 ```
 
 **响应示例**：
+
 ```json
 {
   "success": true,
@@ -441,6 +448,7 @@ curl -X PUT http://localhost:8045/admin/rotation \
 ```
 
 **可用策略**：
+
 - `round_robin`：每次请求切换 Token
 - `quota_exhausted`：额度耗尽才切换
 - `request_count`：自定义请求次数后切换

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ npm install
 你也可以手动复制示例文件：
 
 ```bash
-cp .env.example .env
+cp .env.example .env,.
 cp config.json.example config.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,26 +43,31 @@
 ### 方式一：一键部署脚本（推荐）
 
 **Windows (cmd.exe)**：
+
 ```bash
 curl -O https://raw.githubusercontent.com/liuw1535/antigravity2api-nodejs/main/setup.bat && setup.bat
 ```
 
 **Windows (PowerShell)**：
+
 ```powershell
 IwR -Uri https://raw.githubusercontent.com/liuw1535/antigravity2api-nodejs/main/setup.bat -OutFile setup.bat; .\setup.bat
 ```
 
 **Linux/macOS**：
+
 ```bash
 wget https://raw.githubusercontent.com/liuw1535/antigravity2api-nodejs/main/setup.sh && chmod +x setup.sh && ./setup.sh
 ```
 
 或使用 curl：
+
 ```bash
 curl -O https://raw.githubusercontent.com/liuw1535/antigravity2api-nodejs/main/setup.sh && chmod +x setup.sh && ./setup.sh
 ```
 
 脚本会自动完成以下操作：
+
 1. 克隆项目仓库
 2. 安装依赖
 3. 复制配置文件
@@ -74,11 +79,13 @@ curl -O https://raw.githubusercontent.com/liuw1535/antigravity2api-nodejs/main/s
 如果已经部署成功，可以使用启动脚本快速启动服务：
 
 **Windows**：
+
 ```bash
 start.bat
 ```
 
 **Linux/macOS**：
+
 ```bash
 chmod +x start.sh
 ./start.sh
@@ -89,17 +96,20 @@ chmod +x start.sh
 使用更新脚本可以安全地更新到最新版本（自动保存本地修改）：
 
 **Windows**：
+
 ```bash
 update.bat
 ```
 
 **Linux/macOS**：
+
 ```bash
 chmod +x update.sh
 ./update.sh
 ```
 
 更新完成后，可以选择：
+
 - 恢复本地修改：`git stash pop`
 - 删除本地修改：`git stash drop`
 
@@ -118,7 +128,7 @@ npm install
 你也可以手动复制示例文件：
 
 ```bash
-cp .env.example .env,.
+cp .env.example .env
 cp config.json.example config.json
 ```
 
@@ -161,12 +171,12 @@ npm start
 
 从 [GitHub Releases](https://github.com/ZhaoShanGeng/antigravity2api-nodejs/releases) 下载对应平台的二进制文件：
 
-| 平台 | 文件名 |
-|------|--------|
+| 平台        | 文件名                        |
+| ----------- | ----------------------------- |
 | Windows x64 | `antigravity2api-win-x64.exe` |
-| Linux x64 | `antigravity2api-linux-x64` |
+| Linux x64   | `antigravity2api-linux-x64`   |
 | Linux ARM64 | `antigravity2api-linux-arm64` |
-| macOS x64 | `antigravity2api-macos-x64` |
+| macOS x64   | `antigravity2api-macos-x64`   |
 | macOS ARM64 | `antigravity2api-macos-arm64` |
 
 ### 准备配置文件
@@ -210,12 +220,14 @@ JWT_SECRET=your-jwt-secret-key-change-this-in-production
 ### 运行
 
 **Windows**：
+
 ```bash
 # 直接双击运行，或在命令行执行
 antigravity2api-win-x64.exe
 ```
 
 **Linux/macOS**：
+
 ```bash
 # 添加执行权限
 chmod +x antigravity2api-linux-x64
@@ -273,24 +285,25 @@ npm run docker:build
 ```
 
 该命令会自动：
+
 - 从 `.env.example` 创建 `.env`（如果不存在）
 - 从 `config.json.example` 创建 `config.json`（如果不存在）
 - 创建必要的目录（`data/`、`public/images/`）
 - 执行 `docker-compose build` 构建镜像
 
-2. **启动服务**
+1. **启动服务**
 
 ```bash
 docker compose up -d
 ```
 
-3. **查看日志**
+1. **查看日志**
 
 ```bash
 docker compose logs -f
 ```
 
-4. **停止服务**
+1. **停止服务**
 
 ```bash
 docker compose down
@@ -312,7 +325,7 @@ mkdir -p data public/images
 docker build -t antigravity2api .
 ```
 
-2. **运行容器**
+1. **运行容器**
 
 ```bash
 docker run -d \
@@ -330,7 +343,7 @@ docker run -d \
   antigravity2api
 ```
 
-3. **查看日志**
+1. **查看日志**
 
 ```bash
 docker logs -f antigravity2api
@@ -356,40 +369,42 @@ docker logs -f antigravity2api
 ghcr.io/liuw1535/antigravity2api-nodejs
 ```
 
-2. **配置环境变量**
+1. **配置环境变量**
 
 在服务设置中添加以下环境变量：
 
-| 环境变量 | 说明 | 示例值 |
-|--------|------|--------|
-| `API_KEY` | API 认证密钥 | `sk-your-api-key` |
-| `ADMIN_USERNAME` | 管理员用户名 | `admin` |
-| `ADMIN_PASSWORD` | 管理员密码 | `your-secure-password` |
-| `JWT_SECRET` | JWT 密钥 | `your-jwt-secret-key` |
+| 环境变量         | 说明             | 示例值                           |
+| ---------------- | ---------------- | -------------------------------- |
+| `API_KEY`        | API 认证密钥     | `sk-your-api-key`                |
+| `ADMIN_USERNAME` | 管理员用户名     | `admin`                          |
+| `ADMIN_PASSWORD` | 管理员密码       | `your-secure-password`           |
+| `JWT_SECRET`     | JWT 密钥         | `your-jwt-secret-key`            |
 | `IMAGE_BASE_URL` | 图片服务基础 URL | `https://your-domain.zeabur.app` |
 
 可选环境变量：
+
 - `PROXY`：代理地址
 - `SYSTEM_INSTRUCTION`：系统提示词
 
-3. **配置持久化存储**
+1. **配置持久化存储**
 
 在服务的「Volumes」设置中添加以下挂载点：
 
-| 挂载路径 | 说明 |
-|---------|------|
-| `/app/data` | Token 数据存储 |
+| 挂载路径             | 说明           |
+| -------------------- | -------------- |
+| `/app/data`          | Token 数据存储 |
 | `/app/public/images` | 生成的图片存储 |
 
 ⚠️ **重要提示**：
+
 - 只挂载 `/app/data` 和 `/app/public/images` 这两个目录
 - 不要挂载其他目录（如 `/app/.env`、`/app/config.json` 等），否则会导致必要配置文件被清空，项目无法启动
 
-4. **绑定域名**
+1. **绑定域名**
 
 在服务的「Networking」设置中绑定域名，然后将该域名设置到 `IMAGE_BASE_URL` 环境变量中。
 
-5. **启动服务**
+1. **启动服务**
 
 保存配置后，Zeabur 会自动拉取镜像并启动服务。访问绑定的域名即可使用。
 
@@ -575,26 +590,26 @@ curl http://localhost:8045/v1/chat/completions \
 
 ### 轮询策略说明
 
-| 策略 | 说明 |
-|------|------|
-| `round_robin` | 均衡负载：每次请求后切换到下一个 Token |
+| 策略              | 说明                                                          |
+| ----------------- | ------------------------------------------------------------- |
+| `round_robin`     | 均衡负载：每次请求后切换到下一个 Token                        |
 | `quota_exhausted` | 额度耗尽才切换：持续使用当前 Token 直到额度用完（高性能优化） |
-| `request_count` | 自定义次数：每个 Token 使用指定次数后切换（默认策略） |
+| `request_count`   | 自定义次数：每个 Token 使用指定次数后切换（默认策略）         |
 
 ### 2. .env（敏感配置）
 
 环境变量配置文件，包含敏感信息和可选配置：
 
-| 环境变量 | 说明 | 必填 |
-|--------|------|------|
-| `API_KEY` | API 认证密钥 | ✅ |
-| `ADMIN_USERNAME` | 管理员用户名 | ✅ |
-| `ADMIN_PASSWORD` | 管理员密码 | ✅ |
-| `JWT_SECRET` | JWT 密钥 | ✅ |
-| `PROXY` | 代理地址（如：http://127.0.0.1:7890），也支持系统代理环境变量 
-|`HTTP_PROXY`/`HTTPS_PROXY` | ❌ |
-| `SYSTEM_INSTRUCTION` | 系统提示词 | ❌ |
-| `IMAGE_BASE_URL` | 图片服务基础 URL | ❌ |
+| 环境变量                   | 说明                                                            | 必填 |
+| -------------------------- | --------------------------------------------------------------- | ---- |
+| `API_KEY`                  | API 认证密钥                                                    | ✅    |
+| `ADMIN_USERNAME`           | 管理员用户名                                                    | ✅    |
+| `ADMIN_PASSWORD`           | 管理员密码                                                      | ✅    |
+| `JWT_SECRET`               | JWT 密钥                                                        | ✅    |
+| `PROXY`                    | 代理地址（如：<http://127.0.0.1:7890），也支持系统代理环境变量> |
+| `HTTP_PROXY`/`HTTPS_PROXY` | ❌                                                               |
+| `SYSTEM_INSTRUCTION`       | 系统提示词                                                      | ❌    |
+| `IMAGE_BASE_URL`           | 图片服务基础 URL                                                | ❌    |
 
 完整配置示例请参考 `.env.example` 文件。
 
@@ -714,6 +729,7 @@ npm run docker:build
 对于 Pro 订阅账号，可以跳过 API 验证直接使用随机生成的 ProjectId：
 
 1. 在 `config.json` 文件中设置：
+
 ```json
 {
   "other": {
@@ -722,9 +738,9 @@ npm run docker:build
 }
 ```
 
-2. 运行 `npm run login` 登录时会自动使用随机生成的 ProjectId
+1. 运行 `npm run login` 登录时会自动使用随机生成的 ProjectId
 
-3. 已有账号也会在使用时自动生成随机 ProjectId
+2. 已有账号也会在使用时自动生成随机 ProjectId
 
 注意：此功能仅适用于 Pro 订阅账号。官方已修复免费账号使用随机 ProjectId 的漏洞。
 
@@ -736,6 +752,7 @@ npm run docker:build
 2. **无资格的账号**：自动生成随机 ProjectId，避免添加失败
 
 这一机制确保了：
+
 - 无论账号是否有 Pro 订阅，都能成功添加 Token
 - 自动降级处理，无需手动干预
 - 不会因为资格校验失败而阻止登录流程
@@ -756,6 +773,7 @@ messages = [{role: user, content: 你好}]
 ```
 
 这一设计：
+
 - 兼容 OpenAI 的多 system 消息格式
 - 充分利用 Antigravity 的 SystemInstruction 功能
 - 确保系统提示词的完整性和优先级
@@ -779,15 +797,15 @@ messages = [{role: user, content: 你好}]
 }
 ```
 
-| 参数 | 说明 | 默认值 |
-|------|------|--------|
-| `max_tokens` | 最大输出 token 数 | 32000 |
-| `temperature` | 温度 (0.0-1.0) | 1 |
-| `top_p` | Top-P 采样 | 1 |
-| `top_k` | Top-K 采样 | 50 |
-| `thinking_budget` | 思考预算 (1024-32000) | 1024 |
-| `reasoning_effort` | 思考强度 (`low`/`medium`/`high`) | - |
-| `response_format` | 支持响应格式 (`{ "type": "json_object" }`，仅 Gemini 模型支持) | - |
+| 参数               | 说明                                                           | 默认值 |
+| ------------------ | -------------------------------------------------------------- | ------ |
+| `max_tokens`       | 最大输出 token 数                                              | 32000  |
+| `temperature`      | 温度 (0.0-1.0)                                                 | 1      |
+| `top_p`            | Top-P 采样                                                     | 1      |
+| `top_k`            | Top-K 采样                                                     | 50     |
+| `thinking_budget`  | 思考预算 (1024-32000)                                          | 1024   |
+| `reasoning_effort` | 思考强度 (`low`/`medium`/`high`)                               | -      |
+| `response_format`  | 支持响应格式 (`{ "type": "json_object" }`，仅 Gemini 模型支持) | -      |
 
 ### Claude 格式 (`/v1/messages`)
 
@@ -806,14 +824,14 @@ messages = [{role: user, content: 你好}]
 }
 ```
 
-| 参数 | 说明 | 默认值 |
-|------|------|--------|
-| `max_tokens` | 最大输出 token 数 | 32000 |
-| `temperature` | 温度 (0.0-1.0) | 1 |
-| `top_p` | Top-P 采样 | 1 |
-| `top_k` | Top-K 采样 | 50 |
-| `thinking.type` | 思考开关 (`enabled`/`disabled`) | - |
-| `thinking.budget_tokens` | 思考预算 (1024-32000) | 1024 |
+| 参数                     | 说明                            | 默认值 |
+| ------------------------ | ------------------------------- | ------ |
+| `max_tokens`             | 最大输出 token 数               | 32000  |
+| `temperature`            | 温度 (0.0-1.0)                  | 1      |
+| `top_p`                  | Top-P 采样                      | 1      |
+| `top_k`                  | Top-K 采样                      | 50     |
+| `thinking.type`          | 思考开关 (`enabled`/`disabled`) | -      |
+| `thinking.budget_tokens` | 思考预算 (1024-32000)           | 1024   |
 
 ### Gemini 格式 (`/v1beta/models/:model:generateContent`)
 
@@ -833,14 +851,14 @@ messages = [{role: user, content: 你好}]
 }
 ```
 
-| 参数 | 说明 | 默认值 |
-|------|------|--------|
-| `maxOutputTokens` | 最大输出 token 数 | 32000 |
-| `temperature` | 温度 (0.0-1.0) | 1 |
-| `topP` | Top-P 采样 | 1 |
-| `topK` | Top-K 采样 | 50 |
-| `thinkingConfig.includeThoughts` | 是否包含思考内容 | true |
-| `thinkingConfig.thinkingBudget` | 思考预算 (1024-32000) | 1024 |
+| 参数                             | 说明                  | 默认值 |
+| -------------------------------- | --------------------- | ------ |
+| `maxOutputTokens`                | 最大输出 token 数     | 32000  |
+| `temperature`                    | 温度 (0.0-1.0)        | 1      |
+| `topP`                           | Top-P 采样            | 1      |
+| `topK`                           | Top-K 采样            | 50     |
+| `thinkingConfig.includeThoughts` | 是否包含思考内容      | true   |
+| `thinkingConfig.thinkingBudget`  | 思考预算 (1024-32000) | 1024   |
 
 ### 统一参数处理
 
@@ -867,11 +885,11 @@ messages = [{role: user, content: 你好}]
 
 ### reasoning_effort 映射
 
-| 值 | 思考 Token 预算 |
-|---|----------------|
-| `low` | 1024 |
-| `medium` | 16000 |
-| `high` | 32000 |
+| 值       | 思考 Token 预算 |
+| -------- | --------------- |
+| `low`    | 1024            |
+| `medium` | 16000           |
+| `high`   | 32000           |
 
 ## 内存优化
 
@@ -879,11 +897,11 @@ messages = [{role: user, content: 你好}]
 
 ### 优化效果
 
-| 指标 | 优化前 | 优化后 |
-|------|--------|--------|
-| 进程数 | 8+ | 2 |
-| 内存占用 | 100MB+ | 50MB+ |
-| GC 频率 | 高 | 低 |
+| 指标     | 优化前 | 优化后 |
+| -------- | ------ | ------ |
+| 进程数   | 8+     | 2      |
+| 内存占用 | 100MB+ | 50MB+  |
+| GC 频率  | 高     | 低     |
 
 ### 优化手段
 
@@ -897,12 +915,12 @@ messages = [{role: user, content: 你好}]
 
 内存压力阈值根据用户配置的 `memoryThreshold`（MB）动态计算：
 
-| 压力级别 | 阈值比例 | 默认值（100MB 配置） | 行为 |
-|---------|---------|---------------------|------|
-| LOW | 30% | 30MB | 正常运行 |
-| MEDIUM | 60% | 60MB | 轻度清理 |
-| HIGH | 100% | 100MB | 积极清理 + GC |
-| CRITICAL | >100% | >100MB | 紧急清理 + 强制 GC |
+| 压力级别 | 阈值比例 | 默认值（100MB 配置） | 行为               |
+| -------- | -------- | -------------------- | ------------------ |
+| LOW      | 30%      | 30MB                 | 正常运行           |
+| MEDIUM   | 60%      | 60MB                 | 轻度清理           |
+| HIGH     | 100%     | 100MB                | 积极清理 + GC      |
+| CRITICAL | >100%    | >100MB               | 紧急清理 + 强制 GC |
 
 ### 配置
 
@@ -952,18 +970,18 @@ src/utils/converters/
 
 #### 公共函数
 
-| 函数 | 说明 |
-|------|------|
-| `getSignatureContext()` | 获取思维签名和工具签名 |
-| `pushUserMessage()` | 添加用户消息到消息数组 |
-| `findFunctionNameById()` | 根据工具调用 ID 查找函数名 |
-| `pushFunctionResponse()` | 添加函数响应到消息数组 |
-| `createThoughtPart()` | 创建带签名的思维 part |
-| `createFunctionCallPart()` | 创建带签名的函数调用 part |
-| `processToolName()` | 处理工具名称映射 |
-| `pushModelMessage()` | 添加模型消息到消息数组 |
-| `buildRequestBody()` | 构建 Antigravity 请求体 |
-| `mergeSystemInstruction()` | 合并系统指令 |
+| 函数                       | 说明                       |
+| -------------------------- | -------------------------- |
+| `getSignatureContext()`    | 获取思维签名和工具签名     |
+| `pushUserMessage()`        | 添加用户消息到消息数组     |
+| `findFunctionNameById()`   | 根据工具调用 ID 查找函数名 |
+| `pushFunctionResponse()`   | 添加函数响应到消息数组     |
+| `createThoughtPart()`      | 创建带签名的思维 part      |
+| `createFunctionCallPart()` | 创建带签名的函数调用 part  |
+| `processToolName()`        | 处理工具名称映射           |
+| `pushModelMessage()`       | 添加模型消息到消息数组     |
+| `buildRequestBody()`       | 构建 Antigravity 请求体    |
+| `mergeSystemInstruction()` | 合并系统指令               |
 
 ### 参数规范化模块
 
@@ -973,12 +991,12 @@ src/utils/parameterNormalizer.js  # 统一参数处理
 
 将 OpenAI、Claude、Gemini 三种格式的参数统一转换为内部格式：
 
-| 函数 | 说明 |
-|------|------|
+| 函数                          | 说明                   |
+| ----------------------------- | ---------------------- |
 | `normalizeOpenAIParameters()` | 规范化 OpenAI 格式参数 |
 | `normalizeClaudeParameters()` | 规范化 Claude 格式参数 |
 | `normalizeGeminiParameters()` | 规范化 Gemini 格式参数 |
-| `toGenerationConfig()` | 转换为上游 API 格式 |
+| `toGenerationConfig()`        | 转换为上游 API 格式    |
 
 ### 工具转换模块
 

--- a/auth_api.md
+++ b/auth_api.md
@@ -184,6 +184,47 @@ Content-Type: application/json
 }
 ```
 
+---
+
+## 4. 查询 Gemini CLI 额度
+
+### 接口
+
+`GET /admin/geminicli/tokens/:tokenId/quotas`
+
+### 说明
+
+- 仅适用于 `geminicli` 模式账号
+- 若 Token 过期会自动刷新，失败时返回 400
+- 支持 `refresh=true` 强制刷新
+
+### Query 参数
+
+| 参数      | 类型   | 必填 | 说明                  |
+| --------- | ------ | ---: | --------------------- |
+| `refresh` | string |   否 | `true` 时强制刷新缓存 |
+
+### 返回示例
+
+```json
+{
+  "success": true,
+  "data": {
+    "lastUpdated": 1765109350660,
+    "models": {
+      "gemini-2.5-pro": {
+        "remaining": 0.75,
+        "resetTime": "01-15 08:00",
+        "resetTimeRaw": "2025-01-15T00:00:00Z"
+      }
+    },
+    "requestCounts": {
+      "gemini": 3
+    }
+  }
+}
+```
+
 说明：
 
 - 当提供 [`callbackUrl`](auth_api.md) 时，服务端会自动解析出 `code` 与 `port`

--- a/auth_api.md
+++ b/auth_api.md
@@ -77,6 +77,59 @@ GET /admin/oauth/url?mode=geminicli&count=2&password=your-admin-password
 
 ---
 
+## 2.5 获取凭证统计
+
+### 接口
+
+`GET /admin/token-summary`
+
+### 鉴权方式
+
+支持以下任一方式：
+
+- 已登录后台，自动携带 Cookie
+- 通过 query 传管理员密码 `password`
+
+### Query 参数
+
+| 参数       | 类型   | 必填 | 说明                                             |
+| ---------- | ------ | ---: | ------------------------------------------------ |
+| `password` | string |   否 | 未携带后台 Cookie 时，可直接传管理员密码进行调用 |
+
+### 示例
+
+```http
+GET /admin/token-summary?password=your-admin-password
+```
+
+### 返回示例
+
+```json
+{
+  "success": true,
+  "data": {
+    "antigravity": {
+      "total": 12,
+      "enabled": 9,
+      "disabled": 3
+    },
+    "geminicli": {
+      "total": 5,
+      "enabled": 4,
+      "disabled": 1
+    }
+  }
+}
+```
+
+### 说明
+
+- `enabled` 表示当前可用数量
+- `disabled` 表示当前不可用数量
+- 适合外部程序快速轮询可用凭证数
+
+---
+
 ## 3. 提交授权码并交换 Token
 
 ### 接口

--- a/auth_api.md
+++ b/auth_api.md
@@ -91,12 +91,13 @@ Content-Type: application/json
 
 ### 请求体
 
-| 字段       | 类型   | 必填 | 说明                                             |
-| ---------- | ------ | ---: | ------------------------------------------------ |
-| `code`     | string |   是 | Google OAuth 回调地址中的授权码                  |
-| `port`     | number |   是 | 回调地址中的本地端口                             |
-| `mode`     | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
-| `password` | string |   否 | 未携带后台 Cookie 时，可直接传管理员密码进行调用 |
+| 字段          | 类型   | 必填 | 说明                                             |
+| ------------- | ------ | ---: | ------------------------------------------------ |
+| `code`        | string |   是 | Google OAuth 回调地址中的授权码                  |
+| `port`        | number |   是 | 回调地址中的本地端口                             |
+| `mode`        | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
+| `password`    | string |   否 | 未携带后台 Cookie 时，可直接传管理员密码进行调用 |
+| `callbackUrl` | string |   否 | 完整回调 URL；提供后可自动解析 `code` 与 `port`  |
 
 ### 示例
 
@@ -108,6 +109,21 @@ Content-Type: application/json
   "password": "your-admin-password"
 }
 ```
+
+### 使用完整回调 URL 的示例
+
+```json
+{
+  "callbackUrl": "http://localhost:53120/oauth-callback?code=4/0AQSTgQ...&scope=...",
+  "mode": "antigravity",
+  "password": "your-admin-password"
+}
+```
+
+说明：
+
+- 当提供 [`callbackUrl`](auth_api.md) 时，服务端会自动解析出 `code` 与 `port`
+- 如果同时传了 `code` / `port`，则优先使用显式传入值
 
 ### Antigravity 返回示例
 

--- a/auth_api.md
+++ b/auth_api.md
@@ -1,6 +1,6 @@
 # Auth API 文档
 
-本文档说明管理后台中与 OAuth 授权相关的 API 接口，用于获取授权链接以及提交授权码完成登录 / Token 交换。
+本文档说明管理后台中与 OAuth 授权相关的 API 接口，用于获取授权链接以及提交授权码完成 Token 交换与自动保存。
 
 ## 1. 适用范围
 
@@ -83,6 +83,17 @@ GET /admin/oauth/url?mode=geminicli&count=2&password=your-admin-password
 
 `POST /admin/oauth/exchange`
 
+### 行为说明
+
+该接口会一步完成以下操作：
+
+1. 使用授权码交换 access token / refresh token
+2. 获取邮箱
+3. Antigravity 模式下尝试获取 `projectId`
+4. 自动保存到系统 Token 列表
+
+因此外部程序调用 [`POST /admin/oauth/exchange`](src/routes/admin.js:611) 后，通常**不需要再额外调用** [`POST /admin/tokens`](src/routes/admin.js:208) 或 [`POST /admin/geminicli/tokens`](src/routes/admin.js:913)。
+
 ### 请求头
 
 ```http
@@ -140,7 +151,8 @@ Content-Type: application/json
     "enable": true
   },
   "message": "Token添加成功",
-  "fallbackMode": false
+  "fallbackMode": false,
+  "saved": true
 }
 ```
 
@@ -156,7 +168,8 @@ Content-Type: application/json
     "email": "user@example.com",
     "enable": true
   },
-  "message": "Gemini CLI Token添加成功"
+  "message": "Gemini CLI Token添加成功",
+  "saved": true
 }
 ```
 
@@ -171,7 +184,7 @@ Content-Type: application/json
 3. 完成 Google 登录与授权
 4. 从回调 URL 中提取 `code` 和 `port`
 5. 调用 `POST /admin/oauth/exchange`
-6. 将返回的账号信息保存到对应 Token 列表
+6. 接口自动保存 Token，无需再额外调用保存接口
 
 ### 批量流程
 
@@ -180,6 +193,7 @@ Content-Type: application/json
 3. 收集多条回调 URL
 4. 逐条提取 `code` 与 `port`
 5. 多次调用 `POST /admin/oauth/exchange`
+6. 每次交换成功后接口会自动保存
 
 ---
 

--- a/auth_api.md
+++ b/auth_api.md
@@ -1,0 +1,197 @@
+# Auth API 文档
+
+本文档说明管理后台中与 OAuth 授权相关的 API 接口，用于获取授权链接以及提交授权码完成登录 / Token 交换。
+
+## 1. 适用范围
+
+当前支持两种模式：
+
+- `antigravity`
+- `geminicli`
+
+所有接口均位于管理后台路由下，默认需要先完成后台登录。
+
+---
+
+## 2. 获取授权链接
+
+### 接口
+
+`GET /admin/oauth/url`
+
+### Query 参数
+
+| 参数    | 类型   | 必填 | 说明                                             |
+| ------- | ------ | ---: | ------------------------------------------------ |
+| `mode`  | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
+| `count` | number |   否 | 返回授权链接数量，范围 `1~100`，默认 `1`         |
+
+### 示例
+
+```http
+GET /admin/oauth/url?mode=geminicli&count=2
+```
+
+### 返回示例
+
+```json
+{
+  "success": true,
+  "data": {
+    "mode": "geminicli",
+    "count": 2,
+    "urls": [
+      {
+        "port": 53120,
+        "url": "https://accounts.google.com/o/oauth2/v2/auth?..."
+      },
+      {
+        "port": 53121,
+        "url": "https://accounts.google.com/o/oauth2/v2/auth?..."
+      }
+    ],
+    "submit": {
+      "method": "POST",
+      "url": "/admin/oauth/exchange",
+      "contentType": "application/json",
+      "body": {
+        "code": "从回调URL中提取的code",
+        "port": "回调URL中的本地端口",
+        "mode": "geminicli"
+      }
+    }
+  }
+}
+```
+
+### 说明
+
+- 接口会随机生成本地回调端口
+- 每条授权链接都与一个本地 `port` 对应
+- 返回中的 `submit` 字段用于指导后续如何提交授权码
+
+---
+
+## 3. 提交授权码并交换 Token
+
+### 接口
+
+`POST /admin/oauth/exchange`
+
+### 请求头
+
+```http
+Content-Type: application/json
+```
+
+### 请求体
+
+| 字段   | 类型   | 必填 | 说明                                             |
+| ------ | ------ | ---: | ------------------------------------------------ |
+| `code` | string |   是 | Google OAuth 回调地址中的授权码                  |
+| `port` | number |   是 | 回调地址中的本地端口                             |
+| `mode` | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
+
+### 示例
+
+```json
+{
+  "code": "4/0AQSTgQ...",
+  "port": 53120,
+  "mode": "antigravity"
+}
+```
+
+### Antigravity 返回示例
+
+```json
+{
+  "success": true,
+  "data": {
+    "access_token": "...",
+    "refresh_token": "...",
+    "expires_in": 3600,
+    "email": "user@example.com",
+    "projectId": "project-id",
+    "hasQuota": true,
+    "enable": true
+  },
+  "message": "Token添加成功",
+  "fallbackMode": false
+}
+```
+
+### Gemini CLI 返回示例
+
+```json
+{
+  "success": true,
+  "data": {
+    "access_token": "...",
+    "refresh_token": "...",
+    "expires_in": 3600,
+    "email": "user@example.com",
+    "enable": true
+  },
+  "message": "Gemini CLI Token添加成功"
+}
+```
+
+---
+
+## 4. 使用流程建议
+
+### 普通流程
+
+1. 调用 `GET /admin/oauth/url`
+2. 打开返回的授权链接
+3. 完成 Google 登录与授权
+4. 从回调 URL 中提取 `code` 和 `port`
+5. 调用 `POST /admin/oauth/exchange`
+6. 将返回的账号信息保存到对应 Token 列表
+
+### 批量流程
+
+1. 调用 `GET /admin/oauth/url?count=N`
+2. 依次打开多条授权链接
+3. 收集多条回调 URL
+4. 逐条提取 `code` 与 `port`
+5. 多次调用 `POST /admin/oauth/exchange`
+
+---
+
+## 5. 错误说明
+
+### 常见错误
+
+#### 缺少参数
+
+```json
+{
+  "success": false,
+  "message": "code和port必填"
+}
+```
+
+#### OAuth 认证失败
+
+```json
+{
+  "success": false,
+  "message": "具体错误信息"
+}
+```
+
+#### 未登录后台
+
+接口会因未通过后台认证而返回 `401`。
+
+---
+
+## 6. 相关实现位置
+
+- OAuth URL 接口：`src/routes/admin.js`
+- OAuth 授权码交换接口：`src/routes/admin.js`
+- 授权 URL 生成逻辑：`src/auth/oauth_manager.js`
+- 前端普通 OAuth：`public/js/auth.js`
+- 前端 Gemini CLI OAuth：`public/js/geminicli.js`

--- a/auth_api.md
+++ b/auth_api.md
@@ -9,7 +9,10 @@
 - `antigravity`
 - `geminicli`
 
-所有接口均位于管理后台路由下，默认需要先完成后台登录。
+所有接口均位于管理后台路由下，支持以下两种鉴权方式之一：
+
+- 已登录后台，自动携带 Cookie
+- 直接传管理员密码 `password`
 
 ---
 
@@ -21,15 +24,16 @@
 
 ### Query 参数
 
-| 参数    | 类型   | 必填 | 说明                                             |
-| ------- | ------ | ---: | ------------------------------------------------ |
-| `mode`  | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
-| `count` | number |   否 | 返回授权链接数量，范围 `1~100`，默认 `1`         |
+| 参数       | 类型   | 必填 | 说明                                             |
+| ---------- | ------ | ---: | ------------------------------------------------ |
+| `mode`     | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
+| `count`    | number |   否 | 返回授权链接数量，范围 `1~100`，默认 `1`         |
+| `password` | string |   否 | 未携带后台 Cookie 时，可直接传管理员密码进行调用 |
 
 ### 示例
 
 ```http
-GET /admin/oauth/url?mode=geminicli&count=2
+GET /admin/oauth/url?mode=geminicli&count=2&password=your-admin-password
 ```
 
 ### 返回示例
@@ -57,7 +61,8 @@ GET /admin/oauth/url?mode=geminicli&count=2
       "body": {
         "code": "从回调URL中提取的code",
         "port": "回调URL中的本地端口",
-        "mode": "geminicli"
+        "mode": "geminicli",
+        "password": "可选，未携带Cookie时可直接传管理员密码"
       }
     }
   }
@@ -86,11 +91,12 @@ Content-Type: application/json
 
 ### 请求体
 
-| 字段   | 类型   | 必填 | 说明                                             |
-| ------ | ------ | ---: | ------------------------------------------------ |
-| `code` | string |   是 | Google OAuth 回调地址中的授权码                  |
-| `port` | number |   是 | 回调地址中的本地端口                             |
-| `mode` | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
+| 字段       | 类型   | 必填 | 说明                                             |
+| ---------- | ------ | ---: | ------------------------------------------------ |
+| `code`     | string |   是 | Google OAuth 回调地址中的授权码                  |
+| `port`     | number |   是 | 回调地址中的本地端口                             |
+| `mode`     | string |   否 | `antigravity` 或 `geminicli`，默认 `antigravity` |
+| `password` | string |   否 | 未携带后台 Cookie 时，可直接传管理员密码进行调用 |
 
 ### 示例
 
@@ -98,7 +104,8 @@ Content-Type: application/json
 {
   "code": "4/0AQSTgQ...",
   "port": 53120,
-  "mode": "antigravity"
+  "mode": "antigravity",
+  "password": "your-admin-password"
 }
 ```
 
@@ -184,7 +191,7 @@ Content-Type: application/json
 
 #### 未登录后台
 
-接口会因未通过后台认证而返回 `401`。
+接口会因未通过后台认证，且 `password` 未提供或错误，而返回 `401`。
 
 ---
 

--- a/cli_project_quota_summary.md
+++ b/cli_project_quota_summary.md
@@ -1,0 +1,990 @@
+# CLI 凭证中的 Project ID 与额度获取机制说明
+
+> 本文档是**给另一个程序中的 LLM 直接使用**的技术说明。
+>
+> 目标不是解释某个仓库的源码，而是把“**如何获取 CLI OAuth 凭证中的 Project ID**”以及“**如何获取额度（quota）**”抽象成一套可复刻的实现方案。
+>
+> 因此本文档：
+>
+> - **不依赖源码上下文**
+> - **不要求读取原项目文件**
+> - **直接描述协议、流程、字段和实现策略**
+> - 适合作为其他程序实现相同能力时的参考输入
+
+---
+
+## 1. 目标
+
+需要解决两个问题：
+
+1. **如何从 Google OAuth 登录后的 CLI 凭证中拿到可用的 `project_id`**
+2. **如何查询该凭证对应的模型额度 / 配额信息（quota）**
+
+这两个问题的关键点是：
+
+- OAuth 本身通常只给你：
+  - `access_token`
+  - `refresh_token`
+  - 过期时间
+- **`project_id` 往往不是 OAuth 回调里直接返回的字段**
+- `project_id` 需要在 OAuth 完成后，再调用额外接口获得
+- quota 也不是本地算出来的，而是要通过服务端接口返回的模型元信息中提取
+
+---
+
+## 2. 先说结论
+
+如果你要复刻该能力，核心思路如下：
+
+### 获取 `project_id`
+
+完整流程通常是：
+
+1. 用户完成 Google OAuth
+2. 得到 `access_token` 和 `refresh_token`
+3. 用 `access_token` 调用内部接口：
+   - `loadCodeAssist`
+4. 如果 `loadCodeAssist` 没有返回 `project_id`
+   - 再调用 `onboardUser`
+5. 如果仍失败
+   - 回退到 Google Cloud 项目列表接口
+   - 自动选项目，或要求用户手工选择
+6. 最终把拿到的 `project_id` 存入凭证
+
+### 获取 quota
+
+1. 准备一个可用的 Antigravity / 对应服务的 `access_token`
+2. 调用：
+   - `fetchAvailableModels`
+3. 从每个模型返回的 `quotaInfo` 中提取：
+   - 剩余额度比例
+   - 重置时间
+
+一句话概括：
+
+- **Project ID 是 OAuth 后通过附加接口查出来或创建出来的**
+- **Quota 是通过模型列表接口里的 `quotaInfo` 提取出来的**
+
+---
+
+## 3. 推荐的数据结构
+
+建议把凭证保存成统一结构，至少包含以下字段：
+
+```json
+{
+  "client_id": "...",
+  "client_secret": "...",
+  "token": "access_token_value",
+  "access_token": "access_token_value",
+  "refresh_token": "refresh_token_value",
+  "scopes": ["..."],
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "project_id": "your-project-id-or-resource-name",
+  "expiry": "2026-03-30T17:00:00+00:00"
+}
+```
+
+建议说明：
+
+- `token` 和 `access_token` 最好同时兼容保存
+- `refresh_token` 必须保留，否则后续无法自动刷新
+- `project_id` 是后续调用 CLI 接口的关键字段
+- `expiry` 建议保存为 ISO 8601 UTC 时间字符串
+
+同时建议单独维护一份**运行状态**：
+
+```json
+{
+  "disabled": false,
+  "error_codes": [],
+  "last_success": 1711111111,
+  "user_email": null,
+  "tier": "pro",
+  "preview": true,
+  "model_cooldowns": {}
+}
+```
+
+用途：
+
+- 控制凭证启用/禁用
+- 记录错误和冷却信息
+- 记录订阅等级
+- 标记某些能力是否支持
+
+---
+
+## 4. OAuth 阶段应该怎么做
+
+### 4.1 目标
+
+先拿到：
+
+- `access_token`
+- `refresh_token`
+- `expires_in`
+
+### 4.2 授权 URL 的关键参数
+
+OAuth 授权 URL 建议包含：
+
+- `client_id`
+- `redirect_uri`
+- `scope`
+- `response_type=code`
+- `access_type=offline`
+- `prompt=consent`
+- `include_granted_scopes=true`
+- `state=<random_state>`
+
+其中最关键的是：
+
+- `access_type=offline`：确保拿到 `refresh_token`
+- `prompt=consent`：提高返回 refresh token 的概率
+
+### 4.3 用授权码换 token
+
+回调拿到 `code` 后，向 Google token 接口发起请求：
+
+`POST https://oauth2.googleapis.com/token`
+
+请求参数：
+
+```x-www-form-urlencoded
+client_id=...
+client_secret=...
+redirect_uri=...
+code=...
+grant_type=authorization_code
+```
+
+预期响应：
+
+```json
+{
+  "access_token": "ya29....",
+  "expires_in": 3599,
+  "refresh_token": "1//0g....",
+  "scope": "...",
+  "token_type": "Bearer"
+}
+```
+
+拿到后应立即标准化为内部凭证对象。
+
+---
+
+## 5. `project_id` 不是 OAuth 直接给的
+
+这是最重要的认知点。
+
+### 本质
+
+Google OAuth 登录成功后，你只拿到了“用户身份”和“访问能力”，**还没有拿到业务调用所需的 CLI 项目上下文**。
+
+因此必须继续调用额外接口，为当前用户确定：
+
+- 当前 CLI 该绑定哪个项目
+- 当前用户属于什么 tier
+- 如果还没初始化，是否需要先做 onboarding
+
+换句话说：
+
+- OAuth 给的是“通行证”
+- `project_id` 是“业务环境上下文”
+
+---
+
+## 6. 获取 `project_id` 的推荐流程
+
+## 6.1 第一优先：调用 `loadCodeAssist`
+
+使用 OAuth 得到的 `access_token` 调用：
+
+```http
+POST {api_base_url}/v1internal:loadCodeAssist
+Authorization: Bearer <access_token>
+User-Agent: <对应 CLI 的 User-Agent>
+Content-Type: application/json
+Accept-Encoding: gzip
+```
+
+请求体建议：
+
+```json
+{
+  "metadata": {
+    "ideType": "ANTIGRAVITY"
+  }
+}
+```
+
+说明：
+
+- 不同客户端可能会额外带：
+  - `platform`
+  - `pluginType`
+- 但最核心的是 Bearer token 和匹配的 User-Agent
+
+### 成功时重点提取的字段
+
+如果返回成功，重点关注：
+
+```json
+{
+  "cloudaicompanionProject": "projects/xxx-or-project-id",
+  "currentTier": {
+    "id": "standard-tier"
+  },
+  "paidTier": {
+    "id": "g1-ultra-tier"
+  },
+  "allowedTiers": [...]
+}
+```
+
+从中提取：
+
+- `cloudaicompanionProject` → 作为 `project_id`
+- `paidTier.id` 或 `currentTier.id` → 作为 tier 原始值
+
+### 推荐 tier 映射
+
+可以做如下统一映射：
+
+| 原始 tier                   | 统一 tier |
+| --------------------------- | --------- |
+| `g1-ultra-tier`             | `ultra`   |
+| `ws-ai-ultra-business-tier` | `ultra`   |
+| `g1-pro-tier`               | `pro`     |
+| `helium-tier`               | `pro`     |
+| `standard-tier`             | `pro`     |
+| `free-tier`                 | `free`    |
+| 其他未知值                  | `pro`     |
+
+### `loadCodeAssist` 的结果分两种情况
+
+#### 情况 A：已经激活
+
+如果响应中存在：
+
+- `currentTier`
+- 同时有 `cloudaicompanionProject`
+
+则说明该用户已经完成初始化，可以直接拿到：
+
+- `project_id`
+- `subscription_tier`
+
+#### 情况 B：尚未激活
+
+如果响应中：
+
+- 没有 `currentTier`
+- 或者没有 `cloudaicompanionProject`
+
+就说明还不能直接使用，需要进入 onboarding 流程。
+
+---
+
+## 6.2 第二优先：调用 `onboardUser`
+
+如果 `loadCodeAssist` 没返回 `project_id`，下一步是调用：
+
+```http
+POST {api_base_url}/v1internal:onboardUser
+Authorization: Bearer <access_token>
+User-Agent: <对应 CLI 的 User-Agent>
+Content-Type: application/json
+```
+
+### 请求前先确定 tier
+
+推荐先再次调用 `loadCodeAssist`，从其中的 `allowedTiers` 里选默认 tier：
+
+示例：
+
+```json
+{
+  "allowedTiers": [
+    {"id": "FREE", "isDefault": false},
+    {"id": "LEGACY", "isDefault": true}
+  ]
+}
+```
+
+选择逻辑：
+
+1. 找 `isDefault=true` 的 tier
+2. 如果没有，就回退成 `LEGACY`
+
+### `onboardUser` 请求体示例
+
+```json
+{
+  "tierId": "LEGACY",
+  "metadata": {
+    "ideType": "ANTIGRAVITY",
+    "platform": "PLATFORM_UNSPECIFIED",
+    "pluginType": "GEMINI"
+  }
+}
+```
+
+### `onboardUser` 可能是长任务
+
+这个接口常见表现不是一次就完成，而是**长时间运行操作**。
+
+返回可能类似：
+
+```json
+{
+  "done": false
+}
+```
+
+或者：
+
+```json
+{
+  "done": true,
+  "response": {
+    "cloudaicompanionProject": {
+      "id": "projects/xxx"
+    }
+  }
+}
+```
+
+因此建议：
+
+- 轮询最多 5 次
+- 每次间隔 2 秒
+- 最长等待约 10 秒
+
+### 成功时提取字段
+
+从以下任一结构中读取：
+
+- `response.cloudaicompanionProject.id`
+- `response.cloudaicompanionProject`（如果它直接是字符串）
+
+拿到后保存为最终 `project_id`。
+
+---
+
+## 6.3 第三优先：回退到 Google Cloud 项目列表
+
+如果前两步都失败，不代表凭证完全不可用，也可能只是内部接口未返回项目信息。
+
+这时建议调用 Google Cloud Resource Manager：
+
+```http
+GET https://cloudresourcemanager.googleapis.com/v1/projects
+Authorization: Bearer <access_token>
+User-Agent: <CLI User-Agent>
+```
+
+从响应中筛选：
+
+- `lifecycleState == "ACTIVE"`
+
+并提取：
+
+- `projectId`
+- `displayName`
+- `projectNumber`
+
+### 自动选择策略
+
+建议按如下顺序选择：
+
+1. 如果只有一个项目 → 直接使用
+2. 如果多个项目中存在名称或 ID 包含 `default` → 优先用它
+3. 否则使用第一个项目
+4. 如果不希望自动选择 → 把项目列表返回给上层，由用户手选
+
+### 如果仍然失败
+
+此时应明确返回：
+
+- 需要用户手工输入 `project_id`
+
+---
+
+## 7. `project_id` 保存后如何使用
+
+后续在真正调用 CLI 业务接口时，通常请求体里必须包含 `project` 字段。
+
+典型请求形式：
+
+```http
+POST {code_assist_endpoint}/v1internal:streamGenerateContent?alt=sse
+Authorization: Bearer <access_token>
+Content-Type: application/json
+User-Agent: <CLI User-Agent>
+```
+
+请求体：
+
+```json
+{
+  "model": "gemini-2.5-pro",
+  "project": "your_project_id",
+  "request": {
+    "contents": [...]
+  }
+}
+```
+
+这说明：
+
+- `access_token` 用于身份认证
+- `project_id` 用于指定业务上下文
+
+如果没有 `project_id`，很多 CLI 内部接口调用会直接失败。
+
+因此建议把它视为**必填上下文字段**，不是可选元数据。
+
+---
+
+## 8. token 刷新机制必须做
+
+因为这是长期运行系统，不能只依赖首次 OAuth 拿到的 access token。
+
+## 8.1 刷新时机建议
+
+满足任一条件时刷新：
+
+- 没有 `access_token`
+- 没有 `expiry`
+- 距离过期不足 5 分钟
+
+## 8.2 刷新请求
+
+使用 refresh token 调用：
+
+`POST https://oauth2.googleapis.com/token`
+
+请求参数：
+
+```x-www-form-urlencoded
+client_id=...
+client_secret=...
+refresh_token=...
+grant_type=refresh_token
+```
+
+成功响应示例：
+
+```json
+{
+  "access_token": "ya29....",
+  "expires_in": 3599,
+  "token_type": "Bearer"
+}
+```
+
+刷新成功后应更新：
+
+- `access_token`
+- `token`
+- `expiry`
+
+并立即回写凭证存储。
+
+## 8.3 失败分类建议
+
+### 认为是永久失效的情况
+
+符合以下任一条件，可视为凭证永久失效：
+
+- HTTP `400`
+- HTTP `401`
+- HTTP `403`
+- 错误文本包含：
+  - `invalid_grant`
+  - `refresh_token_expired`
+  - `invalid_refresh_token`
+  - `unauthorized_client`
+  - `access_denied`
+
+处理建议：
+
+- 将凭证标记为 `disabled=true`
+- 记录错误码
+- 后续不再优先使用
+
+### 认为是临时失败的情况
+
+以下通常不应直接封禁凭证：
+
+- HTTP `429`
+- HTTP `500`
+- HTTP `502`
+- HTTP `503`
+- HTTP `504`
+- 网络异常 / 超时
+
+处理建议：
+
+- 保持凭证启用
+- 做重试或冷却
+
+---
+
+## 9. quota 是怎么拿到的
+
+这里说的 quota，通常是**模型可用额度**，不是传统云账单余额。
+
+## 9.1 推荐接口
+
+使用：
+
+```http
+POST {antigravity_url}/v1internal:fetchAvailableModels
+Authorization: Bearer <access_token>
+User-Agent: antigravity/...
+Content-Type: application/json
+Accept-Encoding: gzip
+requestId: req-<uuid>
+```
+
+请求体可以为空：
+
+```json
+{}
+```
+
+## 9.2 为什么这个接口能拿 quota
+
+因为该接口不仅返回可用模型列表，还会在每个模型对象里附带 quota 元信息。
+
+典型结构类似：
+
+```json
+{
+  "models": {
+    "gemini-2.5-pro": {
+      "quotaInfo": {
+        "remainingFraction": 0.95,
+        "resetTime": "2025-12-20T02:30:00Z"
+      }
+    },
+    "claude-sonnet-4-6": {
+      "quotaInfo": {
+        "remainingFraction": 0.20,
+        "resetTime": "2025-12-20T03:00:00Z"
+      }
+    }
+  }
+}
+```
+
+## 9.3 应提取哪些字段
+
+对每个模型提取：
+
+- `remainingFraction` → 剩余额度比例
+- `resetTime` → 配额重置时间
+
+建议整理为：
+
+```json
+{
+  "success": true,
+  "models": {
+    "gemini-2.5-pro": {
+      "remaining": 0.95,
+      "resetTime": "12-20 10:30",
+      "resetTimeRaw": "2025-12-20T02:30:00Z"
+    }
+  }
+}
+```
+
+说明：
+
+- `remaining`：建议直接保留 0~1 的比例值
+- `resetTimeRaw`：保留原始 UTC 时间字符串
+- `resetTime`：为了 UI 展示，转成本地时间字符串
+
+## 9.4 时间转换建议
+
+如果面向中国用户，建议把 `resetTimeRaw` 转成北京时间：
+
+- 解析 UTC 时间
+- 加 `8` 小时
+- 格式化为：`MM-DD HH:mm`
+
+但同时**必须保留原始时间**，方便别的程序自己决定时区处理方式。
+
+---
+
+## 10. quota 查询前必须先确保 token 有效
+
+不要直接拿本地保存的 token 就查 quota。
+
+正确顺序应该是：
+
+1. 从存储加载凭证
+2. 检查是否过期
+3. 如有需要先刷新 token
+4. 如果 token 刷新了，回写存储
+5. 再调用 quota 接口
+
+否则会出现：
+
+- 本地凭证看起来存在
+- 实际请求却因 access token 失效而失败
+
+---
+
+## 11. 运行期如何选择“可用凭证”
+
+如果系统维护多个凭证，建议采用以下策略：
+
+### 11.1 选择规则
+
+每次请求前，从凭证池中选一个：
+
+- 未禁用
+- 未处于冷却中
+- token 可刷新或仍有效
+- 符合模型约束（如 preview / 非 preview）
+
+### 11.2 建议流程
+
+1. 随机或轮询选一个候选凭证
+2. 检查 token 是否需要刷新
+3. 刷新成功则继续使用
+4. 刷新失败且属于永久错误，则禁用该凭证
+5. 换下一个凭证重试
+
+### 11.3 模型级冷却
+
+如果请求失败时返回：
+
+- `429` quota exhausted
+- `503` temporary unavailable
+
+建议从错误响应中解析出冷却结束时间，并只对：
+
+- 当前凭证
+- 当前模型
+
+设置冷却，而不是把整个凭证永久封禁。
+
+这样会更符合真实使用场景。
+
+---
+
+## 12. 推荐给 LLM 的实现顺序
+
+如果你希望另一个 LLM 直接据此写代码，建议它按下面顺序实现。
+
+## 第一步：实现 OAuth 登录
+
+实现能力：
+
+- 生成授权 URL
+- 接收回调 code
+- code 换 token
+- 存储凭证
+
+输出：
+
+- `access_token`
+- `refresh_token`
+- `expiry`
+
+## 第二步：实现 `project_id` 自动发现
+
+实现能力：
+
+1. `loadCodeAssist`
+2. `onboardUser`
+3. 项目列表回退
+4. tier 解析
+5. 凭证回写
+
+输出：
+
+- `project_id`
+- `subscription_tier`
+
+## 第三步：实现 token 自动刷新
+
+实现能力：
+
+- 根据过期时间刷新
+- 刷新成功后回写存储
+- 区分永久失败和临时失败
+
+## 第四步：实现业务请求
+
+实现能力：
+
+- 读取可用凭证
+- 自动刷新 token
+- 把 `project_id` 注入请求体
+- 处理 429 / 503 / 403
+
+## 第五步：实现 quota 查询
+
+实现能力：
+
+- 调 `fetchAvailableModels`
+- 解析每个模型的 `quotaInfo`
+- 输出统一 quota 结构
+
+---
+
+## 13. 可直接复刻的伪代码
+
+## 13.1 获取 `project_id`
+
+```python
+async def get_project_id_from_oauth_credential(access_token, api_base_url, user_agent):
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "User-Agent": user_agent,
+        "Content-Type": "application/json",
+        "Accept-Encoding": "gzip",
+    }
+
+    # Step 1: try loadCodeAssist
+    resp = await post(
+        f"{api_base_url}/v1internal:loadCodeAssist",
+        json={"metadata": {"ideType": "ANTIGRAVITY"}},
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        project_id = data.get("cloudaicompanionProject")
+        tier = map_tier(
+            (data.get("paidTier") or {}).get("id")
+            or (data.get("currentTier") or {}).get("id")
+        )
+        if project_id:
+            return project_id, tier
+
+    # Step 2: try onboardUser
+    tier_id = await get_default_onboard_tier(api_base_url, headers)
+    for _ in range(5):
+        resp = await post(
+            f"{api_base_url}/v1internal:onboardUser",
+            json={
+                "tierId": tier_id or "LEGACY",
+                "metadata": {
+                    "ideType": "ANTIGRAVITY",
+                    "platform": "PLATFORM_UNSPECIFIED",
+                    "pluginType": "GEMINI",
+                },
+            },
+            headers=headers,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            if data.get("done"):
+                obj = (data.get("response") or {}).get("cloudaicompanionProject")
+                if isinstance(obj, dict):
+                    return obj.get("id"), None
+                if isinstance(obj, str):
+                    return obj, None
+        await sleep(2)
+
+    # Step 3: fallback to cloud project list
+    projects = await list_google_cloud_projects(access_token, user_agent)
+    if len(projects) == 1:
+        return projects[0]["projectId"], None
+    if len(projects) > 1:
+        return choose_default_project(projects), None
+
+    return None, None
+```
+
+## 13.2 获取 quota
+
+```python
+async def fetch_quota_info(access_token, antigravity_url, user_agent):
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "User-Agent": user_agent,
+        "Content-Type": "application/json",
+        "Accept-Encoding": "gzip",
+        "requestId": generate_request_id(),
+    }
+
+    resp = await post(
+        f"{antigravity_url}/v1internal:fetchAvailableModels",
+        json={},
+        headers=headers,
+    )
+
+    if resp.status_code != 200:
+        return {"success": False, "error": f"HTTP {resp.status_code}"}
+
+    data = resp.json()
+    result = {}
+
+    for model_name, model_data in (data.get("models") or {}).items():
+        quota = (model_data or {}).get("quotaInfo") or {}
+        result[model_name] = {
+            "remaining": quota.get("remainingFraction", 0),
+            "resetTimeRaw": quota.get("resetTime", ""),
+            "resetTime": format_to_local_time(quota.get("resetTime", "")),
+        }
+
+    return {"success": True, "models": result}
+```
+
+---
+
+## 14. 另一个 LLM 最容易踩的坑
+
+如果把本文档发给另一个 LLM，最需要提醒它避免以下错误：
+
+### 坑 1：误以为 OAuth 响应里直接有 `project_id`
+
+通常没有。
+
+必须继续调用：
+
+- `loadCodeAssist`
+- `onboardUser`
+- 或项目列表接口
+
+### 坑 2：只保存 access token，不保存 refresh token
+
+这样系统一小时左右就失效。
+
+### 坑 3：拿到 token 后不做刷新逻辑
+
+长期运行系统一定会出问题。
+
+### 坑 4：把 429 当成永久失效
+
+429 更适合冷却 / 重试，不适合直接永久封禁凭证。
+
+### 坑 5：quota 当成本地统计值
+
+本文中的 quota 不是本地统计，而是接口返回的模型级额度信息。
+
+### 坑 6：不保留原始 UTC 时间
+
+只保存本地格式字符串会让后续跨时区处理变麻烦。
+
+### 坑 7：缺失 `project` 字段就直接发业务请求
+
+很多 CLI 接口要求请求体里必须有 `project`。
+
+---
+
+## 15. 建议输出给其他程序的标准接口
+
+如果你在别的系统中封装，建议至少提供以下函数。
+
+### `exchange_oauth_code(code) -> credential`
+
+输入：
+
+- `code`
+
+输出：
+
+- `access_token`
+- `refresh_token`
+- `expiry`
+
+### `resolve_project_id(credential) -> {project_id, tier}`
+
+输入：
+
+- OAuth 凭证
+
+输出：
+
+- `project_id`
+- `tier`
+
+### `refresh_credential_if_needed(credential) -> credential`
+
+输入：
+
+- 当前凭证
+
+输出：
+
+- 刷新后的凭证
+
+### `call_cli_api(credential, model, request) -> response`
+
+输入：
+
+- 凭证
+- 模型名
+- 请求内容
+
+要求内部自动：
+
+- 刷新 token
+- 注入 `project`
+- 处理重试
+
+### `fetch_model_quota(credential) -> quota_info`
+
+输入：
+
+- 凭证
+
+输出：
+
+- 每个模型的 quota 信息
+
+---
+
+## 16. 最终总结
+
+要复刻“CLI 凭证中的项目 ID 与额度获取”机制，正确理解应该是：
+
+### 项目 ID 获取
+
+不是从 OAuth 结果里直接读，而是：
+
+1. 先 OAuth 拿 token
+2. 调 `loadCodeAssist` 获取 `cloudaicompanionProject`
+3. 不行就调 `onboardUser`
+4. 再不行就退回 Google Cloud 项目列表
+5. 最终把结果写回凭证
+
+### quota 获取
+
+不是本地计算，而是：
+
+1. 用有效 access token 调 `fetchAvailableModels`
+2. 从每个模型的 `quotaInfo` 读取：
+   - `remainingFraction`
+   - `resetTime`
+3. 转换成统一输出结构
+
+### 运行稳定性
+
+想让系统长期可用，必须补齐：
+
+- refresh token 刷新
+- 永久错误与临时错误区分
+- 冷却与重试
+- 多凭证调度
+- `project_id` 持久化
+
+如果另一个 LLM 需要据此直接写实现，优先让它完成以下 4 个能力：
+
+1. OAuth code exchange
+2. `project_id` resolve
+3. token refresh
+4. quota fetch
+
+只要这四块实现正确，整个方案就能跑起来。

--- a/config.json.example
+++ b/config.json.example
@@ -55,6 +55,7 @@
     "retryTimes": 10,
     "proxyProtocol": "http",
     "proxyPool": "",
+    "proxyAllRequests": false,
     "forceIPv4": false,
     "skipProjectIdFetch": false,
     "useNativeAxios": false,

--- a/config.json.example
+++ b/config.json.example
@@ -53,6 +53,8 @@
   "other": {
     "timeout": 300000,
     "retryTimes": 10,
+    "proxyProtocol": "http",
+    "proxyPool": "",
     "forceIPv4": false,
     "skipProjectIdFetch": false,
     "useNativeAxios": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,11 @@
         "cors": "^2.8.6",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "http-proxy-agent": "^8.0.0",
+        "https-proxy-agent": "^8.0.0",
         "jsonwebtoken": "^9.0.3",
         "protobufjs": "^8.0.0",
+        "socks-proxy-agent": "^9.0.0",
         "ws": "^8.19.0"
       },
       "bin": {
@@ -698,16 +701,12 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-8.0.0.tgz",
+      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -1755,18 +1754,30 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
+    "node_modules/http-proxy-agent": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -1844,6 +1855,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -2397,6 +2417,33 @@
         "pkg-fetch": "lib-es5/bin.js"
       }
     },
+    "node_modules/pkg-fetch/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -2900,6 +2947,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmmirror.com/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmmirror.com/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
     "cors": "^2.8.6",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "http-proxy-agent": "^8.0.0",
+    "https-proxy-agent": "^8.0.0",
     "jsonwebtoken": "^9.0.3",
     "protobufjs": "^8.0.0",
+    "socks-proxy-agent": "^9.0.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-2";
+        window.__STATIC_VERSION__ = "20260330-3";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -724,6 +724,20 @@
                         />
                       </div>
                       <div class="form-row-inline">
+                        <div class="form-group compact switch-group">
+                          <label
+                            >全代理模式
+                            <span
+                              class="help-tip"
+                              data-tooltip="开启后所有上游请求都走代理；关闭后仅在向 LLM 发送消息时走代理。"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input type="checkbox" name="PROXY_ALL_REQUESTS" />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
                         <div class="form-group compact">
                           <label>代理协议</label>
                           <select name="PROXY_PROTOCOL">

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-9";
+        window.__STATIC_VERSION__ = "20260330-10";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260327-4";
+        window.__STATIC_VERSION__ = "20260327-5";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-10";
+        window.__STATIC_VERSION__ = "20260331-1";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
+        window.__STATIC_VERSION__ = "20260327-1";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";
@@ -206,7 +207,15 @@
       }
     </style>
     <!-- 主样式表 - 优先加载 -->
-    <link rel="stylesheet" href="style.css" />
+    <script>
+      (function () {
+        var version = window.__STATIC_VERSION__ || "dev";
+        var link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = "style.css?v=" + encodeURIComponent(version);
+        document.head.appendChild(link);
+      })();
+    </script>
     <!-- 预连接字体服务器 -->
     <link rel="preconnect" href="https://font.sec.miui.com" crossorigin />
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
@@ -1238,15 +1247,29 @@
     </div>
 
     <!-- 按依赖顺序加载模块 -->
-    <script src="js/utils.js" defer></script>
-    <script src="js/ui.js" defer></script>
-    <script src="js/auth.js" defer></script>
-    <script src="js/quota.js" defer></script>
-    <script src="js/tokens.js" defer></script>
-    <script src="js/geminicli.js" defer></script>
-    <script src="js/config.js" defer></script>
-    <script src="js/security.js" defer></script>
-    <script src="js/logs.js" defer></script>
-    <script src="js/main.js" defer></script>
+    <script>
+      (function () {
+        var version = window.__STATIC_VERSION__ || "dev";
+        var scripts = [
+          "js/utils.js",
+          "js/ui.js",
+          "js/auth.js",
+          "js/quota.js",
+          "js/tokens.js",
+          "js/geminicli.js",
+          "js/config.js",
+          "js/security.js",
+          "js/logs.js",
+          "js/main.js",
+        ];
+
+        scripts.forEach(function (src) {
+          var script = document.createElement("script");
+          script.src = src + "?v=" + encodeURIComponent(version);
+          script.defer = true;
+          document.body.appendChild(script);
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,733 +1,1240 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-CN">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>Token 管理</title>
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
-        (function () {
-            // 初始状态：auth-checking 表示正在验证登录状态
-            // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
-            var currentTab = localStorage.getItem('currentTab') || 'tokens';
-            var classes = ['auth-checking'];
-            if (currentTab === 'settings') classes.push('tab-settings');
-            if (currentTab === 'logs') classes.push('tab-logs');
-            document.documentElement.className = classes.join(' ');
-            // 检测字体加载
-            if ('fonts' in document) {
-                document.fonts.ready.then(function () {
-                    document.documentElement.classList.add('fonts-loaded');
-                });
-            } else {
-                // 后备方案：延迟添加
-                setTimeout(function () {
-                    document.documentElement.classList.add('fonts-loaded');
-                }, 1000);
-            }
-        })();
+      (function () {
+        // 初始状态：auth-checking 表示正在验证登录状态
+        // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
+        var currentTab = localStorage.getItem("currentTab") || "tokens";
+        var classes = ["auth-checking"];
+        if (currentTab === "settings") classes.push("tab-settings");
+        if (currentTab === "logs") classes.push("tab-logs");
+        document.documentElement.className = classes.join(" ");
+        // 检测字体加载
+        if ("fonts" in document) {
+          document.fonts.ready.then(function () {
+            document.documentElement.classList.add("fonts-loaded");
+          });
+        } else {
+          // 后备方案：延迟添加
+          setTimeout(function () {
+            document.documentElement.classList.add("fonts-loaded");
+          }, 1000);
+        }
+      })();
     </script>
     <style>
-        /* 验证中状态：隐藏登录框和主内容，显示加载指示器 */
-        html.auth-checking #loginForm,
-        html.auth-checking #mainContent {
-            display: none !important;
-        }
+      /* 验证中状态：隐藏登录框和主内容，显示加载指示器 */
+      html.auth-checking #loginForm,
+      html.auth-checking #mainContent {
+        display: none !important;
+      }
 
-        html.auth-checking #authLoading {
-            display: flex !important;
-        }
+      html.auth-checking #authLoading {
+        display: flex !important;
+      }
 
-        /* 验证完成后：隐藏加载指示器 */
-        html.auth-ready #authLoading {
-            display: none !important;
-        }
+      /* 验证完成后：隐藏加载指示器 */
+      html.auth-ready #authLoading {
+        display: none !important;
+      }
 
-        /* 登录状态显示控制 */
-        .logged-in #loginForm {
-            display: none !important;
-        }
+      /* 登录状态显示控制 */
+      .logged-in #loginForm {
+        display: none !important;
+      }
 
-        .logged-in #mainContent {
-            display: flex !important;
-        }
+      .logged-in #mainContent {
+        display: flex !important;
+      }
 
-        html.auth-ready:not(.logged-in) #loginForm {
-            display: block !important;
-        }
+      html.auth-ready:not(.logged-in) #loginForm {
+        display: block !important;
+      }
 
-        html.auth-ready:not(.logged-in) #mainContent {
-            display: none !important;
-        }
+      html.auth-ready:not(.logged-in) #mainContent {
+        display: none !important;
+      }
 
-        /* Tab状态管理 */
-        html.tab-settings #tokensPage {
-            display: none !important;
-        }
+      /* Tab状态管理 */
+      html.tab-settings #tokensPage {
+        display: none !important;
+      }
 
-        html.tab-settings #settingsPage {
-            display: block !important;
-        }
+      html.tab-settings #settingsPage {
+        display: block !important;
+      }
 
-        html.tab-settings #logsPage {
-            display: none !important;
-        }
+      html.tab-settings #logsPage {
+        display: none !important;
+      }
 
-        html.tab-settings .tab[data-tab="tokens"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-settings .tab[data-tab="tokens"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        html.tab-settings .tab[data-tab="settings"] {
-            background: var(--primary, #4f46e5) !important;
-            color: white !important;
-        }
+      html.tab-settings .tab[data-tab="settings"] {
+        background: var(--primary, #4f46e5) !important;
+        color: white !important;
+      }
 
-        html.tab-settings .tab[data-tab="logs"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-settings .tab[data-tab="logs"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        html.tab-logs #tokensPage {
-            display: none !important;
-        }
+      html.tab-logs #tokensPage {
+        display: none !important;
+      }
 
-        html.tab-logs #settingsPage {
-            display: none !important;
-        }
+      html.tab-logs #settingsPage {
+        display: none !important;
+      }
 
-        html.tab-logs #logsPage {
-            display: flex !important;
-        }
+      html.tab-logs #logsPage {
+        display: flex !important;
+      }
 
-        html.tab-logs #geminicliPage {
-            display: none !important;
-        }
+      html.tab-logs #geminicliPage {
+        display: none !important;
+      }
 
-        html.tab-logs .tab[data-tab="tokens"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-logs .tab[data-tab="tokens"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        html.tab-logs .tab[data-tab="settings"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-logs .tab[data-tab="settings"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        html.tab-logs .tab[data-tab="logs"] {
-            background: var(--primary, #4f46e5) !important;
-            color: white !important;
-        }
+      html.tab-logs .tab[data-tab="logs"] {
+        background: var(--primary, #4f46e5) !important;
+        color: white !important;
+      }
 
-        html.tab-logs .tab[data-tab="geminicli"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-logs .tab[data-tab="geminicli"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        /* Gemini CLI Tab 状态 */
-        html.tab-geminicli #tokensPage {
-            display: none !important;
-        }
+      /* Gemini CLI Tab 状态 */
+      html.tab-geminicli #tokensPage {
+        display: none !important;
+      }
 
-        html.tab-geminicli #settingsPage {
-            display: none !important;
-        }
+      html.tab-geminicli #settingsPage {
+        display: none !important;
+      }
 
-        html.tab-geminicli #logsPage {
-            display: none !important;
-        }
+      html.tab-geminicli #logsPage {
+        display: none !important;
+      }
 
-        html.tab-geminicli #geminicliPage {
-            display: block !important;
-        }
+      html.tab-geminicli #geminicliPage {
+        display: block !important;
+      }
 
-        html.tab-geminicli .tab[data-tab="tokens"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-geminicli .tab[data-tab="tokens"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        html.tab-geminicli .tab[data-tab="settings"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-geminicli .tab[data-tab="settings"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        html.tab-geminicli .tab[data-tab="logs"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-geminicli .tab[data-tab="logs"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        html.tab-geminicli .tab[data-tab="geminicli"] {
-            background: var(--primary, #4f46e5) !important;
-            color: white !important;
-        }
+      html.tab-geminicli .tab[data-tab="geminicli"] {
+        background: var(--primary, #4f46e5) !important;
+        color: white !important;
+      }
 
-        html.tab-settings #geminicliPage {
-            display: none !important;
-        }
+      html.tab-settings #geminicliPage {
+        display: none !important;
+      }
 
-        html.tab-settings .tab[data-tab="geminicli"] {
-            background: transparent !important;
-            color: var(--text-light, #888) !important;
-        }
+      html.tab-settings .tab[data-tab="geminicli"] {
+        background: transparent !important;
+        color: var(--text-light, #888) !important;
+      }
 
-        /* 加载指示器样式 */
-        #authLoading {
-            display: none;
-            position: fixed;
-            inset: 0;
-            align-items: center;
-            justify-content: center;
-            flex-direction: column;
-            gap: 1rem;
-            background: var(--bg, #f8fafc);
-        }
+      /* 加载指示器样式 */
+      #authLoading {
+        display: none;
+        position: fixed;
+        inset: 0;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 1rem;
+        background: var(--bg, #f8fafc);
+      }
 
-        #authLoading .spinner {
-            width: 40px;
-            height: 40px;
-            border: 3px solid var(--border, #e2e8f0);
-            border-top-color: var(--primary, #0891b2);
-            border-radius: 50%;
-            animation: spin 0.7s linear infinite;
-        }
+      #authLoading .spinner {
+        width: 40px;
+        height: 40px;
+        border: 3px solid var(--border, #e2e8f0);
+        border-top-color: var(--primary, #0891b2);
+        border-radius: 50%;
+        animation: spin 0.7s linear infinite;
+      }
 
-        #authLoading .loading-text {
-            color: var(--text-light, #64748b);
-            font-size: 0.875rem;
-        }
+      #authLoading .loading-text {
+        color: var(--text-light, #64748b);
+        font-size: 0.875rem;
+      }
 
-        @keyframes spin {
-            to {
-                transform: rotate(360deg);
-            }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
         }
+      }
     </style>
     <!-- 主样式表 - 优先加载 -->
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
     <!-- 预连接字体服务器 -->
-    <link rel="preconnect" href="https://font.sec.miui.com" crossorigin>
-    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://font.sec.miui.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <!-- 字体异步加载 - 不阻塞渲染 -->
-    <link rel="stylesheet"
-        href="https://font.sec.miui.com/font/css?family=MiSans:400,500,600,700:Chinese_Simplify,Latin&display=swap"
-        media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:wght@400;700&display=swap"
-        media="print" onload="this.media='all'">
+    <link
+      rel="stylesheet"
+      href="https://font.sec.miui.com/font/css?family=MiSans:400,500,600,700:Chinese_Simplify,Latin&display=swap"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:wght@400;700&display=swap"
+      media="print"
+      onload="this.media = 'all'"
+    />
     <noscript>
-        <link rel="stylesheet"
-            href="https://font.sec.miui.com/font/css?family=MiSans:400,500,600,700:Chinese_Simplify,Latin&display=swap">
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:wght@400;700&display=swap">
+      <link
+        rel="stylesheet"
+        href="https://font.sec.miui.com/font/css?family=MiSans:400,500,600,700:Chinese_Simplify,Latin&display=swap"
+      />
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:wght@400;700&display=swap"
+      />
     </noscript>
-</head>
+  </head>
 
-<body>
+  <body>
     <!-- 验证登录状态时的加载指示器 -->
     <div id="authLoading">
-        <div class="spinner"></div>
-        <div class="loading-text">正在验证登录状态...</div>
+      <div class="spinner"></div>
+      <div class="loading-text">正在验证登录状态...</div>
     </div>
 
     <div class="container">
-        <!-- 登录表单 -->
-        <div id="loginForm" class="login-form">
-            <h2>Token 管理</h2>
-            <form id="login">
-                <div class="form-group">
-                    <label>👤 用户名</label>
-                    <input type="text" id="username" required autocomplete="username">
+      <!-- 登录表单 -->
+      <div id="loginForm" class="login-form">
+        <h2>Token 管理</h2>
+        <form id="login">
+          <div class="form-group">
+            <label>👤 用户名</label>
+            <input type="text" id="username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label>🔑 密码</label>
+            <input
+              type="password"
+              id="password"
+              required
+              autocomplete="current-password"
+            />
+          </div>
+          <button type="submit">登录</button>
+        </form>
+      </div>
+
+      <!-- 主内容 -->
+      <div id="mainContent" class="main-content hidden">
+        <div class="header">
+          <div class="tabs">
+            <button
+              class="tab active"
+              data-tab="tokens"
+              onclick="switchTab('tokens')"
+            >
+              <span class="tab-icon">🎯</span
+              ><span class="tab-text">Token</span>
+            </button>
+            <button
+              class="tab"
+              data-tab="geminicli"
+              onclick="switchTab('geminicli')"
+            >
+              <span class="tab-icon">💎</span><span class="tab-text">CLI</span>
+            </button>
+            <button
+              class="tab"
+              data-tab="settings"
+              onclick="switchTab('settings')"
+            >
+              <span class="tab-icon">⚙️</span><span class="tab-text">设置</span>
+            </button>
+            <button class="tab" data-tab="logs" onclick="switchTab('logs')">
+              <span class="tab-icon">📋</span><span class="tab-text">日志</span>
+            </button>
+          </div>
+          <div class="header-right">
+            <button onclick="logout()">🚪 退出</button>
+          </div>
+        </div>
+        <div class="content">
+          <!-- Token管理页面 -->
+          <div id="tokensPage">
+            <!-- 统计卡片 + 操作按钮 -->
+            <div class="top-bar">
+              <div class="stats-inline">
+                <div
+                  class="stat-item clickable active"
+                  onclick="filterTokens('all')"
+                >
+                  <span class="stat-num" id="totalTokens">0</span>
+                  <span class="stat-text">总数</span>
                 </div>
-                <div class="form-group">
-                    <label>🔑 密码</label>
-                    <input type="password" id="password" required autocomplete="current-password">
+                <div
+                  class="stat-item success clickable"
+                  onclick="filterTokens('enabled')"
+                >
+                  <span class="stat-num" id="enabledTokens">0</span>
+                  <span class="stat-text">启用</span>
                 </div>
-                <button type="submit">登录</button>
+                <div
+                  class="stat-item danger clickable"
+                  onclick="filterTokens('disabled')"
+                >
+                  <span class="stat-num" id="disabledTokens">0</span>
+                  <span class="stat-text">禁用</span>
+                </div>
+                <button
+                  type="button"
+                  class="action-toggle-btn"
+                  id="actionToggleBtn"
+                  onclick="toggleActionBar()"
+                  title="收起操作按钮"
+                >
+                  ▾
+                </button>
+              </div>
+              <div class="action-btns" id="actionBar">
+                <button
+                  type="button"
+                  onclick="showOAuthModal()"
+                  class="btn btn-success btn-sm"
+                >
+                  🔐 OAuth
+                </button>
+                <button
+                  type="button"
+                  onclick="toggleSensitiveInfo()"
+                  class="btn btn-secondary btn-sm"
+                  id="toggleSensitiveBtn"
+                  title="点击显示敏感信息"
+                >
+                  🙈 隐藏
+                </button>
+                <button
+                  type="button"
+                  onclick="refreshAllQuotas()"
+                  class="btn btn-info btn-sm"
+                  id="refreshQuotasBtn"
+                >
+                  📊 刷新额度
+                </button>
+                <button
+                  type="button"
+                  onclick="batchFetchProjectIds()"
+                  class="btn btn-info btn-sm"
+                  title="批量获取所有启用Token的Project ID"
+                >
+                  🔍 批量获取
+                </button>
+                <button
+                  type="button"
+                  onclick="loadTokens()"
+                  class="btn btn-warning btn-sm"
+                >
+                  🔄 重载
+                </button>
+                <button
+                  type="button"
+                  onclick="exportTokens()"
+                  class="btn btn-sm"
+                  style="background: var(--primary)"
+                  title="导出Token"
+                >
+                  📤 导出
+                </button>
+                <button
+                  type="button"
+                  onclick="importTokens()"
+                  class="btn btn-sm"
+                  style="background: var(--primary)"
+                  title="添加/导入Token"
+                >
+                  📥 导入
+                </button>
+              </div>
+            </div>
+
+            <!-- Token网格 -->
+            <div id="tokenList" class="token-grid">
+              <div class="empty-state">
+                <div class="empty-state-icon">📦</div>
+                <div class="empty-state-text">暂无Token</div>
+                <div class="empty-state-hint">点击上方OAuth按钮添加Token</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Gemini CLI 页面 -->
+          <div id="geminicliPage" class="hidden">
+            <!-- 统计卡片 + 操作按钮 -->
+            <div class="top-bar">
+              <div class="stats-inline">
+                <div
+                  class="stat-item clickable active"
+                  onclick="filterGeminiCliTokens('all')"
+                >
+                  <span class="stat-num" id="geminicliTotalTokens">0</span>
+                  <span class="stat-text">总数</span>
+                </div>
+                <div
+                  class="stat-item success clickable"
+                  onclick="filterGeminiCliTokens('enabled')"
+                >
+                  <span class="stat-num" id="geminicliEnabledTokens">0</span>
+                  <span class="stat-text">启用</span>
+                </div>
+                <div
+                  class="stat-item danger clickable"
+                  onclick="filterGeminiCliTokens('disabled')"
+                >
+                  <span class="stat-num" id="geminicliDisabledTokens">0</span>
+                  <span class="stat-text">禁用</span>
+                </div>
+              </div>
+              <div class="action-btns">
+                <button
+                  type="button"
+                  onclick="showGeminiCliOAuthModal()"
+                  class="btn btn-success btn-sm"
+                >
+                  🔐 OAuth
+                </button>
+                <button
+                  type="button"
+                  onclick="toggleSensitiveInfo()"
+                  class="btn btn-secondary btn-sm"
+                  title="点击显示敏感信息"
+                >
+                  🙈 隐藏
+                </button>
+                <button
+                  type="button"
+                  onclick="reloadGeminiCliTokens()"
+                  class="btn btn-warning btn-sm"
+                >
+                  🔄 重载
+                </button>
+                <button
+                  type="button"
+                  onclick="exportGeminiCliTokens()"
+                  class="btn btn-sm"
+                  style="background: var(--primary)"
+                  title="导出Token"
+                >
+                  📤 导出
+                </button>
+                <button
+                  type="button"
+                  onclick="importGeminiCliTokens()"
+                  class="btn btn-sm"
+                  style="background: var(--primary)"
+                  title="添加/导入Token"
+                >
+                  📥 导入
+                </button>
+              </div>
+            </div>
+
+            <!-- Token网格 -->
+            <div id="geminicliTokenList" class="token-grid">
+              <div class="empty-state">
+                <div class="empty-state-icon">📦</div>
+                <div class="empty-state-text">暂无Gemini CLI Token</div>
+                <div class="empty-state-hint">点击上方OAuth按钮添加Token</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 日志页面 -->
+          <div id="logsPage" class="hidden">
+            <div class="logs-top-bar">
+              <div class="logs-top-row">
+                <div id="logStats" class="log-stats">
+                  <!-- 日志统计将由 JS 渲染 -->
+                </div>
+              </div>
+              <div class="logs-second-row">
+                <div class="log-search">
+                  <input
+                    type="text"
+                    id="logSearchInput"
+                    placeholder="搜索日志..."
+                    oninput="searchLogs(this.value)"
+                  />
+                </div>
+                <div class="log-action-btns">
+                  <button
+                    id="autoRefreshBtn"
+                    class="btn btn-sm btn-secondary"
+                    onclick="toggleAutoRefresh()"
+                    title="每3秒自动刷新日志"
+                  >
+                    🔄 自动刷新
+                  </button>
+                  <button
+                    class="btn btn-sm btn-info"
+                    onclick="
+                      loadLogs();
+                      loadLogStats();
+                    "
+                    title="手动刷新日志"
+                  >
+                    ↻ 刷新
+                  </button>
+                  <button
+                    class="btn btn-sm"
+                    style="background: var(--primary)"
+                    onclick="exportLogs()"
+                    title="导出日志为文本文件"
+                  >
+                    📤 导出
+                  </button>
+                  <button
+                    class="btn btn-sm btn-danger"
+                    onclick="clearLogs()"
+                    title="清空所有日志"
+                  >
+                    🗑️ 清空
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div class="log-container">
+              <div id="logList" class="log-list">
+                <div class="log-empty">
+                  <div class="log-empty-icon">📋</div>
+                  <div class="log-empty-text">加载中...</div>
+                </div>
+              </div>
+            </div>
+            <button
+              id="loadMoreLogsBtn"
+              class="btn btn-secondary load-more-btn"
+              onclick="loadMoreLogs()"
+              style="display: none"
+            >
+              加载更多
+            </button>
+          </div>
+
+          <!-- 设置页面 -->
+          <div id="settingsPage" class="hidden">
+            <form id="configForm" class="config-form">
+              <div class="settings-layout">
+                <aside class="settings-nav">
+                  <div class="settings-search">
+                    <input
+                      type="text"
+                      id="settingsSearch"
+                      placeholder="搜索设置..."
+                      oninput="filterSettings(this.value)"
+                    />
+                  </div>
+                  <select
+                    class="settings-section-select"
+                    id="settingsSectionSelect"
+                    onchange="setActiveSettingSection(this.value, true)"
+                  >
+                    <option value="section-server">🖥️ 服务器</option>
+                    <option value="section-model">🎛️ 模型参数</option>
+                    <option value="section-rotation">🔄 轮询与性能</option>
+                    <option value="section-security">🛡️ 安全管理</option>
+                  </select>
+                  <div class="settings-nav-list">
+                    <button
+                      type="button"
+                      class="settings-nav-item"
+                      data-target="section-server"
+                      onclick="setActiveSettingSection('section-server', true)"
+                    >
+                      🖥️ 服务器
+                    </button>
+                    <button
+                      type="button"
+                      class="settings-nav-item"
+                      data-target="section-model"
+                      onclick="setActiveSettingSection('section-model', true)"
+                    >
+                      🎛️ 模型参数
+                    </button>
+                    <button
+                      type="button"
+                      class="settings-nav-item"
+                      data-target="section-rotation"
+                      onclick="
+                        setActiveSettingSection('section-rotation', true)
+                      "
+                    >
+                      🔄 轮询与性能
+                    </button>
+                    <button
+                      type="button"
+                      class="settings-nav-item"
+                      data-target="section-security"
+                      onclick="
+                        setActiveSettingSection('section-security', true)
+                      "
+                    >
+                      🛡️ 安全管理
+                    </button>
+                  </div>
+                </aside>
+                <div class="settings-content">
+                  <div class="config-grid">
+                    <!-- 服务器配置 -->
+                    <div class="config-section" id="section-server">
+                      <h4>🖥️ 服务器</h4>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label>端口</label>
+                          <input type="number" name="PORT" placeholder="8045" />
+                        </div>
+                        <div class="form-group compact">
+                          <label>监听地址</label>
+                          <input
+                            type="text"
+                            name="HOST"
+                            placeholder="0.0.0.0"
+                          />
+                        </div>
+                      </div>
+                      <div class="form-group compact">
+                        <label
+                          >API 环境
+                          <span
+                            class="help-tip"
+                            data-tooltip="选择使用 sandbox 或 production 环境的 API 接口"
+                            >?</span
+                          ></label
+                        >
+                        <select name="API_USE" id="apiUseSelect">
+                          <option value="sandbox">Sandbox (测试)</option>
+                          <option value="production">Production (生产)</option>
+                        </select>
+                      </div>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label>最大请求大小</label>
+                          <input
+                            type="text"
+                            name="MAX_REQUEST_SIZE"
+                            placeholder="500mb"
+                          />
+                        </div>
+                        <div class="form-group compact">
+                          <label>API密钥</label>
+                          <input
+                            type="password"
+                            name="API_KEY"
+                            placeholder="留空则不验证"
+                          />
+                        </div>
+                      </div>
+                      <div class="form-row-inline switch-row">
+                        <div class="form-group compact switch-group">
+                          <label
+                            >跳过验证
+                            <span
+                              class="help-tip"
+                              data-tooltip="跳过ProjectId获取，直接随机生成（仅Pro账号）"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="SKIP_PROJECT_ID_FETCH"
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                        <div class="form-group compact switch-group">
+                          <label
+                            >原生Axios
+                            <span
+                              class="help-tip"
+                              data-tooltip="使用原生axios而非TLS指纹请求器"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input type="checkbox" name="USE_NATIVE_AXIOS" />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                      </div>
+                      <div class="form-group compact">
+                        <label>图片访问链接</label>
+                        <input
+                          type="text"
+                          name="IMAGE_BASE_URL"
+                          placeholder="https://your-domain.zeabur.app"
+                        />
+                      </div>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label>代理协议</label>
+                          <select name="PROXY_PROTOCOL">
+                            <option value="http">HTTP</option>
+                            <option value="https">HTTPS</option>
+                            <option value="socks5">SOCKS5</option>
+                          </select>
+                        </div>
+                      </div>
+                      <div class="form-group compact">
+                        <label
+                          >代理池
+                          <span
+                            class="help-tip"
+                            data-tooltip="支持多行输入，每行格式：主机:端口:用户名:密码。每次请求自动轮询，并持久化轮询进度。"
+                            >?</span
+                          ></label
+                        >
+                        <textarea
+                          name="PROXY_POOL"
+                          rows="4"
+                          placeholder="p.webshare.io:10000:efuztrhi-1:Ld987654321&#10;p.webshare.io:10001:efuztrhi-2:Ld987654321"
+                        ></textarea>
+                      </div>
+                    </div>
+
+                    <!-- 模型默认参数 -->
+                    <div class="config-section" id="section-model">
+                      <h4>🎛️ 模型参数</h4>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label>温度</label>
+                          <input
+                            type="number"
+                            step="0.1"
+                            name="DEFAULT_TEMPERATURE"
+                            placeholder="1"
+                          />
+                        </div>
+                        <div class="form-group compact">
+                          <label>Top P</label>
+                          <input
+                            type="number"
+                            step="0.01"
+                            name="DEFAULT_TOP_P"
+                            placeholder="1"
+                          />
+                        </div>
+                      </div>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label>Top K</label>
+                          <input
+                            type="number"
+                            name="DEFAULT_TOP_K"
+                            placeholder="50"
+                          />
+                        </div>
+                        <div class="form-group compact">
+                          <label>最大Token</label>
+                          <input
+                            type="number"
+                            name="DEFAULT_MAX_TOKENS"
+                            placeholder="32000"
+                          />
+                        </div>
+                      </div>
+                      <div class="form-group compact highlight">
+                        <label
+                          >思考预算
+                          <span
+                            class="help-tip"
+                            data-tooltip="思考模型的思考token预算，影响推理深度"
+                            >?</span
+                          ></label
+                        >
+                        <input
+                          type="number"
+                          name="DEFAULT_THINKING_BUDGET"
+                          placeholder="16000"
+                        />
+                      </div>
+                      <div class="form-row-inline switch-row">
+                        <div class="form-group compact switch-group">
+                          <label
+                            >上下文System
+                            <span
+                              class="help-tip"
+                              data-tooltip="开启后，将用户请求的system消息追加到反代提示词后面"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="USE_CONTEXT_SYSTEM_PROMPT"
+                              id="useContextSystemPrompt"
+                              onchange="handleContextSystemChange()"
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                        <div class="form-group compact switch-group">
+                          <label
+                            >合并提示词
+                            <span
+                              class="help-tip"
+                              data-tooltip="开启后，将所有系统提示词合并为单个part（需要先开启上下文System）"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="MERGE_SYSTEM_PROMPT"
+                              id="mergeSystemPrompt"
+                              checked
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                        <div class="form-group compact switch-group">
+                          <label
+                            >假非流
+                            <span
+                              class="help-tip"
+                              data-tooltip="非流式请求使用流式获取数据，最终返回非流式格式的JSON（更快）"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="FAKE_NON_STREAM"
+                              checked
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                      </div>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label
+                            >官方提示词位置
+                            <span
+                              class="help-tip"
+                              data-tooltip="官方提示词相对于反代提示词的位置"
+                              >?</span
+                            ></label
+                          >
+                          <select name="OFFICIAL_PROMPT_POSITION">
+                            <option value="before">在反代提示词前面</option>
+                            <option value="after">在反代提示词后面</option>
+                          </select>
+                        </div>
+                      </div>
+                      <div class="form-group compact">
+                        <label
+                          >反代系统提示词
+                          <span
+                            class="restore-default"
+                            onclick="restoreDefaultSystemInstruction()"
+                            title="恢复默认"
+                            >↻ 恢复默认</span
+                          ></label
+                        >
+                        <textarea
+                          name="SYSTEM_INSTRUCTION"
+                          rows="3"
+                          placeholder="反代系统提示词（留空则不使用）"
+                        ></textarea>
+                      </div>
+                      <div class="form-group compact">
+                        <label>
+                          官方系统提示词
+                          <span
+                            class="help-tip"
+                            data-tooltip="反重力官方要求的系统提示词"
+                            >?</span
+                          >
+                          <span
+                            class="restore-default"
+                            onclick="restoreDefaultOfficialSystemPrompt()"
+                            title="恢复默认"
+                            id="restoreOfficialBtn"
+                            style="display: none"
+                            >↻ 恢复默认</span
+                          >
+                        </label>
+                        <div class="textarea-wrapper">
+                          <textarea
+                            name="OFFICIAL_SYSTEM_PROMPT"
+                            id="officialSystemPrompt"
+                            rows="5"
+                            placeholder="官方系统提示词（留空则不使用）"
+                            readonly
+                          ></textarea>
+                          <div
+                            class="textarea-lock-btn"
+                            id="unlockOfficialBtn"
+                            onclick="unlockOfficialSystemPrompt()"
+                            title="点击解锁修改"
+                          >
+                            🔒
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- 轮询策略与性能优化 -->
+                    <div class="config-section" id="section-rotation">
+                      <h4>🔄 轮询与性能</h4>
+                      <div class="form-row-inline switch-row">
+                        <div class="form-group compact switch-group">
+                          <label
+                            >透传签名
+                            <span
+                              class="help-tip"
+                              data-tooltip="将响应中的thoughtSignature透传到客户端"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="PASS_SIGNATURE_TO_CLIENT"
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                        <div class="form-group compact switch-group">
+                          <label
+                            >兜底签名
+                            <span
+                              class="help-tip"
+                              data-tooltip="没有缓存签名时，使用内置默认签名自动补全"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="USE_FALLBACK_SIGNATURE"
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                      </div>
+                      <div class="form-row-inline switch-row">
+                        <div class="form-group compact switch-group">
+                          <label
+                            >缓存所有签名
+                            <span
+                              class="help-tip"
+                              data-tooltip="开启后缓存所有签名"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="CACHE_ALL_SIGNATURES"
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                        <div class="form-group compact switch-group">
+                          <label
+                            >工具签名
+                            <span
+                              class="help-tip"
+                              data-tooltip="使用工具时缓存签名"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="CACHE_TOOL_SIGNATURES"
+                              checked
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                        <div class="form-group compact switch-group">
+                          <label
+                            >图像签名
+                            <span
+                              class="help-tip"
+                              data-tooltip="使用图像模型时缓存签名"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="CACHE_IMAGE_SIGNATURES"
+                              checked
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                        <div class="form-group compact switch-group">
+                          <label
+                            >缓存思考
+                            <span
+                              class="help-tip"
+                              data-tooltip="缓存思考内容，随签名一起返回"
+                              >?</span
+                            ></label
+                          >
+                          <label class="switch">
+                            <input
+                              type="checkbox"
+                              name="CACHE_THINKING"
+                              checked
+                            />
+                            <span class="slider"></span>
+                          </label>
+                        </div>
+                      </div>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label
+                            >策略模式
+                            <span
+                              class="help-tip"
+                              data-tooltip="均衡负载：每次请求切换Token&#10;额度耗尽：用完额度才切换&#10;自定义次数：指定次数后切换"
+                              >?</span
+                            ></label
+                          >
+                          <select
+                            name="ROTATION_STRATEGY"
+                            id="rotationStrategy"
+                            onchange="toggleRequestCountInput()"
+                          >
+                            <option value="round_robin">均衡负载</option>
+                            <option value="quota_exhausted">
+                              额度耗尽切换
+                            </option>
+                            <option value="request_count">自定义次数</option>
+                          </select>
+                        </div>
+                        <div class="form-group compact" id="requestCountGroup">
+                          <label
+                            >每Token请求次数
+                            <span
+                              class="help-tip"
+                              data-tooltip="自定义次数模式下，每个Token处理多少次请求后切换"
+                              >?</span
+                            ></label
+                          >
+                          <input
+                            type="number"
+                            name="ROTATION_REQUEST_COUNT"
+                            min="1"
+                            placeholder="10"
+                          />
+                        </div>
+                      </div>
+                      <div class="rotation-status" id="rotationStatus">
+                        <span class="rotation-label">当前状态:</span>
+                        <span id="currentRotationInfo">加载中...</span>
+                      </div>
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label>超时(ms)</label>
+                          <input
+                            type="number"
+                            name="TIMEOUT"
+                            placeholder="300000"
+                          />
+                        </div>
+                        <div class="form-group compact">
+                          <label>429/503重试次数</label>
+                          <input
+                            type="number"
+                            name="RETRY_TIMES"
+                            placeholder="0"
+                          />
+                        </div>
+                      </div>
+
+                      <div class="form-row-inline">
+                        <div class="form-group compact">
+                          <label
+                            >心跳间隔(ms)
+                            <span
+                              class="help-tip"
+                              data-tooltip="SSE心跳间隔，防止CF超时断连"
+                              >?</span
+                            ></label
+                          >
+                          <input
+                            type="number"
+                            name="HEARTBEAT_INTERVAL"
+                            placeholder="15000"
+                          />
+                        </div>
+                        <div class="form-group compact">
+                          <label
+                            >内存清理间隔(ms)
+                            <span
+                              class="help-tip"
+                              data-tooltip="按固定间隔触发缓存/对象池清理"
+                              >?</span
+                            ></label
+                          >
+                          <input
+                            type="number"
+                            name="MEMORY_CLEANUP_INTERVAL"
+                            placeholder="1800000"
+                          />
+                        </div>
+                      </div>
+                      <div class="form-group compact">
+                        <label>🔤 界面字体大小 (px)</label>
+                        <div class="font-size-control">
+                          <input
+                            type="range"
+                            id="fontSizeRange"
+                            min="10"
+                            max="24"
+                            value="18"
+                            oninput="changeFontSize(this.value)"
+                          />
+                          <input
+                            type="number"
+                            id="fontSizeInput"
+                            min="10"
+                            max="24"
+                            value="18"
+                            onchange="changeFontSize(this.value)"
+                            style="width: 60px"
+                          />
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- 安全管理 -->
+                    <div class="config-section" id="section-security">
+                      <h4>🛡️ 安全管理</h4>
+                      <div class="form-group compact switch-group">
+                        <label
+                          >启用封禁
+                          <span
+                            class="help-tip"
+                            data-tooltip="开启后自动封禁频繁违规的IP地址"
+                            >?</span
+                          ></label
+                        >
+                        <label class="switch">
+                          <input type="checkbox" id="blockingEnabled" />
+                          <span class="slider"></span>
+                        </label>
+                      </div>
+                      <div class="security-info">
+                        <p>IP封禁机制：自动识别并封禁频繁违规的IP地址</p>
+                        <ul>
+                          <li>5分钟内50次违规 → 临时封禁1小时</li>
+                          <li>累计10次临时封禁 → 永久封禁</li>
+                          <li>
+                            内网IP自动白名单（127.x、10.x、172.16-31.x、192.168.x）
+                          </li>
+                        </ul>
+                      </div>
+                      <div class="blocked-ips-header">
+                        <h5>封禁列表</h5>
+                        <button
+                          type="button"
+                          onclick="loadBlockedIPs()"
+                          class="btn btn-sm btn-info"
+                        >
+                          🔄 刷新
+                        </button>
+                      </div>
+                      <div id="blockedIPsList" class="blocked-ips-list">
+                        <div class="empty-state-small">加载中...</div>
+                      </div>
+                      <div class="whitelist-section">
+                        <h5>白名单管理</h5>
+                        <div class="whitelist-input-group">
+                          <input
+                            type="text"
+                            id="whitelistIPInput"
+                            placeholder="输入IP地址"
+                          />
+                          <button
+                            type="button"
+                            onclick="addWhitelistIP()"
+                            class="btn btn-sm btn-success"
+                          >
+                            ➕ 添加
+                          </button>
+                        </div>
+                        <div
+                          id="whitelistIPsList"
+                          class="whitelist-ips-list"
+                        ></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="config-actions">
+                    <button
+                      type="button"
+                      onclick="loadConfig()"
+                      class="btn btn-secondary"
+                    >
+                      🔄 重新加载
+                    </button>
+                    <button type="submit" class="btn btn-success">
+                      💾 保存配置
+                    </button>
+                  </div>
+                </div>
+              </div>
             </form>
+          </div>
         </div>
-
-        <!-- 主内容 -->
-        <div id="mainContent" class="main-content hidden">
-            <div class="header">
-            <div class="tabs">
-                <button class="tab active" data-tab="tokens" onclick="switchTab('tokens')"><span
-                        class="tab-icon">🎯</span><span class="tab-text">Token</span></button>
-                <button class="tab" data-tab="geminicli" onclick="switchTab('geminicli')"><span
-                        class="tab-icon">💎</span><span class="tab-text">CLI</span></button>
-                <button class="tab" data-tab="settings" onclick="switchTab('settings')"><span
-                        class="tab-icon">⚙️</span><span class="tab-text">设置</span></button>
-                <button class="tab" data-tab="logs" onclick="switchTab('logs')"><span
-                        class="tab-icon">📋</span><span class="tab-text">日志</span></button>
-            </div>
-                <div class="header-right">
-                    <button onclick="logout()">🚪 退出</button>
-                </div>
-            </div>
-            <div class="content">
-                <!-- Token管理页面 -->
-                <div id="tokensPage">
-                    <!-- 统计卡片 + 操作按钮 -->
-                    <div class="top-bar">
-                        <div class="stats-inline">
-                            <div class="stat-item clickable active" onclick="filterTokens('all')">
-                                <span class="stat-num" id="totalTokens">0</span>
-                                <span class="stat-text">总数</span>
-                            </div>
-                            <div class="stat-item success clickable" onclick="filterTokens('enabled')">
-                                <span class="stat-num" id="enabledTokens">0</span>
-                                <span class="stat-text">启用</span>
-                            </div>
-                            <div class="stat-item danger clickable" onclick="filterTokens('disabled')">
-                                <span class="stat-num" id="disabledTokens">0</span>
-                                <span class="stat-text">禁用</span>
-                            </div>
-                            <button type="button" class="action-toggle-btn" id="actionToggleBtn"
-                                onclick="toggleActionBar()" title="收起操作按钮">▾</button>
-                        </div>
-                        <div class="action-btns" id="actionBar">
-                            <button type="button" onclick="showOAuthModal()" class="btn btn-success btn-sm">🔐
-                                OAuth</button>
-                            <button type="button" onclick="toggleSensitiveInfo()" class="btn btn-secondary btn-sm"
-                                id="toggleSensitiveBtn" title="点击显示敏感信息">🙈 隐藏</button>
-                            <button type="button" onclick="refreshAllQuotas()" class="btn btn-info btn-sm"
-                                id="refreshQuotasBtn">📊 刷新额度</button>
-                            <button type="button" onclick="batchFetchProjectIds()" class="btn btn-info btn-sm"
-                                title="批量获取所有启用Token的Project ID">🔍 批量获取</button>
-                            <button type="button" onclick="loadTokens()" class="btn btn-warning btn-sm">🔄 重载</button>
-                            <button type="button" onclick="exportTokens()" class="btn btn-sm"
-                                style="background: var(--primary);" title="导出Token">📤 导出</button>
-                            <button type="button" onclick="importTokens()" class="btn btn-sm"
-                                style="background: var(--primary);" title="添加/导入Token">📥 导入</button>
-                        </div>
-                    </div>
-
-                    <!-- Token网格 -->
-                    <div id="tokenList" class="token-grid">
-                        <div class="empty-state">
-                            <div class="empty-state-icon">📦</div>
-                            <div class="empty-state-text">暂无Token</div>
-                            <div class="empty-state-hint">点击上方OAuth按钮添加Token</div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Gemini CLI 页面 -->
-                <div id="geminicliPage" class="hidden">
-                    <!-- 统计卡片 + 操作按钮 -->
-                    <div class="top-bar">
-                        <div class="stats-inline">
-                            <div class="stat-item clickable active" onclick="filterGeminiCliTokens('all')">
-                                <span class="stat-num" id="geminicliTotalTokens">0</span>
-                                <span class="stat-text">总数</span>
-                            </div>
-                            <div class="stat-item success clickable" onclick="filterGeminiCliTokens('enabled')">
-                                <span class="stat-num" id="geminicliEnabledTokens">0</span>
-                                <span class="stat-text">启用</span>
-                            </div>
-                            <div class="stat-item danger clickable" onclick="filterGeminiCliTokens('disabled')">
-                                <span class="stat-num" id="geminicliDisabledTokens">0</span>
-                                <span class="stat-text">禁用</span>
-                            </div>
-                        </div>
-                        <div class="action-btns">
-                            <button type="button" onclick="showGeminiCliOAuthModal()" class="btn btn-success btn-sm">🔐
-                                OAuth</button>
-                            <button type="button" onclick="toggleSensitiveInfo()" class="btn btn-secondary btn-sm"
-                                title="点击显示敏感信息">🙈 隐藏</button>
-                            <button type="button" onclick="reloadGeminiCliTokens()" class="btn btn-warning btn-sm">🔄 重载</button>
-                            <button type="button" onclick="exportGeminiCliTokens()" class="btn btn-sm"
-                                style="background: var(--primary);" title="导出Token">📤 导出</button>
-                            <button type="button" onclick="importGeminiCliTokens()" class="btn btn-sm"
-                                style="background: var(--primary);" title="添加/导入Token">📥 导入</button>
-                        </div>
-                    </div>
-
-                    <!-- Token网格 -->
-                    <div id="geminicliTokenList" class="token-grid">
-                        <div class="empty-state">
-                            <div class="empty-state-icon">📦</div>
-                            <div class="empty-state-text">暂无Gemini CLI Token</div>
-                            <div class="empty-state-hint">点击上方OAuth按钮添加Token</div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- 日志页面 -->
-                <div id="logsPage" class="hidden">
-                    <div class="logs-top-bar">
-                        <div class="logs-top-row">
-                            <div id="logStats" class="log-stats">
-                                <!-- 日志统计将由 JS 渲染 -->
-                            </div>
-                        </div>
-                        <div class="logs-second-row">
-                            <div class="log-search">
-                                <input type="text" id="logSearchInput" placeholder="搜索日志..."
-                                    oninput="searchLogs(this.value)">
-                            </div>
-                            <div class="log-action-btns">
-                                <button id="autoRefreshBtn" class="btn btn-sm btn-secondary"
-                                    onclick="toggleAutoRefresh()" title="每3秒自动刷新日志">🔄 自动刷新</button>
-                                <button class="btn btn-sm btn-info" onclick="loadLogs(); loadLogStats();"
-                                    title="手动刷新日志">↻ 刷新</button>
-                                <button class="btn btn-sm" style="background: var(--primary);" onclick="exportLogs()"
-                                    title="导出日志为文本文件">📤 导出</button>
-                                <button class="btn btn-sm btn-danger" onclick="clearLogs()" title="清空所有日志">🗑️
-                                    清空</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="log-container">
-                        <div id="logList" class="log-list">
-                            <div class="log-empty">
-                                <div class="log-empty-icon">📋</div>
-                                <div class="log-empty-text">加载中...</div>
-                            </div>
-                        </div>
-                    </div>
-                    <button id="loadMoreLogsBtn" class="btn btn-secondary load-more-btn" onclick="loadMoreLogs()"
-                        style="display: none;">加载更多</button>
-                </div>
-
-                <!-- 设置页面 -->
-                <div id="settingsPage" class="hidden">
-                    <form id="configForm" class="config-form">
-                        <div class="settings-layout">
-                            <aside class="settings-nav">
-                                <div class="settings-search">
-                                    <input type="text" id="settingsSearch" placeholder="搜索设置..."
-                                        oninput="filterSettings(this.value)">
-                                </div>
-                                <select class="settings-section-select" id="settingsSectionSelect"
-                                    onchange="setActiveSettingSection(this.value, true)">
-                                    <option value="section-server">🖥️ 服务器</option>
-                                    <option value="section-model">🎛️ 模型参数</option>
-                                    <option value="section-rotation">🔄 轮询与性能</option>
-                                    <option value="section-security">🛡️ 安全管理</option>
-                                </select>
-                                <div class="settings-nav-list">
-                                    <button type="button" class="settings-nav-item" data-target="section-server"
-                                        onclick="setActiveSettingSection('section-server', true)">🖥️ 服务器</button>
-                                    <button type="button" class="settings-nav-item" data-target="section-model"
-                                        onclick="setActiveSettingSection('section-model', true)">🎛️ 模型参数</button>
-                                    <button type="button" class="settings-nav-item" data-target="section-rotation"
-                                        onclick="setActiveSettingSection('section-rotation', true)">🔄 轮询与性能</button>
-                                    <button type="button" class="settings-nav-item" data-target="section-security"
-                                        onclick="setActiveSettingSection('section-security', true)">🛡️ 安全管理</button>
-                                </div>
-                            </aside>
-                            <div class="settings-content">
-                                <div class="config-grid">
-                                    <!-- 服务器配置 -->
-                                    <div class="config-section" id="section-server">
-                                        <h4>🖥️ 服务器</h4>
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>端口</label>
-                                                <input type="number" name="PORT" placeholder="8045">
-                                            </div>
-                                            <div class="form-group compact">
-                                                <label>监听地址</label>
-                                                <input type="text" name="HOST" placeholder="0.0.0.0">
-                                            </div>
-                                        </div>
-                                        <div class="form-group compact">
-                                            <label>API 环境 <span class="help-tip"
-                                                    data-tooltip="选择使用 sandbox 或 production 环境的 API 接口">?</span></label>
-                                            <select name="API_USE" id="apiUseSelect">
-                                                <option value="sandbox">Sandbox (测试)</option>
-                                                <option value="production">Production (生产)</option>
-                                            </select>
-                                        </div>
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>最大请求大小</label>
-                                                <input type="text" name="MAX_REQUEST_SIZE" placeholder="500mb">
-                                            </div>
-                                            <div class="form-group compact">
-                                                <label>API密钥</label>
-                                                <input type="password" name="API_KEY" placeholder="留空则不验证">
-                                            </div>
-                                        </div>
-                                        <div class="form-row-inline switch-row">
-                                            <div class="form-group compact switch-group">
-                                                <label>跳过验证 <span class="help-tip"
-                                                        data-tooltip="跳过ProjectId获取，直接随机生成（仅Pro账号）">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="SKIP_PROJECT_ID_FETCH">
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                            <div class="form-group compact switch-group">
-                                                <label>原生Axios <span class="help-tip"
-                                                        data-tooltip="使用原生axios而非TLS指纹请求器">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="USE_NATIVE_AXIOS">
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="form-group compact">
-                                            <label>图片访问链接</label>
-                                            <input type="text" name="IMAGE_BASE_URL"
-                                                placeholder="https://your-domain.zeabur.app">
-                                        </div>
-                                        <div class="form-group compact">
-                                            <label>代理地址</label>
-                                            <input type="text" name="PROXY" placeholder="http://127.0.0.1:7890">
-                                        </div>
-                                    </div>
-
-                                    <!-- 模型默认参数 -->
-                                    <div class="config-section" id="section-model">
-                                        <h4>🎛️ 模型参数</h4>
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>温度</label>
-                                                <input type="number" step="0.1" name="DEFAULT_TEMPERATURE"
-                                                    placeholder="1">
-                                            </div>
-                                            <div class="form-group compact">
-                                                <label>Top P</label>
-                                                <input type="number" step="0.01" name="DEFAULT_TOP_P" placeholder="1">
-                                            </div>
-                                        </div>
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>Top K</label>
-                                                <input type="number" name="DEFAULT_TOP_K" placeholder="50">
-                                            </div>
-                                            <div class="form-group compact">
-                                                <label>最大Token</label>
-                                                <input type="number" name="DEFAULT_MAX_TOKENS" placeholder="32000">
-                                            </div>
-                                        </div>
-                                        <div class="form-group compact highlight">
-                                            <label>思考预算 <span class="help-tip"
-                                                    data-tooltip="思考模型的思考token预算，影响推理深度">?</span></label>
-                                            <input type="number" name="DEFAULT_THINKING_BUDGET" placeholder="16000">
-                                        </div>
-                                        <div class="form-row-inline switch-row">
-                                            <div class="form-group compact switch-group">
-                                                <label>上下文System <span class="help-tip"
-                                                        data-tooltip="开启后，将用户请求的system消息追加到反代提示词后面">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="USE_CONTEXT_SYSTEM_PROMPT"
-                                                        id="useContextSystemPrompt"
-                                                        onchange="handleContextSystemChange()">
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                            <div class="form-group compact switch-group">
-                                                <label>合并提示词 <span class="help-tip"
-                                                        data-tooltip="开启后，将所有系统提示词合并为单个part（需要先开启上下文System）">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="MERGE_SYSTEM_PROMPT"
-                                                        id="mergeSystemPrompt" checked>
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                            <div class="form-group compact switch-group">
-                                                <label>假非流 <span class="help-tip"
-                                                        data-tooltip="非流式请求使用流式获取数据，最终返回非流式格式的JSON（更快）">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="FAKE_NON_STREAM" checked>
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>官方提示词位置 <span class="help-tip"
-                                                        data-tooltip="官方提示词相对于反代提示词的位置">?</span></label>
-                                                <select name="OFFICIAL_PROMPT_POSITION">
-                                                    <option value="before">在反代提示词前面</option>
-                                                    <option value="after">在反代提示词后面</option>
-                                                </select>
-                                            </div>
-                                        </div>
-                                        <div class="form-group compact">
-                                            <label>反代系统提示词 <span class="restore-default"
-                                                    onclick="restoreDefaultSystemInstruction()" title="恢复默认">↻
-                                                    恢复默认</span></label>
-                                            <textarea name="SYSTEM_INSTRUCTION" rows="3"
-                                                placeholder="反代系统提示词（留空则不使用）"></textarea>
-                                        </div>
-                                        <div class="form-group compact">
-                                            <label>
-                                                官方系统提示词 <span class="help-tip" data-tooltip="反重力官方要求的系统提示词">?</span>
-                                                <span class="restore-default"
-                                                    onclick="restoreDefaultOfficialSystemPrompt()" title="恢复默认"
-                                                    id="restoreOfficialBtn" style="display:none;">↻ 恢复默认</span>
-                                            </label>
-                                            <div class="textarea-wrapper">
-                                                <textarea name="OFFICIAL_SYSTEM_PROMPT" id="officialSystemPrompt"
-                                                    rows="5" placeholder="官方系统提示词（留空则不使用）" readonly></textarea>
-                                                <div class="textarea-lock-btn" id="unlockOfficialBtn"
-                                                    onclick="unlockOfficialSystemPrompt()" title="点击解锁修改">🔒</div>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <!-- 轮询策略与性能优化 -->
-                                    <div class="config-section" id="section-rotation">
-                                        <h4>🔄 轮询与性能</h4>
-                                        <div class="form-row-inline switch-row">
-                                            <div class="form-group compact switch-group">
-                                                <label>透传签名 <span class="help-tip"
-                                                        data-tooltip="将响应中的thoughtSignature透传到客户端">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="PASS_SIGNATURE_TO_CLIENT">
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                            <div class="form-group compact switch-group">
-                                                <label>兜底签名 <span class="help-tip"
-                                                        data-tooltip="没有缓存签名时，使用内置默认签名自动补全">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="USE_FALLBACK_SIGNATURE">
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="form-row-inline switch-row">
-                                            <div class="form-group compact switch-group">
-                                                <label>缓存所有签名 <span class="help-tip"
-                                                        data-tooltip="开启后缓存所有签名">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="CACHE_ALL_SIGNATURES">
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                            <div class="form-group compact switch-group">
-                                                <label>工具签名 <span class="help-tip"
-                                                        data-tooltip="使用工具时缓存签名">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="CACHE_TOOL_SIGNATURES" checked>
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                            <div class="form-group compact switch-group">
-                                                <label>图像签名 <span class="help-tip"
-                                                        data-tooltip="使用图像模型时缓存签名">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="CACHE_IMAGE_SIGNATURES" checked>
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                            <div class="form-group compact switch-group">
-                                                <label>缓存思考 <span class="help-tip"
-                                                        data-tooltip="缓存思考内容，随签名一起返回">?</span></label>
-                                                <label class="switch">
-                                                    <input type="checkbox" name="CACHE_THINKING" checked>
-                                                    <span class="slider"></span>
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>策略模式 <span class="help-tip"
-                                                        data-tooltip="均衡负载：每次请求切换Token&#10;额度耗尽：用完额度才切换&#10;自定义次数：指定次数后切换">?</span></label>
-                                                <select name="ROTATION_STRATEGY" id="rotationStrategy"
-                                                    onchange="toggleRequestCountInput()">
-                                                    <option value="round_robin">均衡负载</option>
-                                                    <option value="quota_exhausted">额度耗尽切换</option>
-                                                    <option value="request_count">自定义次数</option>
-                                                </select>
-                                            </div>
-                                            <div class="form-group compact" id="requestCountGroup">
-                                                <label>每Token请求次数 <span class="help-tip"
-                                                        data-tooltip="自定义次数模式下，每个Token处理多少次请求后切换">?</span></label>
-                                                <input type="number" name="ROTATION_REQUEST_COUNT" min="1"
-                                                    placeholder="10">
-                                            </div>
-                                        </div>
-                                        <div class="rotation-status" id="rotationStatus">
-                                            <span class="rotation-label">当前状态:</span>
-                                            <span id="currentRotationInfo">加载中...</span>
-                                        </div>
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>超时(ms)</label>
-                                                <input type="number" name="TIMEOUT" placeholder="300000">
-                                            </div>
-                                            <div class="form-group compact">
-                                                <label>429/503重试次数</label>
-                                                <input type="number" name="RETRY_TIMES" placeholder="0">
-                                            </div>
-                                        </div>
-
-                                        <div class="form-row-inline">
-                                            <div class="form-group compact">
-                                                <label>心跳间隔(ms) <span class="help-tip"
-                                                        data-tooltip="SSE心跳间隔，防止CF超时断连">?</span></label>
-                                                <input type="number" name="HEARTBEAT_INTERVAL" placeholder="15000">
-                                            </div>
-                                            <div class="form-group compact">
-                                                <label>内存清理间隔(ms) <span class="help-tip"
-                                                        data-tooltip="按固定间隔触发缓存/对象池清理">?</span></label>
-                                                <input type="number" name="MEMORY_CLEANUP_INTERVAL"
-                                                    placeholder="1800000">
-                                            </div>
-                                        </div>
-                                        <div class="form-group compact">
-                                            <label>🔤 界面字体大小 (px)</label>
-                                            <div class="font-size-control">
-                                                <input type="range" id="fontSizeRange" min="10" max="24" value="18"
-                                                    oninput="changeFontSize(this.value)">
-                                                <input type="number" id="fontSizeInput" min="10" max="24" value="18"
-                                                    onchange="changeFontSize(this.value)" style="width: 60px;">
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <!-- 安全管理 -->
-                                    <div class="config-section" id="section-security">
-                                        <h4>🛡️ 安全管理</h4>
-                                        <div class="form-group compact switch-group">
-                                            <label>启用封禁 <span class="help-tip"
-                                                    data-tooltip="开启后自动封禁频繁违规的IP地址">?</span></label>
-                                            <label class="switch">
-                                                <input type="checkbox" id="blockingEnabled">
-                                                <span class="slider"></span>
-                                            </label>
-                                        </div>
-                                        <div class="security-info">
-                                            <p>IP封禁机制：自动识别并封禁频繁违规的IP地址</p>
-                                            <ul>
-                                                <li>5分钟内50次违规 → 临时封禁1小时</li>
-                                                <li>累计10次临时封禁 → 永久封禁</li>
-                                                <li>内网IP自动白名单（127.x、10.x、172.16-31.x、192.168.x）</li>
-                                            </ul>
-                                        </div>
-                                        <div class="blocked-ips-header">
-                                            <h5>封禁列表</h5>
-                                            <button type="button" onclick="loadBlockedIPs()" class="btn btn-sm btn-info">🔄 刷新</button>
-                                        </div>
-                                        <div id="blockedIPsList" class="blocked-ips-list">
-                                            <div class="empty-state-small">加载中...</div>
-                                        </div>
-                                        <div class="whitelist-section">
-                                            <h5>白名单管理</h5>
-                                            <div class="whitelist-input-group">
-                                                <input type="text" id="whitelistIPInput" placeholder="输入IP地址" />
-                                                <button type="button" onclick="addWhitelistIP()" class="btn btn-sm btn-success">➕ 添加</button>
-                                            </div>
-                                            <div id="whitelistIPsList" class="whitelist-ips-list"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="config-actions">
-                                    <button type="button" onclick="loadConfig()" class="btn btn-secondary">🔄
-                                        重新加载</button>
-                                    <button type="submit" class="btn btn-success">💾 保存配置</button>
-                                </div>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
+      </div>
     </div>
 
     <!-- 按依赖顺序加载模块 -->
@@ -741,6 +1248,5 @@
     <script src="js/security.js" defer></script>
     <script src="js/logs.js" defer></script>
     <script src="js/main.js" defer></script>
-</body>
-
+  </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260329-1";
+        window.__STATIC_VERSION__ = "20260329-2";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-1";
+        window.__STATIC_VERSION__ = "20260330-2";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-5";
+        window.__STATIC_VERSION__ = "20260330-6";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-7";
+        window.__STATIC_VERSION__ = "20260330-8";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260327-3";
+        window.__STATIC_VERSION__ = "20260327-4";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-4";
+        window.__STATIC_VERSION__ = "20260330-5";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260329-4";
+        window.__STATIC_VERSION__ = "20260330-1";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260327-5";
+        window.__STATIC_VERSION__ = "20260329-1";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260329-3";
+        window.__STATIC_VERSION__ = "20260329-4";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-8";
+        window.__STATIC_VERSION__ = "20260330-9";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260327-2";
+        window.__STATIC_VERSION__ = "20260327-3";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";
@@ -738,14 +738,14 @@
                           >代理池
                           <span
                             class="help-tip"
-                            data-tooltip="支持多行输入，每行格式：主机:端口:用户名:密码。每次请求自动轮询，并持久化轮询进度。"
+                            data-tooltip="支持多行输入，每行格式支持 `IP:port:username:password` 或 `username:password@IP:port`。代理协议由左侧选择。每次请求自动轮询，并持久化轮询进度。"
                             >?</span
                           ></label
                         >
                         <textarea
                           name="PROXY_POOL"
                           rows="4"
-                          placeholder="p.webshare.io:10000:efuztrhi-1:Ld987654321&#10;p.webshare.io:10001:efuztrhi-2:Ld987654321"
+                          placeholder="1.2.3.4:8080:username:password&#10;username:password@1.2.3.5:8081"
                         ></textarea>
                       </div>
                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260329-2";
+        window.__STATIC_VERSION__ = "20260329-3";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260327-1";
+        window.__STATIC_VERSION__ = "20260327-2";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-6";
+        window.__STATIC_VERSION__ = "20260330-7";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";
@@ -458,6 +458,14 @@
                   title="点击显示敏感信息"
                 >
                   🙈 隐藏
+                </button>
+                <button
+                  type="button"
+                  onclick="batchFetchGeminiCliProjectIds()"
+                  class="btn btn-info btn-sm"
+                  title="批量获取所有已启用 Gemini CLI 凭证的 Project ID"
+                >
+                  🔍 批量获取
                 </button>
                 <button
                   type="button"

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <!-- 防止页面闪烁：在渲染前根据Tab状态设置初始显示 -->
     <script>
       (function () {
-        window.__STATIC_VERSION__ = "20260330-3";
+        window.__STATIC_VERSION__ = "20260330-4";
         // 初始状态：auth-checking 表示正在验证登录状态
         // 验证完成后会变成 auth-ready + logged-in 或 auth-ready
         var currentTab = localStorage.getItem("currentTab") || "tokens";

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -277,20 +277,6 @@ async function processOAuthCallbackModal() {
           throw new Error("交换失败: " + result.message);
         }
 
-        const account = result.data;
-        const addResponse = await authFetch("/admin/tokens", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(account),
-        });
-
-        const addResult = await addResponse.json();
-        if (!addResult.success) {
-          throw new Error("添加失败: " + addResult.message);
-        }
-
         successCount += 1;
         if (result.fallbackMode) {
           fallbackCount += 1;

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -3,184 +3,338 @@
 // 不再使用 localStorage 存储 token，改用 HttpOnly Cookie
 let isLoggedIn = false;
 let oauthPort = null;
+let generatedOAuthUrls = [];
 
-const CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
+const CLIENT_ID =
+  "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com";
 const SCOPES = [
-    'https://www.googleapis.com/auth/cloud-platform',
-    'https://www.googleapis.com/auth/userinfo.email',
-    'https://www.googleapis.com/auth/userinfo.profile',
-    'https://www.googleapis.com/auth/cclog',
-    'https://www.googleapis.com/auth/experimentsandconfigs'
-].join(' ');
+  "https://www.googleapis.com/auth/cloud-platform",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "https://www.googleapis.com/auth/cclog",
+  "https://www.googleapis.com/auth/experimentsandconfigs",
+].join(" ");
 
 // 封装fetch，自动处理401，使用 credentials: 'include' 发送 Cookie
 const authFetch = async (url, options = {}) => {
-    const response = await fetch(url, {
-        ...options,
-        credentials: 'include'
-    });
-    if (response.status === 401) {
-        silentLogout();
-        showToast('登录已过期，请重新登录', 'warning');
-        throw new Error('Unauthorized');
-    }
-    return response;
+  const response = await fetch(url, {
+    ...options,
+    credentials: "include",
+  });
+  if (response.status === 401) {
+    silentLogout();
+    showToast("登录已过期，请重新登录", "warning");
+    throw new Error("Unauthorized");
+  }
+  return response;
 };
 
 function showMainContent() {
-    isLoggedIn = true;
-    document.documentElement.classList.add('logged-in');
-    document.getElementById('loginForm').classList.add('hidden');
-    document.getElementById('mainContent').classList.remove('hidden');
+  isLoggedIn = true;
+  document.documentElement.classList.add("logged-in");
+  document.getElementById("loginForm").classList.add("hidden");
+  document.getElementById("mainContent").classList.remove("hidden");
 }
 
 function silentLogout() {
-    isLoggedIn = false;
-    // 清除旧版本的 localStorage token（如果存在）
-    localStorage.removeItem('authToken');
-    document.documentElement.classList.remove('logged-in');
-    document.getElementById('loginForm').classList.remove('hidden');
-    document.getElementById('mainContent').classList.add('hidden');
+  isLoggedIn = false;
+  // 清除旧版本的 localStorage token（如果存在）
+  localStorage.removeItem("authToken");
+  document.documentElement.classList.remove("logged-in");
+  document.getElementById("loginForm").classList.remove("hidden");
+  document.getElementById("mainContent").classList.add("hidden");
 }
 
 async function logout() {
-    const confirmed = await showConfirm('确定要退出登录吗？', '退出确认');
-    if (!confirmed) return;
+  const confirmed = await showConfirm("确定要退出登录吗？", "退出确认");
+  if (!confirmed) return;
 
-    try {
-        // 调用后端登出接口清除 Cookie
-        await fetch('/admin/logout', {
-            method: 'POST',
-            credentials: 'include'
-        });
-    } catch (e) {
-        // 忽略错误
-    }
+  try {
+    // 调用后端登出接口清除 Cookie
+    await fetch("/admin/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+  } catch (e) {
+    // 忽略错误
+  }
 
-    silentLogout();
-    showToast('已退出登录', 'info');
+  silentLogout();
+  showToast("已退出登录", "info");
+}
+
+function generateOAuthPorts(count = 1) {
+  const ports = new Set();
+  while (ports.size < count) {
+    ports.add(Math.floor(Math.random() * 10000) + 50000);
+  }
+  return Array.from(ports);
+}
+
+function getOAuthUrls(count = 1) {
+  const normalizedCount = Math.max(1, Math.min(100, Number(count) || 1));
+  const ports = generateOAuthPorts(normalizedCount);
+
+  if (normalizedCount === 1) {
+    oauthPort = ports[0];
+  }
+
+  return ports.map((port) => {
+    const redirectUri = `http://localhost:${port}/oauth-callback`;
+    return (
+      `https://accounts.google.com/o/oauth2/v2/auth?` +
+      `access_type=offline&client_id=${CLIENT_ID}&prompt=consent&` +
+      `redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&` +
+      `scope=${encodeURIComponent(SCOPES)}&state=${Date.now()}_${port}`
+    );
+  });
 }
 
 function getOAuthUrl() {
-    if (!oauthPort) oauthPort = Math.floor(Math.random() * 10000) + 50000;
-    const redirectUri = `http://localhost:${oauthPort}/oauth-callback`;
-    return `https://accounts.google.com/o/oauth2/v2/auth?` +
-        `access_type=offline&client_id=${CLIENT_ID}&prompt=consent&` +
-        `redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&` +
-        `scope=${encodeURIComponent(SCOPES)}&state=${Date.now()}`;
+  return getOAuthUrls(1)[0];
+}
+
+function getOAuthUrlCount() {
+  const countInput = document.getElementById("oauthUrlCount");
+  return Math.max(1, Math.min(100, Number(countInput?.value) || 1));
+}
+
+function escapeOAuthHtml(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderGeneratedOAuthUrls(urls) {
+  const preview = document.getElementById("oauthGeneratedUrls");
+  if (!preview) return;
+
+  if (!urls.length) {
+    preview.innerHTML = `
+      <div class="oauth-generated-empty">
+        点击“生成授权链接”后，将按条展示在这里，支持单条复制、全部复制和手动框选。
+      </div>
+    `;
+    return;
+  }
+
+  preview.innerHTML = `
+    <div class="oauth-generated-header">
+      <div class="oauth-generated-summary">
+        已生成 ${urls.length} 条授权链接，建议逐条打开或按条复制。
+      </div>
+      <button type="button" class="btn btn-secondary oauth-generated-copy-btn" onclick="copyOAuthUrl()">📋 复制全部</button>
+    </div>
+    <div class="oauth-generated-list">
+      ${urls
+        .map(
+          (url, index) => `
+            <div class="oauth-generated-item">
+              <div class="oauth-generated-item-header">
+                <span>授权链接 ${index + 1}</span>
+                <button type="button" class="btn btn-secondary oauth-generated-copy-btn" onclick="copySingleOAuthUrl(${index})">复制此条</button>
+              </div>
+              <textarea readonly onclick="this.focus();this.select();" rows="2">${escapeOAuthHtml(url)}</textarea>
+            </div>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+}
+
+function copySingleOAuthUrl(index) {
+  const url = generatedOAuthUrls[index];
+  if (!url) {
+    showToast("未找到要复制的授权链接", "error");
+    return;
+  }
+
+  navigator.clipboard
+    .writeText(url)
+    .then(() => {
+      showToast(`已复制第 ${index + 1} 条授权链接`, "success");
+    })
+    .catch(() => {
+      showToast("复制失败", "error");
+    });
+}
+
+function generateOAuthUrlList() {
+  generatedOAuthUrls = getOAuthUrls(getOAuthUrlCount());
+  renderGeneratedOAuthUrls(generatedOAuthUrls);
+  showToast(`已生成 ${generatedOAuthUrls.length} 条授权链接`, "success");
 }
 
 function openOAuthWindow() {
-    window.open(getOAuthUrl(), '_blank');
+  const urls = generatedOAuthUrls.length
+    ? generatedOAuthUrls
+    : getOAuthUrls(getOAuthUrlCount());
+  urls.forEach((url) => window.open(url, "_blank"));
 }
 
 function copyOAuthUrl() {
-    const url = getOAuthUrl();
-    navigator.clipboard.writeText(url).then(() => {
-        showToast('授权链接已复制', 'success');
-    }).catch(() => {
-        showToast('复制失败', 'error');
+  const urls = generatedOAuthUrls.length
+    ? generatedOAuthUrls
+    : getOAuthUrls(getOAuthUrlCount());
+  navigator.clipboard
+    .writeText(urls.join("\n"))
+    .then(() => {
+      showToast(`已复制 ${urls.length} 条授权链接`, "success");
+    })
+    .catch(() => {
+      showToast("复制失败", "error");
     });
 }
 
 function showOAuthModal() {
-    showToast('点击后请在新窗口完成授权', 'info');
-    const modal = document.createElement('div');
-    modal.className = 'modal form-modal';
-    modal.innerHTML = `
+  showToast("点击后请在新窗口完成授权", "info");
+  generatedOAuthUrls = [];
+  const modal = document.createElement("div");
+  modal.className = "modal form-modal oauth-modal";
+  modal.innerHTML = `
         <div class="modal-content">
             <div class="modal-title">🔐 OAuth授权登录</div>
             <div class="oauth-steps">
                 <p><strong>📝 授权流程：</strong></p>
-                <p>1️⃣ 点击下方按钮打开Google授权页面</p>
-                <p>2️⃣ 完成授权后，复制浏览器地址栏的完整URL</p>
-                <p>3️⃣ 粘贴URL到下方输入框并提交</p>
+                <p>1️⃣ 设置要生成的授权链接数量</p>
+                <p>2️⃣ 点击下方按钮打开Google授权页面</p>
+                <p>3️⃣ 每完成一次授权后，复制浏览器地址栏的完整URL</p>
+                <p>4️⃣ 每行粘贴一个回调URL后提交</p>
             </div>
+            <div class="oauth-generator-row">
+                <label for="oauthUrlCount" style="white-space: nowrap;">生成数量</label>
+                <input type="number" id="oauthUrlCount" min="1" max="100" value="1" style="width: 100px;">
+                <button type="button" onclick="generateOAuthUrlList()" class="btn btn-secondary" style="flex: 1;">🔗 生成授权链接</button>
+            </div>
+            <div id="oauthGeneratedUrls" class="oauth-generated-panel"></div>
             <div style="display: flex; gap: 8px; margin-bottom: 12px;">
                 <button type="button" onclick="openOAuthWindow()" class="btn btn-success" style="flex: 1;">🔐 打开授权页面</button>
                 <button type="button" onclick="copyOAuthUrl()" class="btn btn-info" style="flex: 1;">📋 复制授权链接</button>
             </div>
-            <input type="text" id="modalCallbackUrl" placeholder="粘贴完整的回调URL (http://localhost:xxxxx/oauth-callback?code=...)">
+            <textarea id="modalCallbackUrl" rows="6" placeholder="每行粘贴一个完整的回调URL&#10;http://localhost:xxxxx/oauth-callback?code=..."></textarea>
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="this.closest('.modal').remove()">取消</button>
                 <button class="btn btn-success" onclick="processOAuthCallbackModal()">✅ 提交</button>
             </div>
         </div>
     `;
-    document.body.appendChild(modal);
-    modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
+  document.body.appendChild(modal);
+  renderGeneratedOAuthUrls([]);
+  modal.onclick = (e) => {
+    if (e.target === modal) modal.remove();
+  };
 }
 
 async function processOAuthCallbackModal() {
-    const modal = document.querySelector('.form-modal');
-    const callbackUrl = document.getElementById('modalCallbackUrl').value.trim();
-    if (!callbackUrl) {
-        showToast('请输入回调URL', 'warning');
-        return;
-    }
+  const modal = document.querySelector(".form-modal");
+  const callbackInput = document
+    .getElementById("modalCallbackUrl")
+    .value.trim();
+  if (!callbackInput) {
+    showToast("请输入回调URL", "warning");
+    return;
+  }
 
-    showLoading('正在处理授权...');
+  const callbackUrls = callbackInput
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 
-    try {
+  showLoading("正在处理授权...");
+
+  try {
+    let successCount = 0;
+    let fallbackCount = 0;
+    const errors = [];
+
+    for (let index = 0; index < callbackUrls.length; index++) {
+      const callbackUrl = callbackUrls[index];
+
+      try {
         const url = new URL(callbackUrl);
-        const code = url.searchParams.get('code');
-        const port = new URL(url.origin).port || (url.protocol === 'https:' ? 443 : 80);
+        const code = url.searchParams.get("code");
+        const port =
+          new URL(url.origin).port || (url.protocol === "https:" ? 443 : 80);
 
         if (!code) {
-            hideLoading();
-            showToast('URL中未找到授权码', 'error');
-            return;
+          throw new Error("URL中未找到授权码");
         }
 
-        const response = await authFetch('/admin/oauth/exchange', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ code, port })
+        const response = await authFetch("/admin/oauth/exchange", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ code, port }),
         });
 
         const result = await response.json();
-        if (result.success) {
-            const account = result.data;
-            const addResponse = await authFetch('/admin/tokens', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(account)
-            });
-
-            const addResult = await addResponse.json();
-            hideLoading();
-            if (addResult.success) {
-                modal.remove();
-                const message = result.fallbackMode
-                    ? 'Token添加成功（该账号无资格，已自动使用随机ProjectId）'
-                    : 'Token添加成功';
-                showToast(message, result.fallbackMode ? 'warning' : 'success');
-                loadTokens();
-            } else {
-                showToast('添加失败: ' + addResult.message, 'error');
-            }
-        } else {
-            hideLoading();
-            showToast('交换失败: ' + result.message, 'error');
+        if (!result.success) {
+          throw new Error("交换失败: " + result.message);
         }
-    } catch (error) {
-        hideLoading();
-        showToast('处理失败: ' + error.message, 'error');
+
+        const account = result.data;
+        const addResponse = await authFetch("/admin/tokens", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(account),
+        });
+
+        const addResult = await addResponse.json();
+        if (!addResult.success) {
+          throw new Error("添加失败: " + addResult.message);
+        }
+
+        successCount += 1;
+        if (result.fallbackMode) {
+          fallbackCount += 1;
+        }
+      } catch (error) {
+        errors.push(`第${index + 1}行: ${error.message}`);
+      }
     }
+
+    hideLoading();
+
+    if (successCount > 0) {
+      modal.remove();
+      loadTokens();
+      const summary = [`成功添加 ${successCount} 个Token`];
+      if (fallbackCount > 0) {
+        summary.push(
+          `其中 ${fallbackCount} 个账号无资格并已自动使用随机ProjectId`,
+        );
+      }
+      if (errors.length > 0) {
+        summary.push(`失败 ${errors.length} 条`);
+      }
+      showToast(
+        summary.join("，"),
+        errors.length > 0 || fallbackCount > 0 ? "warning" : "success",
+      );
+    } else {
+      showToast(errors.join("；") || "处理失败", "error");
+    }
+  } catch (error) {
+    hideLoading();
+    showToast("处理失败: " + error.message, "error");
+  }
 }
 
 // 检查登录状态（通过尝试访问需要认证的接口）
 async function checkLoginStatus() {
-    try {
-        const response = await fetch('/admin/tokens', {
-            credentials: 'include'
-        });
-        return response.status === 200;
-    } catch (e) {
-        return false;
-    }
+  try {
+    const response = await fetch("/admin/tokens", {
+      credentials: "include",
+    });
+    return response.status === 200;
+  } catch (e) {
+    return false;
+  }
 }

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -281,6 +281,11 @@ async function processOAuthCallbackModal() {
         if (result.fallbackMode) {
           fallbackCount += 1;
         }
+        if (result.disabled) {
+          errors.push(
+            `第${index + 1}行: 已导入但测试消息校验失败，凭证已放入禁用池 - ${result.message || "未知错误"}`,
+          );
+        }
       } catch (error) {
         errors.push(`第${index + 1}行: ${error.message}`);
       }
@@ -291,7 +296,11 @@ async function processOAuthCallbackModal() {
     if (successCount > 0) {
       modal.remove();
       loadTokens();
-      const summary = [`成功添加 ${successCount} 个Token`];
+      const activeCount = Math.max(successCount - errors.length, 0);
+      const summary = [`成功接收 ${successCount} 个Token`];
+      if (activeCount > 0) {
+        summary.push(`其中 ${activeCount} 个通过测试并已启用`);
+      }
       if (fallbackCount > 0) {
         summary.push(
           `其中 ${fallbackCount} 个账号无资格并已自动使用随机ProjectId`,

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,7 +1,8 @@
 // 配置管理：加载、保存
 
 // 默认系统提示词
-const DEFAULT_SYSTEM_INSTRUCTION = '你是聊天机器人，名字叫萌萌，如同名字这般，你的性格是软软糯糯萌萌哒的，专门为用户提供聊天和情绪价值，协助进行小说创作或者角色扮演';
+const DEFAULT_SYSTEM_INSTRUCTION =
+  "你是聊天机器人，名字叫萌萌，如同名字这般，你的性格是软软糯糯萌萌哒的，专门为用户提供聊天和情绪价值，协助进行小说创作或者角色扮演";
 const DEFAULT_OFFICIAL_SYSTEM_PROMPT = `<example_only do_not_follow="true" type="counter-example" ignore="true">
 You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Proactiveness**
 </example_only>
@@ -9,20 +10,24 @@ You are Antigravity, a powerful agentic AI coding assistant designed by the Goog
 
 // 恢复默认反代系统提示词
 function restoreDefaultSystemInstruction() {
-    const textarea = document.querySelector('textarea[name="SYSTEM_INSTRUCTION"]');
-    if (textarea) {
-        textarea.value = DEFAULT_SYSTEM_INSTRUCTION;
-        showToast('已恢复默认反代系统提示词', 'success');
-    }
+  const textarea = document.querySelector(
+    'textarea[name="SYSTEM_INSTRUCTION"]',
+  );
+  if (textarea) {
+    textarea.value = DEFAULT_SYSTEM_INSTRUCTION;
+    showToast("已恢复默认反代系统提示词", "success");
+  }
 }
 
 // 恢复默认官方系统提示词
 function restoreDefaultOfficialSystemPrompt() {
-    const textarea = document.querySelector('textarea[name="OFFICIAL_SYSTEM_PROMPT"]');
-    if (textarea) {
-        textarea.value = DEFAULT_OFFICIAL_SYSTEM_PROMPT;
-        showToast('已恢复默认官方系统提示词', 'success');
-    }
+  const textarea = document.querySelector(
+    'textarea[name="OFFICIAL_SYSTEM_PROMPT"]',
+  );
+  if (textarea) {
+    textarea.value = DEFAULT_OFFICIAL_SYSTEM_PROMPT;
+    showToast("已恢复默认官方系统提示词", "success");
+  }
 }
 
 // 暂存解锁密码
@@ -30,397 +35,556 @@ let unlockedPassword = null;
 // 暂存加载时的官方系统提示词原始值（用于比较是否真正修改）
 let originalOfficialSystemPrompt = null;
 
+function normalizeProxyProtocol(protocol) {
+  const normalized = String(protocol || "http")
+    .trim()
+    .toLowerCase();
+  if (
+    normalized === "socket5" ||
+    normalized === "socks" ||
+    normalized === "socks5"
+  ) {
+    return "socks5";
+  }
+  if (normalized === "https") {
+    return "https";
+  }
+  return "http";
+}
+
+function inferProxyProtocolFromValue(proxyValue) {
+  const value = String(proxyValue || "")
+    .trim()
+    .toLowerCase();
+  if (!value) return "http";
+  if (value.startsWith("socks5://") || value.startsWith("socks://"))
+    return "socks5";
+  if (value.startsWith("https://")) return "https";
+  return "http";
+}
+
 // 正规化换行符（用于比较）
 function normalizeNewlines(str) {
-    return (str || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+  return (str || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
 }
 
 // 解锁官方系统提示词修改
 async function unlockOfficialSystemPrompt() {
-    const warningMsg = '<span style="color:#ef4444;font-weight:bold;font-size:1rem;">⚠️ 警告！修改官方系统提示词可能会导致 429 错误！<br>是否确认更改？</span>';
-    const password = await showPasswordPrompt(warningMsg);
+  const warningMsg =
+    '<span style="color:#ef4444;font-weight:bold;font-size:1rem;">⚠️ 警告！修改官方系统提示词可能会导致 429 错误！<br>是否确认更改？</span>';
+  const password = await showPasswordPrompt(warningMsg);
 
-    if (password) {
-        // 暂存密码
-        unlockedPassword = password;
+  if (password) {
+    // 暂存密码
+    unlockedPassword = password;
 
-        // 解锁界面
-        const textarea = document.getElementById('officialSystemPrompt');
-        const unlockBtn = document.getElementById('unlockOfficialBtn');
-        const restoreBtn = document.getElementById('restoreOfficialBtn');
+    // 解锁界面
+    const textarea = document.getElementById("officialSystemPrompt");
+    const unlockBtn = document.getElementById("unlockOfficialBtn");
+    const restoreBtn = document.getElementById("restoreOfficialBtn");
 
-        if (textarea) {
-            textarea.readOnly = false;
-            textarea.classList.add('unlocked');
-        }
-        // CSS handles lock button visibility based on readonly state
-        if (restoreBtn) restoreBtn.style.display = 'inline-flex';
-
-        showToast('已解锁，请谨慎修改', 'warning');
+    if (textarea) {
+      textarea.readOnly = false;
+      textarea.classList.add("unlocked");
     }
+    // CSS handles lock button visibility based on readonly state
+    if (restoreBtn) restoreBtn.style.display = "inline-flex";
+
+    showToast("已解锁，请谨慎修改", "warning");
+  }
 }
 
 // 处理上下文System开关变化
 function handleContextSystemChange() {
-    const useContextSystem = document.getElementById('useContextSystemPrompt');
-    const mergeSystemPrompt = document.getElementById('mergeSystemPrompt');
+  const useContextSystem = document.getElementById("useContextSystemPrompt");
+  const mergeSystemPrompt = document.getElementById("mergeSystemPrompt");
 
-    if (useContextSystem && mergeSystemPrompt) {
-        if (useContextSystem.checked) {
-            // 开启上下文System时，合并提示词可以自由选择
-            mergeSystemPrompt.disabled = false;
-        } else {
-            // 关闭上下文System时，合并提示词自动关闭且禁用
-            mergeSystemPrompt.checked = false;
-            mergeSystemPrompt.disabled = true;
-        }
+  if (useContextSystem && mergeSystemPrompt) {
+    if (useContextSystem.checked) {
+      // 开启上下文System时，合并提示词可以自由选择
+      mergeSystemPrompt.disabled = false;
+    } else {
+      // 关闭上下文System时，合并提示词自动关闭且禁用
+      mergeSystemPrompt.checked = false;
+      mergeSystemPrompt.disabled = true;
     }
+  }
 }
 
 function toggleRequestCountInput() {
-    const strategy = document.getElementById('rotationStrategy').value;
-    const requestCountGroup = document.getElementById('requestCountGroup');
-    if (requestCountGroup) {
-        requestCountGroup.style.display = strategy === 'request_count' ? 'block' : 'none';
-    }
+  const strategy = document.getElementById("rotationStrategy").value;
+  const requestCountGroup = document.getElementById("requestCountGroup");
+  if (requestCountGroup) {
+    requestCountGroup.style.display =
+      strategy === "request_count" ? "block" : "none";
+  }
 }
 
 async function loadRotationStatus() {
-    try {
-        const response = await authFetch('/admin/rotation');
-        const data = await response.json();
-        if (data.success) {
-            const { strategy, requestCount, currentIndex } = data.data;
-            const strategyNames = {
-                'round_robin': '均衡负载',
-                'quota_exhausted': '额度耗尽切换',
-                'request_count': '自定义次数'
-            };
-            const statusEl = document.getElementById('currentRotationInfo');
-            if (statusEl) {
-                let statusText = `${strategyNames[strategy] || strategy}`;
-                if (strategy === 'request_count') {
-                    statusText += ` (每${requestCount}次)`;
-                }
-                statusText += ` | 当前索引: ${currentIndex}`;
-                statusEl.textContent = statusText;
-            }
+  try {
+    const response = await authFetch("/admin/rotation");
+    const data = await response.json();
+    if (data.success) {
+      const { strategy, requestCount, currentIndex } = data.data;
+      const strategyNames = {
+        round_robin: "均衡负载",
+        quota_exhausted: "额度耗尽切换",
+        request_count: "自定义次数",
+      };
+      const statusEl = document.getElementById("currentRotationInfo");
+      if (statusEl) {
+        let statusText = `${strategyNames[strategy] || strategy}`;
+        if (strategy === "request_count") {
+          statusText += ` (每${requestCount}次)`;
         }
-    } catch (error) {
-        console.error('加载轮询状态失败:', error);
+        statusText += ` | 当前索引: ${currentIndex}`;
+        statusEl.textContent = statusText;
+      }
     }
+  } catch (error) {
+    console.error("加载轮询状态失败:", error);
+  }
 }
 
 async function loadConfig() {
-    try {
-        const response = await authFetch('/admin/config');
-        const data = await response.json();
-        if (data.success) {
-            const form = document.getElementById('configForm');
-            const { env, json } = data.data;
+  try {
+    const response = await authFetch("/admin/config");
+    const data = await response.json();
+    if (data.success) {
+      const form = document.getElementById("configForm");
+      const { env, json } = data.data;
 
-            Object.entries(env).forEach(([key, value]) => {
-                const input = form.elements[key];
-                if (input) input.value = value || '';
-            });
+      Object.entries(env).forEach(([key, value]) => {
+        const input = form.elements[key];
+        if (input) input.value = value || "";
+      });
 
-            if (json.server) {
-                if (form.elements['PORT']) form.elements['PORT'].value = json.server.port || '';
-                if (form.elements['HOST']) form.elements['HOST'].value = json.server.host || '';
-                if (form.elements['MAX_REQUEST_SIZE']) form.elements['MAX_REQUEST_SIZE'].value = json.server.maxRequestSize || '';
-                if (form.elements['HEARTBEAT_INTERVAL']) form.elements['HEARTBEAT_INTERVAL'].value = json.server.heartbeatInterval || '';
-                if (form.elements['MEMORY_CLEANUP_INTERVAL']) form.elements['MEMORY_CLEANUP_INTERVAL'].value = json.server.memoryCleanupInterval || '';
-            }
-            if (json.api) {
-                if (form.elements['API_USE']) form.elements['API_USE'].value = json.api.use || 'sandbox';
-            }
-            if (json.defaults) {
-                if (form.elements['DEFAULT_TEMPERATURE']) form.elements['DEFAULT_TEMPERATURE'].value = json.defaults.temperature ?? '';
-                if (form.elements['DEFAULT_TOP_P']) form.elements['DEFAULT_TOP_P'].value = json.defaults.topP ?? '';
-                if (form.elements['DEFAULT_TOP_K']) form.elements['DEFAULT_TOP_K'].value = json.defaults.topK ?? '';
-                if (form.elements['DEFAULT_MAX_TOKENS']) form.elements['DEFAULT_MAX_TOKENS'].value = json.defaults.maxTokens ?? '';
-                if (form.elements['DEFAULT_THINKING_BUDGET']) form.elements['DEFAULT_THINKING_BUDGET'].value = json.defaults.thinkingBudget ?? '';
-            }
-            if (json.other) {
-                if (form.elements['TIMEOUT']) form.elements['TIMEOUT'].value = json.other.timeout ?? '';
-                if (form.elements['RETRY_TIMES']) form.elements['RETRY_TIMES'].value = json.other.retryTimes ?? '';
-                if (form.elements['SKIP_PROJECT_ID_FETCH']) form.elements['SKIP_PROJECT_ID_FETCH'].checked = json.other.skipProjectIdFetch || false;
-                if (form.elements['USE_NATIVE_AXIOS']) form.elements['USE_NATIVE_AXIOS'].checked = json.other.useNativeAxios !== false;
-                if (form.elements['USE_CONTEXT_SYSTEM_PROMPT']) form.elements['USE_CONTEXT_SYSTEM_PROMPT'].checked = json.other.useContextSystemPrompt || false;
-                if (form.elements['MERGE_SYSTEM_PROMPT']) form.elements['MERGE_SYSTEM_PROMPT'].checked = json.other.mergeSystemPrompt !== false;
-                if (form.elements['OFFICIAL_PROMPT_POSITION']) form.elements['OFFICIAL_PROMPT_POSITION'].value = json.other.officialPromptPosition || 'before';
-                if (form.elements['PASS_SIGNATURE_TO_CLIENT']) form.elements['PASS_SIGNATURE_TO_CLIENT'].checked = json.other.passSignatureToClient || false;
-                if (form.elements['USE_FALLBACK_SIGNATURE']) form.elements['USE_FALLBACK_SIGNATURE'].checked = json.other.useFallbackSignature || false;
-                if (form.elements['CACHE_ALL_SIGNATURES']) form.elements['CACHE_ALL_SIGNATURES'].checked = json.other.cacheAllSignatures || false;
-                if (form.elements['CACHE_TOOL_SIGNATURES']) form.elements['CACHE_TOOL_SIGNATURES'].checked = json.other.cacheToolSignatures !== false;
-                if (form.elements['CACHE_IMAGE_SIGNATURES']) form.elements['CACHE_IMAGE_SIGNATURES'].checked = json.other.cacheImageSignatures !== false;
-                if (form.elements['CACHE_THINKING']) form.elements['CACHE_THINKING'].checked = json.other.cacheThinking !== false;
-                if (form.elements['FAKE_NON_STREAM']) form.elements['FAKE_NON_STREAM'].checked = json.other.fakeNonStream !== false;
-            }
+      if (json.server) {
+        if (form.elements["PORT"])
+          form.elements["PORT"].value = json.server.port || "";
+        if (form.elements["HOST"])
+          form.elements["HOST"].value = json.server.host || "";
+        if (form.elements["MAX_REQUEST_SIZE"])
+          form.elements["MAX_REQUEST_SIZE"].value =
+            json.server.maxRequestSize || "";
+        if (form.elements["HEARTBEAT_INTERVAL"])
+          form.elements["HEARTBEAT_INTERVAL"].value =
+            json.server.heartbeatInterval || "";
+        if (form.elements["MEMORY_CLEANUP_INTERVAL"])
+          form.elements["MEMORY_CLEANUP_INTERVAL"].value =
+            json.server.memoryCleanupInterval || "";
+      }
+      if (json.api) {
+        if (form.elements["API_USE"])
+          form.elements["API_USE"].value = json.api.use || "sandbox";
+      }
+      if (json.defaults) {
+        if (form.elements["DEFAULT_TEMPERATURE"])
+          form.elements["DEFAULT_TEMPERATURE"].value =
+            json.defaults.temperature ?? "";
+        if (form.elements["DEFAULT_TOP_P"])
+          form.elements["DEFAULT_TOP_P"].value = json.defaults.topP ?? "";
+        if (form.elements["DEFAULT_TOP_K"])
+          form.elements["DEFAULT_TOP_K"].value = json.defaults.topK ?? "";
+        if (form.elements["DEFAULT_MAX_TOKENS"])
+          form.elements["DEFAULT_MAX_TOKENS"].value =
+            json.defaults.maxTokens ?? "";
+        if (form.elements["DEFAULT_THINKING_BUDGET"])
+          form.elements["DEFAULT_THINKING_BUDGET"].value =
+            json.defaults.thinkingBudget ?? "";
+      }
+      if (json.other) {
+        if (form.elements["TIMEOUT"])
+          form.elements["TIMEOUT"].value = json.other.timeout ?? "";
+        if (form.elements["RETRY_TIMES"])
+          form.elements["RETRY_TIMES"].value = json.other.retryTimes ?? "";
+        if (form.elements["PROXY_PROTOCOL"])
+          form.elements["PROXY_PROTOCOL"].value = normalizeProxyProtocol(
+            json.other.proxyProtocol || "http",
+          );
+        if (form.elements["PROXY_POOL"])
+          form.elements["PROXY_POOL"].value = json.other.proxyPool ?? "";
+        if (form.elements["SKIP_PROJECT_ID_FETCH"])
+          form.elements["SKIP_PROJECT_ID_FETCH"].checked =
+            json.other.skipProjectIdFetch || false;
+        if (form.elements["USE_NATIVE_AXIOS"])
+          form.elements["USE_NATIVE_AXIOS"].checked =
+            json.other.useNativeAxios !== false;
+        if (form.elements["USE_CONTEXT_SYSTEM_PROMPT"])
+          form.elements["USE_CONTEXT_SYSTEM_PROMPT"].checked =
+            json.other.useContextSystemPrompt || false;
+        if (form.elements["MERGE_SYSTEM_PROMPT"])
+          form.elements["MERGE_SYSTEM_PROMPT"].checked =
+            json.other.mergeSystemPrompt !== false;
+        if (form.elements["OFFICIAL_PROMPT_POSITION"])
+          form.elements["OFFICIAL_PROMPT_POSITION"].value =
+            json.other.officialPromptPosition || "before";
+        if (form.elements["PASS_SIGNATURE_TO_CLIENT"])
+          form.elements["PASS_SIGNATURE_TO_CLIENT"].checked =
+            json.other.passSignatureToClient || false;
+        if (form.elements["USE_FALLBACK_SIGNATURE"])
+          form.elements["USE_FALLBACK_SIGNATURE"].checked =
+            json.other.useFallbackSignature || false;
+        if (form.elements["CACHE_ALL_SIGNATURES"])
+          form.elements["CACHE_ALL_SIGNATURES"].checked =
+            json.other.cacheAllSignatures || false;
+        if (form.elements["CACHE_TOOL_SIGNATURES"])
+          form.elements["CACHE_TOOL_SIGNATURES"].checked =
+            json.other.cacheToolSignatures !== false;
+        if (form.elements["CACHE_IMAGE_SIGNATURES"])
+          form.elements["CACHE_IMAGE_SIGNATURES"].checked =
+            json.other.cacheImageSignatures !== false;
+        if (form.elements["CACHE_THINKING"])
+          form.elements["CACHE_THINKING"].checked =
+            json.other.cacheThinking !== false;
+        if (form.elements["FAKE_NON_STREAM"])
+          form.elements["FAKE_NON_STREAM"].checked =
+            json.other.fakeNonStream !== false;
+      }
 
-            // 加载官方系统提示词
-            if (form.elements['OFFICIAL_SYSTEM_PROMPT']) {
-                if (env.OFFICIAL_SYSTEM_PROMPT !== undefined) {
-                    form.elements['OFFICIAL_SYSTEM_PROMPT'].value = env.OFFICIAL_SYSTEM_PROMPT;
-                    originalOfficialSystemPrompt = env.OFFICIAL_SYSTEM_PROMPT;
-                } else {
-                    form.elements['OFFICIAL_SYSTEM_PROMPT'].value = DEFAULT_OFFICIAL_SYSTEM_PROMPT;
-                    originalOfficialSystemPrompt = DEFAULT_OFFICIAL_SYSTEM_PROMPT;
-                }
-            }
-
-            // 更新合并提示词开关状态
-            handleContextSystemChange();
-            if (json.rotation) {
-                if (form.elements['ROTATION_STRATEGY']) {
-                    form.elements['ROTATION_STRATEGY'].value = json.rotation.strategy || 'round_robin';
-                }
-                if (form.elements['ROTATION_REQUEST_COUNT']) {
-                    form.elements['ROTATION_REQUEST_COUNT'].value = json.rotation.requestCount || 10;
-                }
-                toggleRequestCountInput();
-            }
-
-            loadRotationStatus();
-            // 默认只显示当前激活的设置分区（便于后续扩展）
-            if (typeof setActiveSettingSection === 'function') {
-                setActiveSettingSection(activeSettingSectionId, false);
-            }
-            
-            // 加载IP封禁列表
-            if (typeof loadBlockedIPs === 'function') {
-                loadBlockedIPs();
-            }
-            // 加载白名单
-            if (typeof loadWhitelistIPs === 'function') {
-                loadWhitelistIPs();
-            }
+      if (
+        (!json.other?.proxyPool || !String(json.other.proxyPool).trim()) &&
+        env.PROXY &&
+        form.elements["PROXY_POOL"]
+      ) {
+        form.elements["PROXY_POOL"].value = env.PROXY;
+        if (form.elements["PROXY_PROTOCOL"]) {
+          form.elements["PROXY_PROTOCOL"].value = inferProxyProtocolFromValue(
+            env.PROXY,
+          );
         }
-    } catch (error) {
-        showToast('加载配置失败: ' + error.message, 'error');
+      }
+
+      // 加载官方系统提示词
+      if (form.elements["OFFICIAL_SYSTEM_PROMPT"]) {
+        if (env.OFFICIAL_SYSTEM_PROMPT !== undefined) {
+          form.elements["OFFICIAL_SYSTEM_PROMPT"].value =
+            env.OFFICIAL_SYSTEM_PROMPT;
+          originalOfficialSystemPrompt = env.OFFICIAL_SYSTEM_PROMPT;
+        } else {
+          form.elements["OFFICIAL_SYSTEM_PROMPT"].value =
+            DEFAULT_OFFICIAL_SYSTEM_PROMPT;
+          originalOfficialSystemPrompt = DEFAULT_OFFICIAL_SYSTEM_PROMPT;
+        }
+      }
+
+      // 更新合并提示词开关状态
+      handleContextSystemChange();
+      if (json.rotation) {
+        if (form.elements["ROTATION_STRATEGY"]) {
+          form.elements["ROTATION_STRATEGY"].value =
+            json.rotation.strategy || "round_robin";
+        }
+        if (form.elements["ROTATION_REQUEST_COUNT"]) {
+          form.elements["ROTATION_REQUEST_COUNT"].value =
+            json.rotation.requestCount || 10;
+        }
+        toggleRequestCountInput();
+      }
+
+      loadRotationStatus();
+      // 默认只显示当前激活的设置分区（便于后续扩展）
+      if (typeof setActiveSettingSection === "function") {
+        setActiveSettingSection(activeSettingSectionId, false);
+      }
+
+      // 加载IP封禁列表
+      if (typeof loadBlockedIPs === "function") {
+        loadBlockedIPs();
+      }
+      // 加载白名单
+      if (typeof loadWhitelistIPs === "function") {
+        loadWhitelistIPs();
+      }
     }
+  } catch (error) {
+    showToast("加载配置失败: " + error.message, "error");
+  }
 }
 
-let activeSettingSectionId = localStorage.getItem('activeSettingSectionId') || 'section-server';
+let activeSettingSectionId =
+  localStorage.getItem("activeSettingSectionId") || "section-server";
 
 function setActiveSettingSection(id, scroll = true) {
-    const nextId = id || 'section-server';
-    activeSettingSectionId = nextId;
-    localStorage.setItem('activeSettingSectionId', activeSettingSectionId);
+  const nextId = id || "section-server";
+  activeSettingSectionId = nextId;
+  localStorage.setItem("activeSettingSectionId", activeSettingSectionId);
 
-    // 清理搜索状态，避免“只显示一个分区”和“搜索过滤”互相干扰
-    const searchInput = document.getElementById('settingsSearch');
-    if (searchInput && searchInput.value) {
-        searchInput.value = '';
+  // 清理搜索状态，避免“只显示一个分区”和“搜索过滤”互相干扰
+  const searchInput = document.getElementById("settingsSearch");
+  if (searchInput && searchInput.value) {
+    searchInput.value = "";
+  }
+
+  const sections = document.querySelectorAll("#settingsPage .config-section");
+  sections.forEach((section) => {
+    section.style.display = section.id === activeSettingSectionId ? "" : "none";
+  });
+
+  document.querySelectorAll(".settings-nav-item").forEach((btn) => {
+    btn.classList.toggle(
+      "active",
+      btn.dataset.target === activeSettingSectionId,
+    );
+  });
+
+  const select = document.getElementById("settingsSectionSelect");
+  if (select) select.value = activeSettingSectionId;
+
+  if (scroll) {
+    const el = document.getElementById(activeSettingSectionId);
+    const container = document.getElementById("settingsPage");
+    if (el && container) {
+      // 计算元素相对于容器的位置
+      const elTop = el.offsetTop;
+      // 滚动容器而不是整个页面
+      container.scrollTo({ top: elTop - 10, behavior: "smooth" });
     }
-
-    const sections = document.querySelectorAll('#settingsPage .config-section');
-    sections.forEach(section => {
-        section.style.display = section.id === activeSettingSectionId ? '' : 'none';
-    });
-
-    document.querySelectorAll('.settings-nav-item').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.target === activeSettingSectionId);
-    });
-
-    const select = document.getElementById('settingsSectionSelect');
-    if (select) select.value = activeSettingSectionId;
-
-    if (scroll) {
-        const el = document.getElementById(activeSettingSectionId);
-        const container = document.getElementById('settingsPage');
-        if (el && container) {
-            // 计算元素相对于容器的位置
-            const elTop = el.offsetTop;
-            // 滚动容器而不是整个页面
-            container.scrollTo({ top: elTop - 10, behavior: 'smooth' });
-        }
-    }
+  }
 }
 
 function filterSettings(query) {
-    const q = (query || '').trim().toLowerCase();
-    const sections = document.querySelectorAll('#settingsPage .config-section');
-    if (!q) {
-        setActiveSettingSection(activeSettingSectionId, false);
-        return;
-    }
-    sections.forEach(section => {
-        const text = (section.innerText || '').toLowerCase();
-        section.style.display = text.includes(q) ? '' : 'none';
-    });
+  const q = (query || "").trim().toLowerCase();
+  const sections = document.querySelectorAll("#settingsPage .config-section");
+  if (!q) {
+    setActiveSettingSection(activeSettingSectionId, false);
+    return;
+  }
+  sections.forEach((section) => {
+    const text = (section.innerText || "").toLowerCase();
+    section.style.display = text.includes(q) ? "" : "none";
+  });
 }
 
 // 重新锁定官方系统提示词
 function lockOfficialSystemPrompt() {
-    const textarea = document.getElementById('officialSystemPrompt');
-    const restoreBtn = document.getElementById('restoreOfficialBtn');
+  const textarea = document.getElementById("officialSystemPrompt");
+  const restoreBtn = document.getElementById("restoreOfficialBtn");
 
-    if (textarea) {
-        textarea.readOnly = true;
-        textarea.classList.remove('unlocked');
-        // 清除可能残留的内联样式
-        textarea.style.borderColor = '';
-        textarea.style.backgroundColor = '';
-    }
+  if (textarea) {
+    textarea.readOnly = true;
+    textarea.classList.remove("unlocked");
+    // 清除可能残留的内联样式
+    textarea.style.borderColor = "";
+    textarea.style.backgroundColor = "";
+  }
 
-    if (restoreBtn) {
-        restoreBtn.style.display = 'none';
-    }
+  if (restoreBtn) {
+    restoreBtn.style.display = "none";
+  }
 
-    // 清除暂存密码
-    unlockedPassword = null;
+  // 清除暂存密码
+  unlockedPassword = null;
 }
 
 async function saveConfig(e) {
-    e.preventDefault();
-    const form = e.target;
-    const formData = new FormData(form);
-    const allConfig = Object.fromEntries(formData);
+  e.preventDefault();
+  const form = e.target;
+  const formData = new FormData(form);
+  const allConfig = Object.fromEntries(formData);
 
-    const sensitiveKeys = ['API_KEY', 'ADMIN_USERNAME', 'ADMIN_PASSWORD', 'JWT_SECRET', 'PROXY', 'SYSTEM_INSTRUCTION', 'OFFICIAL_SYSTEM_PROMPT', 'IMAGE_BASE_URL'];
-    const envConfig = {};
-    const jsonConfig = {
-        server: {},
-        api: {},
-        defaults: {},
-        other: {},
-        rotation: {}
-    };
+  const sensitiveKeys = [
+    "API_KEY",
+    "ADMIN_USERNAME",
+    "ADMIN_PASSWORD",
+    "JWT_SECRET",
+    "PROXY",
+    "SYSTEM_INSTRUCTION",
+    "OFFICIAL_SYSTEM_PROMPT",
+    "IMAGE_BASE_URL",
+  ];
+  const envConfig = {};
+  const jsonConfig = {
+    server: {},
+    api: {},
+    defaults: {},
+    other: {},
+    rotation: {},
+  };
 
-    // 处理checkbox：未选中的checkbox不会出现在FormData中
-    jsonConfig.other.skipProjectIdFetch = form.elements['SKIP_PROJECT_ID_FETCH']?.checked || false;
-    jsonConfig.other.useNativeAxios = form.elements['USE_NATIVE_AXIOS']?.checked || false;
-    jsonConfig.api = { use: form.elements['API_USE']?.value || 'sandbox' };
-    jsonConfig.other.useContextSystemPrompt = form.elements['USE_CONTEXT_SYSTEM_PROMPT']?.checked || false;
-    jsonConfig.other.mergeSystemPrompt = form.elements['MERGE_SYSTEM_PROMPT']?.checked ?? true;
-    jsonConfig.other.officialPromptPosition = form.elements['OFFICIAL_PROMPT_POSITION']?.value || 'before';
-    jsonConfig.other.passSignatureToClient = form.elements['PASS_SIGNATURE_TO_CLIENT']?.checked || false;
-    jsonConfig.other.useFallbackSignature = form.elements['USE_FALLBACK_SIGNATURE']?.checked || false;
-    jsonConfig.other.cacheAllSignatures = form.elements['CACHE_ALL_SIGNATURES']?.checked || false;
-    jsonConfig.other.cacheToolSignatures = form.elements['CACHE_TOOL_SIGNATURES']?.checked ?? true;
-    jsonConfig.other.cacheImageSignatures = form.elements['CACHE_IMAGE_SIGNATURES']?.checked ?? true;
-    jsonConfig.other.cacheThinking = form.elements['CACHE_THINKING']?.checked ?? true;
-    jsonConfig.other.fakeNonStream = form.elements['FAKE_NON_STREAM']?.checked ?? true;
+  // 处理checkbox：未选中的checkbox不会出现在FormData中
+  jsonConfig.other.skipProjectIdFetch =
+    form.elements["SKIP_PROJECT_ID_FETCH"]?.checked || false;
+  jsonConfig.other.useNativeAxios =
+    form.elements["USE_NATIVE_AXIOS"]?.checked || false;
+  jsonConfig.api = { use: form.elements["API_USE"]?.value || "sandbox" };
+  jsonConfig.other.proxyProtocol = normalizeProxyProtocol(
+    form.elements["PROXY_PROTOCOL"]?.value || "http",
+  );
+  jsonConfig.other.proxyPool = (form.elements["PROXY_POOL"]?.value || "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  jsonConfig.other.useContextSystemPrompt =
+    form.elements["USE_CONTEXT_SYSTEM_PROMPT"]?.checked || false;
+  jsonConfig.other.mergeSystemPrompt =
+    form.elements["MERGE_SYSTEM_PROMPT"]?.checked ?? true;
+  jsonConfig.other.officialPromptPosition =
+    form.elements["OFFICIAL_PROMPT_POSITION"]?.value || "before";
+  jsonConfig.other.passSignatureToClient =
+    form.elements["PASS_SIGNATURE_TO_CLIENT"]?.checked || false;
+  jsonConfig.other.useFallbackSignature =
+    form.elements["USE_FALLBACK_SIGNATURE"]?.checked || false;
+  jsonConfig.other.cacheAllSignatures =
+    form.elements["CACHE_ALL_SIGNATURES"]?.checked || false;
+  jsonConfig.other.cacheToolSignatures =
+    form.elements["CACHE_TOOL_SIGNATURES"]?.checked ?? true;
+  jsonConfig.other.cacheImageSignatures =
+    form.elements["CACHE_IMAGE_SIGNATURES"]?.checked ?? true;
+  jsonConfig.other.cacheThinking =
+    form.elements["CACHE_THINKING"]?.checked ?? true;
+  jsonConfig.other.fakeNonStream =
+    form.elements["FAKE_NON_STREAM"]?.checked ?? true;
 
-    Object.entries(allConfig).forEach(([key, value]) => {
-        if (sensitiveKeys.includes(key)) {
-            envConfig[key] = value;
-        } else {
-            if (key === 'PORT') jsonConfig.server.port = parseInt(value) || undefined;
-            else if (key === 'HOST') jsonConfig.server.host = value || undefined;
-            else if (key === 'MAX_REQUEST_SIZE') jsonConfig.server.maxRequestSize = value || undefined;
-            else if (key === 'HEARTBEAT_INTERVAL') jsonConfig.server.heartbeatInterval = parseInt(value) || undefined;
-            else if (key === 'MEMORY_CLEANUP_INTERVAL') jsonConfig.server.memoryCleanupInterval = parseInt(value) || undefined;
-            else if (key === 'DEFAULT_TEMPERATURE') jsonConfig.defaults.temperature = parseFloat(value) || undefined;
-            else if (key === 'DEFAULT_TOP_P') jsonConfig.defaults.topP = parseFloat(value) || undefined;
-            else if (key === 'DEFAULT_TOP_K') jsonConfig.defaults.topK = parseInt(value) || undefined;
-            else if (key === 'DEFAULT_MAX_TOKENS') jsonConfig.defaults.maxTokens = parseInt(value) || undefined;
-            else if (key === 'DEFAULT_THINKING_BUDGET') {
-                const num = parseInt(value);
-                jsonConfig.defaults.thinkingBudget = Number.isNaN(num) ? undefined : num;
-            }
-            else if (key === 'TIMEOUT') jsonConfig.other.timeout = parseInt(value) || undefined;
-            else if (key === 'RETRY_TIMES') {
-                const num = parseInt(value);
-                jsonConfig.other.retryTimes = Number.isNaN(num) ? undefined : num;
-            }
-            else if (key === 'SKIP_PROJECT_ID_FETCH' || key === 'USE_NATIVE_AXIOS' || key === 'USE_CONTEXT_SYSTEM_PROMPT' || key === 'MERGE_SYSTEM_PROMPT' || key === 'OFFICIAL_PROMPT_POSITION' || key === 'PASS_SIGNATURE_TO_CLIENT' || key === 'USE_FALLBACK_SIGNATURE' || key === 'CACHE_ALL_SIGNATURES' || key === 'CACHE_TOOL_SIGNATURES' || key === 'CACHE_IMAGE_SIGNATURES' || key === 'CACHE_THINKING' || key === 'FAKE_NON_STREAM') {
-                // 跳过，已在上面处理
-            }
-            else if (key === 'ROTATION_STRATEGY') jsonConfig.rotation.strategy = value || undefined;
-            else if (key === 'ROTATION_REQUEST_COUNT') jsonConfig.rotation.requestCount = parseInt(value) || undefined;
-            else envConfig[key] = value;
-        }
+  Object.entries(allConfig).forEach(([key, value]) => {
+    if (sensitiveKeys.includes(key)) {
+      envConfig[key] = value;
+    } else {
+      if (key === "PORT") jsonConfig.server.port = parseInt(value) || undefined;
+      else if (key === "HOST") jsonConfig.server.host = value || undefined;
+      else if (key === "MAX_REQUEST_SIZE")
+        jsonConfig.server.maxRequestSize = value || undefined;
+      else if (key === "HEARTBEAT_INTERVAL")
+        jsonConfig.server.heartbeatInterval = parseInt(value) || undefined;
+      else if (key === "MEMORY_CLEANUP_INTERVAL")
+        jsonConfig.server.memoryCleanupInterval = parseInt(value) || undefined;
+      else if (key === "DEFAULT_TEMPERATURE")
+        jsonConfig.defaults.temperature = parseFloat(value) || undefined;
+      else if (key === "DEFAULT_TOP_P")
+        jsonConfig.defaults.topP = parseFloat(value) || undefined;
+      else if (key === "DEFAULT_TOP_K")
+        jsonConfig.defaults.topK = parseInt(value) || undefined;
+      else if (key === "DEFAULT_MAX_TOKENS")
+        jsonConfig.defaults.maxTokens = parseInt(value) || undefined;
+      else if (key === "DEFAULT_THINKING_BUDGET") {
+        const num = parseInt(value);
+        jsonConfig.defaults.thinkingBudget = Number.isNaN(num)
+          ? undefined
+          : num;
+      } else if (key === "TIMEOUT")
+        jsonConfig.other.timeout = parseInt(value) || undefined;
+      else if (key === "RETRY_TIMES") {
+        const num = parseInt(value);
+        jsonConfig.other.retryTimes = Number.isNaN(num) ? undefined : num;
+      } else if (
+        key === "SKIP_PROJECT_ID_FETCH" ||
+        key === "USE_NATIVE_AXIOS" ||
+        key === "USE_CONTEXT_SYSTEM_PROMPT" ||
+        key === "MERGE_SYSTEM_PROMPT" ||
+        key === "OFFICIAL_PROMPT_POSITION" ||
+        key === "PASS_SIGNATURE_TO_CLIENT" ||
+        key === "USE_FALLBACK_SIGNATURE" ||
+        key === "CACHE_ALL_SIGNATURES" ||
+        key === "CACHE_TOOL_SIGNATURES" ||
+        key === "CACHE_IMAGE_SIGNATURES" ||
+        key === "CACHE_THINKING" ||
+        key === "FAKE_NON_STREAM" ||
+        key === "PROXY_PROTOCOL" ||
+        key === "PROXY_POOL"
+      ) {
+        // 跳过，已在上面处理
+      } else if (key === "ROTATION_STRATEGY")
+        jsonConfig.rotation.strategy = value || undefined;
+      else if (key === "ROTATION_REQUEST_COUNT")
+        jsonConfig.rotation.requestCount = parseInt(value) || undefined;
+      else envConfig[key] = value;
+    }
+  });
+
+  envConfig.PROXY = "";
+
+  Object.keys(jsonConfig).forEach((section) => {
+    Object.keys(jsonConfig[section]).forEach((key) => {
+      if (jsonConfig[section][key] === undefined) {
+        delete jsonConfig[section][key];
+      }
+    });
+    if (Object.keys(jsonConfig[section]).length === 0) {
+      delete jsonConfig[section];
+    }
+  });
+
+  showLoading("正在保存配置...");
+
+  // 检查官方系统提示词是否真正修改了
+  const currentPrompt = envConfig.OFFICIAL_SYSTEM_PROMPT;
+  const promptChanged =
+    normalizeNewlines(currentPrompt) !==
+    normalizeNewlines(originalOfficialSystemPrompt);
+
+  // 如果没有修改，从 envConfig 中删除，避免触发后端验证
+  if (!promptChanged) {
+    delete envConfig.OFFICIAL_SYSTEM_PROMPT;
+  }
+
+  // 构建请求体
+  const payload = { env: envConfig, json: jsonConfig };
+  // 如果官方系统提示词真正修改了且已解锁有密码，带上密码用于后端验证
+  if (promptChanged && unlockedPassword) {
+    payload.password = unlockedPassword;
+  }
+
+  try {
+    const response = await authFetch("/admin/config", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
     });
 
-    Object.keys(jsonConfig).forEach(section => {
-        Object.keys(jsonConfig[section]).forEach(key => {
-            if (jsonConfig[section][key] === undefined) {
-                delete jsonConfig[section][key];
-            }
-        });
-        if (Object.keys(jsonConfig[section]).length === 0) {
-            delete jsonConfig[section];
-        }
-    });
+    const data = await response.json();
 
-    showLoading('正在保存配置...');
-
-    // 检查官方系统提示词是否真正修改了
-    const currentPrompt = envConfig.OFFICIAL_SYSTEM_PROMPT;
-    const promptChanged = normalizeNewlines(currentPrompt) !== normalizeNewlines(originalOfficialSystemPrompt);
-
-    // 如果没有修改，从 envConfig 中删除，避免触发后端验证
-    if (!promptChanged) {
-        delete envConfig.OFFICIAL_SYSTEM_PROMPT;
+    if (jsonConfig.rotation && Object.keys(jsonConfig.rotation).length > 0) {
+      await authFetch("/admin/rotation", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(jsonConfig.rotation),
+      });
     }
 
-    // 构建请求体
-    const payload = { env: envConfig, json: jsonConfig };
-    // 如果官方系统提示词真正修改了且已解锁有密码，带上密码用于后端验证
-    if (promptChanged && unlockedPassword) {
-        payload.password = unlockedPassword;
-    }
-
-    try {
-        const response = await authFetch('/admin/config', {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
+    // 保存安全配置
+    const blockingEnabled = document.getElementById("blockingEnabled")?.checked;
+    if (blockingEnabled !== undefined) {
+      try {
+        await authFetch("/admin/security-config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            config: {
+              blocking: { enabled: blockingEnabled },
+              whitelist: { ips: tempWhitelistIPs || [] },
             },
-            body: JSON.stringify(payload)
+          }),
         });
-
-        const data = await response.json();
-
-        if (jsonConfig.rotation && Object.keys(jsonConfig.rotation).length > 0) {
-            await authFetch('/admin/rotation', {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(jsonConfig.rotation)
-            });
-        }
-
-        // 保存安全配置
-        const blockingEnabled = document.getElementById('blockingEnabled')?.checked;
-        if (blockingEnabled !== undefined) {
-            try {
-                await authFetch('/admin/security-config', {
-                    method: 'PUT',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ 
-                        config: { 
-                            blocking: { enabled: blockingEnabled },
-                            whitelist: { ips: tempWhitelistIPs || [] }
-                        } 
-                    })
-                });
-            } catch (error) {
-                console.error('保存安全配置失败:', error);
-            }
-        }
-
-        hideLoading();
-        if (data.success) {
-            showToast('配置已保存', 'success');
-            // 保存成功后重新锁定
-            lockOfficialSystemPrompt();
-            loadConfig();
-        } else {
-            showToast(data.message || '保存失败', 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('保存失败: ' + error.message, 'error');
+      } catch (error) {
+        console.error("保存安全配置失败:", error);
+      }
     }
+
+    hideLoading();
+    if (data.success) {
+      showToast("配置已保存", "success");
+      // 保存成功后重新锁定
+      lockOfficialSystemPrompt();
+      loadConfig();
+    } else {
+      showToast(data.message || "保存失败", "error");
+    }
+  } catch (error) {
+    hideLoading();
+    showToast("保存失败: " + error.message, "error");
+  }
 }
 
 // 页面初始化：默认只显示一个设置分区
-document.addEventListener('DOMContentLoaded', () => {
-    if (typeof setActiveSettingSection === 'function') {
-        setActiveSettingSection(activeSettingSectionId, false);
-    }
+document.addEventListener("DOMContentLoaded", () => {
+  if (typeof setActiveSettingSection === "function") {
+    setActiveSettingSection(activeSettingSectionId, false);
+  }
 });

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -204,6 +204,9 @@ async function loadConfig() {
           );
         if (form.elements["PROXY_POOL"])
           form.elements["PROXY_POOL"].value = json.other.proxyPool ?? "";
+        if (form.elements["PROXY_ALL_REQUESTS"])
+          form.elements["PROXY_ALL_REQUESTS"].checked =
+            json.other.proxyAllRequests === true;
         if (form.elements["SKIP_PROJECT_ID_FETCH"])
           form.elements["SKIP_PROJECT_ID_FETCH"].checked =
             json.other.skipProjectIdFetch || false;
@@ -418,6 +421,8 @@ async function saveConfig(e) {
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
+  jsonConfig.other.proxyAllRequests =
+    form.elements["PROXY_ALL_REQUESTS"]?.checked || false;
   jsonConfig.other.useContextSystemPrompt =
     form.elements["USE_CONTEXT_SYSTEM_PROMPT"]?.checked || false;
   jsonConfig.other.mergeSystemPrompt =

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -240,21 +240,6 @@ async function processGeminiCliOAuthCallback() {
           throw new Error("交换失败: " + result.message);
         }
 
-        const account = result.data;
-        // 添加到 Gemini CLI token 列表
-        const addResponse = await authFetch("/admin/geminicli/tokens", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(account),
-        });
-
-        const addResult = await addResponse.json();
-        if (!addResult.success) {
-          throw new Error("添加失败: " + addResult.message);
-        }
-
         successCount += 1;
       } catch (error) {
         errors.push(`第${index + 1}行: ${error.message}`);

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -339,6 +339,20 @@ function renderGeminiCliTokens(tokens) {
       const safeEmailJs = escapeJs(token.email || "");
       const safeProjectId = escapeHtml(token.projectId || "");
       const hasProjectId = !!token.projectId;
+      const lastError = token.lastError ? escapeHtml(token.lastError) : "";
+      const lastErrorTimeStr = token.lastErrorTime
+        ? new Date(token.lastErrorTime).toLocaleString("zh-CN")
+        : "";
+      const lastErrorStageLabel =
+        token.lastErrorStage === "startup_refresh"
+          ? "启动检测"
+          : token.lastErrorStage === "disable"
+            ? "禁用"
+            : token.lastErrorStage === "manual"
+              ? "手动"
+              : token.lastErrorStage === "request"
+                ? "请求"
+                : token.lastErrorStage || "";
 
       return `
         <div class="token-card ${!token.enable ? "disabled" : ""}" id="geminicli-card-${escapeHtml(cardId)}">
@@ -353,6 +367,7 @@ function renderGeminiCliTokens(tokens) {
                     <span class="token-id">#${tokenNumber}</span>
                 </div>
             </div>
+            ${lastError ? `<div class="token-error-detail">🧾 ${lastError}${lastErrorTimeStr || lastErrorStageLabel ? `<br><span class=\"token-error-meta\">${lastErrorTimeStr ? "记录时间: " + lastErrorTimeStr : ""}${lastErrorTimeStr && lastErrorStageLabel ? " · " : ""}${lastErrorStageLabel ? "来源: " + lastErrorStageLabel : ""}</span>` : ""}</div>` : ""}
             <div class="token-info">
                 <div class="info-row editable sensitive-row" onclick="editGeminiCliField(event, '${safeTokenId}', 'email', '${safeEmailJs}')" title="点击编辑">
                     <span class="info-label">📧</span>

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -339,7 +339,22 @@ function renderGeminiCliTokens(tokens) {
       const safeEmailJs = escapeJs(token.email || "");
       const safeProjectId = escapeHtml(token.projectId || "");
       const hasProjectId = !!token.projectId;
+      const tierLabel = token.tier
+        ? token.tier === "ultra"
+          ? "💎 Ultra"
+          : token.tier === "pro"
+            ? "⭐ Pro"
+            : token.tier === "free"
+              ? "🆓 Free"
+              : `📋 ${escapeHtml(token.tier)}`
+        : "";
       const lastError = token.lastError ? escapeHtml(token.lastError) : "";
+      const disableReason = token.disableReason
+        ? escapeHtml(token.disableReason)
+        : "";
+      const disableTimeStr = token.disableTime
+        ? new Date(token.disableTime).toLocaleString("zh-CN")
+        : "";
       const lastErrorTimeStr = token.lastErrorTime
         ? new Date(token.lastErrorTime).toLocaleString("zh-CN")
         : "";
@@ -352,7 +367,9 @@ function renderGeminiCliTokens(tokens) {
               ? "手动"
               : token.lastErrorStage === "request"
                 ? "请求"
-                : token.lastErrorStage || "";
+                : token.lastErrorStage === "enable_test"
+                  ? "启用验证"
+                  : token.lastErrorStage || "";
 
       return `
         <div class="token-card ${!token.enable ? "disabled" : ""}" id="geminicli-card-${escapeHtml(cardId)}">
@@ -364,9 +381,11 @@ function renderGeminiCliTokens(tokens) {
                     <button class="btn-icon token-refresh-btn" onclick="refreshGeminiCliToken('${safeTokenId}')" title="刷新Token">🔄</button>
                 </div>
                 <div class="token-header-right">
+                    ${tierLabel ? `<span class="token-tier-badge">${tierLabel}</span>` : ""}
                     <span class="token-id">#${tokenNumber}</span>
                 </div>
             </div>
+            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? "禁用时间: " + disableTimeStr : ""}">⚠️ ${disableReason}${disableTimeStr ? " (" + disableTimeStr + ")" : ""}</div>` : ""}
             ${lastError ? `<div class="token-error-detail">🧾 ${lastError}${lastErrorTimeStr || lastErrorStageLabel ? `<br><span class=\"token-error-meta\">${lastErrorTimeStr ? "记录时间: " + lastErrorTimeStr : ""}${lastErrorTimeStr && lastErrorStageLabel ? " · " : ""}${lastErrorStageLabel ? "来源: " + lastErrorStageLabel : ""}</span>` : ""}</div>` : ""}
             <div class="token-info">
                 <div class="info-row editable sensitive-row" onclick="editGeminiCliField(event, '${safeTokenId}', 'email', '${safeEmailJs}')" title="点击编辑">
@@ -474,7 +493,8 @@ async function fetchGeminiCliProjectId(tokenId) {
     const data = await response.json();
     hideLoading();
     if (data.success) {
-      showToast(`Project ID 获取成功: ${data.projectId}`, "success");
+      const tierInfo = data.tier ? ` (tier: ${data.tier})` : "";
+      showToast(`Project ID 获取成功: ${data.projectId}${tierInfo}`, "success");
       loadGeminiCliTokens();
     } else {
       showToast(`获取失败: ${data.message || "未知错误"}`, "error");
@@ -596,6 +616,10 @@ async function toggleGeminiCliToken(tokenId, enable) {
       loadGeminiCliTokens();
     } else {
       showToast(data.message || "操作失败", enable ? "warning" : "error");
+      // 启用验证失败时也刷新列表，以显示后端记录的错误详情
+      if (enable) {
+        loadGeminiCliTokens();
+      }
     }
   } catch (error) {
     hideLoading();

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -553,13 +553,13 @@ function editGeminiCliField(event, tokenId, field, currentValue) {
 // 切换 Gemini CLI Token 状态
 async function toggleGeminiCliToken(tokenId, enable) {
   const action = enable ? "启用" : "禁用";
-  const confirmed = await showConfirm(
-    `确定要${action}这个Token吗？`,
-    `${action}确认`,
-  );
+  const confirmMsg = enable
+    ? "确定要启用这个Token吗？\n系统将先验证凭证可用性，验证通过后才会启用。"
+    : `确定要${action}这个Token吗？`;
+  const confirmed = await showConfirm(confirmMsg, `${action}确认`);
   if (!confirmed) return;
 
-  showLoading(`正在${action}...`);
+  showLoading(enable ? "正在验证凭证可用性..." : `正在${action}...`);
   try {
     const response = await authFetch(
       `/admin/geminicli/tokens/${encodeURIComponent(tokenId)}`,
@@ -568,7 +568,9 @@ async function toggleGeminiCliToken(tokenId, enable) {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ enable }),
+        body: JSON.stringify(
+          enable ? { enable, enableWithTest: true } : { enable },
+        ),
       },
     );
 
@@ -578,7 +580,7 @@ async function toggleGeminiCliToken(tokenId, enable) {
       showToast(`已${action}`, "success");
       loadGeminiCliTokens();
     } else {
-      showToast(data.message || "操作失败", "error");
+      showToast(data.message || "操作失败", enable ? "warning" : "error");
     }
   } catch (error) {
     hideLoading();

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -396,8 +396,8 @@ function renderGeminiCliTokens(tokens) {
                     <span class="token-id">#${tokenNumber}</span>
                 </div>
             </div>
-            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? "禁用时间: " + disableTimeStr : ""}">⚠️ ${disableReason}${disableTimeStr ? " (" + disableTimeStr + ")" : ""}</div>` : ""}
-            ${lastError ? `<div class="token-error-detail">🧾 ${lastError}${lastErrorTimeStr || lastErrorStageLabel ? `<br><span class=\"token-error-meta\">${lastErrorTimeStr ? "记录时间: " + lastErrorTimeStr : ""}${lastErrorTimeStr && lastErrorStageLabel ? " · " : ""}${lastErrorStageLabel ? "来源: " + lastErrorStageLabel : ""}</span>` : ""}</div>` : ""}
+            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? "禁用时间: " + disableTimeStr : ""}">⚠️ ${disableReason}${disableTimeStr ? " (" + disableTimeStr + ")" : ""}</div>${render403ActionUrls(token.disableReason || "")}` : ""}
+            ${lastError ? `<div class="token-error-detail">🧾 ${lastError}${lastErrorTimeStr || lastErrorStageLabel ? `<br><span class=\"token-error-meta\">${lastErrorTimeStr ? "记录时间: " + lastErrorTimeStr : ""}${lastErrorTimeStr && lastErrorStageLabel ? " · " : ""}${lastErrorStageLabel ? "来源: " + lastErrorStageLabel : ""}</span>` : ""}</div>${render403ActionUrls(token.lastError || "")}` : ""}
             <div class="token-info">
                 <div class="info-row editable sensitive-row" onclick="editGeminiCliField(event, '${safeTokenId}', 'email', '${safeEmailJs}')" title="点击编辑">
                     <span class="info-label">📧</span>

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -1,200 +1,364 @@
 // Gemini CLI Token 管理模块
 
 let cachedGeminiCliTokens = [];
-let currentGeminiCliFilter = localStorage.getItem('geminicliTokenFilter') || 'all';
+let currentGeminiCliFilter =
+  localStorage.getItem("geminicliTokenFilter") || "all";
+let generatedGeminiCliOAuthUrls = [];
 
 // Gemini CLI OAuth 配置
-const GEMINICLI_CLIENT_ID = '681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com';
+const GEMINICLI_CLIENT_ID =
+  "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com";
 const GEMINICLI_SCOPES = [
-    'openid',
-    'https://www.googleapis.com/auth/userinfo.email',
-    'https://www.googleapis.com/auth/cloud-platform'
-].join(' ');
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/cloud-platform",
+].join(" ");
 
 let geminicliOauthPort = null;
 
 // 获取 Gemini CLI OAuth URL
+function generateGeminiCliOAuthPorts(count = 1) {
+  const ports = new Set();
+  while (ports.size < count) {
+    ports.add(Math.floor(Math.random() * 10000) + 50000);
+  }
+  return Array.from(ports);
+}
+
+function getGeminiCliOAuthUrls(count = 1) {
+  const normalizedCount = Math.max(1, Math.min(100, Number(count) || 1));
+  const ports = generateGeminiCliOAuthPorts(normalizedCount);
+
+  if (normalizedCount === 1) {
+    geminicliOauthPort = ports[0];
+  }
+
+  return ports.map((port) => {
+    const redirectUri = `http://localhost:${port}/oauth-callback`;
+    return (
+      `https://accounts.google.com/o/oauth2/v2/auth?` +
+      `access_type=offline&client_id=${GEMINICLI_CLIENT_ID}&prompt=consent&` +
+      `redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&` +
+      `scope=${encodeURIComponent(GEMINICLI_SCOPES)}&state=geminicli_${Date.now()}_${port}`
+    );
+  });
+}
+
 function getGeminiCliOAuthUrl() {
-    if (!geminicliOauthPort) geminicliOauthPort = Math.floor(Math.random() * 10000) + 50000;
-    const redirectUri = `http://localhost:${geminicliOauthPort}/oauth-callback`;
-    return `https://accounts.google.com/o/oauth2/v2/auth?` +
-        `access_type=offline&client_id=${GEMINICLI_CLIENT_ID}&prompt=consent&` +
-        `redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&` +
-        `scope=${encodeURIComponent(GEMINICLI_SCOPES)}&state=geminicli_${Date.now()}`;
+  return getGeminiCliOAuthUrls(1)[0];
+}
+
+function getGeminiCliOAuthUrlCount() {
+  const countInput = document.getElementById("geminicliOauthUrlCount");
+  return Math.max(1, Math.min(100, Number(countInput?.value) || 1));
+}
+
+function escapeGeminiCliOAuthHtml(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderGeneratedGeminiCliOAuthUrls(urls) {
+  const preview = document.getElementById("geminicliGeneratedOauthUrls");
+  if (!preview) return;
+
+  if (!urls.length) {
+    preview.innerHTML = `
+      <div class="oauth-generated-empty">
+        点击“生成授权链接”后，将按条展示在这里，支持单条复制、全部复制和手动框选。
+      </div>
+    `;
+    return;
+  }
+
+  preview.innerHTML = `
+    <div class="oauth-generated-header">
+      <div class="oauth-generated-summary">
+        已生成 ${urls.length} 条 Gemini CLI 授权链接，建议逐条打开或按条复制。
+      </div>
+      <button type="button" class="btn btn-secondary oauth-generated-copy-btn" onclick="copyGeminiCliOAuthUrl()">📋 复制全部</button>
+    </div>
+    <div class="oauth-generated-list">
+      ${urls
+        .map(
+          (url, index) => `
+            <div class="oauth-generated-item">
+              <div class="oauth-generated-item-header">
+                <span>授权链接 ${index + 1}</span>
+                <button type="button" class="btn btn-secondary oauth-generated-copy-btn" onclick="copySingleGeminiCliOAuthUrl(${index})">复制此条</button>
+              </div>
+              <textarea readonly onclick="this.focus();this.select();" rows="2">${escapeGeminiCliOAuthHtml(url)}</textarea>
+            </div>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+}
+
+function copySingleGeminiCliOAuthUrl(index) {
+  const url = generatedGeminiCliOAuthUrls[index];
+  if (!url) {
+    showToast("未找到要复制的授权链接", "error");
+    return;
+  }
+
+  navigator.clipboard
+    .writeText(url)
+    .then(() => {
+      showToast(`已复制第 ${index + 1} 条 Gemini CLI 授权链接`, "success");
+    })
+    .catch(() => {
+      showToast("复制失败", "error");
+    });
+}
+
+function generateGeminiCliOAuthUrlList() {
+  generatedGeminiCliOAuthUrls = getGeminiCliOAuthUrls(
+    getGeminiCliOAuthUrlCount(),
+  );
+  renderGeneratedGeminiCliOAuthUrls(generatedGeminiCliOAuthUrls);
+  showToast(
+    `已生成 ${generatedGeminiCliOAuthUrls.length} 条 Gemini CLI 授权链接`,
+    "success",
+  );
 }
 
 // 打开 Gemini CLI OAuth 窗口
 function openGeminiCliOAuthWindow() {
-    window.open(getGeminiCliOAuthUrl(), '_blank');
+  const urls = generatedGeminiCliOAuthUrls.length
+    ? generatedGeminiCliOAuthUrls
+    : getGeminiCliOAuthUrls(getGeminiCliOAuthUrlCount());
+  urls.forEach((url) => window.open(url, "_blank"));
 }
 
 // 复制 Gemini CLI OAuth URL
 function copyGeminiCliOAuthUrl() {
-    const url = getGeminiCliOAuthUrl();
-    navigator.clipboard.writeText(url).then(() => {
-        showToast('Gemini CLI 授权链接已复制', 'success');
-    }).catch(() => {
-        showToast('复制失败', 'error');
+  const urls = generatedGeminiCliOAuthUrls.length
+    ? generatedGeminiCliOAuthUrls
+    : getGeminiCliOAuthUrls(getGeminiCliOAuthUrlCount());
+  navigator.clipboard
+    .writeText(urls.join("\n"))
+    .then(() => {
+      showToast(`已复制 ${urls.length} 条 Gemini CLI 授权链接`, "success");
+    })
+    .catch(() => {
+      showToast("复制失败", "error");
     });
 }
 
 // 显示 Gemini CLI OAuth 弹窗
 function showGeminiCliOAuthModal() {
-    showToast('点击后请在新窗口完成授权', 'info');
-    const modal = document.createElement('div');
-    modal.className = 'modal form-modal';
-    modal.innerHTML = `
+  showToast("点击后请在新窗口完成授权", "info");
+  generatedGeminiCliOAuthUrls = [];
+  const modal = document.createElement("div");
+  modal.className = "modal form-modal oauth-modal";
+  modal.innerHTML = `
         <div class="modal-content">
             <div class="modal-title">🔐 Gemini CLI OAuth授权</div>
             <div class="oauth-steps">
                 <p><strong>📝 授权流程：</strong></p>
-                <p>1️⃣ 点击下方按钮打开Google授权页面</p>
-                <p>2️⃣ 完成授权后，复制浏览器地址栏的完整URL</p>
-                <p>3️⃣ 粘贴URL到下方输入框并提交</p>
+                <p>1️⃣ 设置要生成的授权链接数量</p>
+                <p>2️⃣ 点击下方按钮打开Google授权页面</p>
+                <p>3️⃣ 每完成一次授权后，复制浏览器地址栏的完整URL</p>
+                <p>4️⃣ 每行粘贴一个回调URL后提交</p>
             </div>
+            <div class="oauth-generator-row">
+                <label for="geminicliOauthUrlCount" style="white-space: nowrap;">生成数量</label>
+                <input type="number" id="geminicliOauthUrlCount" min="1" max="100" value="1" style="width: 100px;">
+                <button type="button" onclick="generateGeminiCliOAuthUrlList()" class="btn btn-secondary" style="flex: 1;">🔗 生成授权链接</button>
+            </div>
+            <div id="geminicliGeneratedOauthUrls" class="oauth-generated-panel"></div>
             <div style="display: flex; gap: 8px; margin-bottom: 12px;">
                 <button type="button" onclick="openGeminiCliOAuthWindow()" class="btn btn-success" style="flex: 1;">🔐 打开授权页面</button>
                 <button type="button" onclick="copyGeminiCliOAuthUrl()" class="btn btn-info" style="flex: 1;">📋 复制授权链接</button>
             </div>
-            <input type="text" id="geminicliCallbackUrl" placeholder="粘贴完整的回调URL (http://localhost:xxxxx/oauth-callback?code=...)">
+            <textarea id="geminicliCallbackUrl" rows="6" placeholder="每行粘贴一个完整的回调URL&#10;http://localhost:xxxxx/oauth-callback?code=..."></textarea>
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="this.closest('.modal').remove()">取消</button>
                 <button class="btn btn-success" onclick="processGeminiCliOAuthCallback()">✅ 提交</button>
             </div>
         </div>
     `;
-    document.body.appendChild(modal);
-    modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
+  document.body.appendChild(modal);
+  renderGeneratedGeminiCliOAuthUrls([]);
+  modal.onclick = (e) => {
+    if (e.target === modal) modal.remove();
+  };
 }
 
 // 处理 Gemini CLI OAuth 回调
 async function processGeminiCliOAuthCallback() {
-    const modal = document.querySelector('.form-modal');
-    const callbackUrl = document.getElementById('geminicliCallbackUrl').value.trim();
-    if (!callbackUrl) {
-        showToast('请输入回调URL', 'warning');
-        return;
-    }
+  const modal = document.querySelector(".form-modal");
+  const callbackInput = document
+    .getElementById("geminicliCallbackUrl")
+    .value.trim();
+  if (!callbackInput) {
+    showToast("请输入回调URL", "warning");
+    return;
+  }
 
-    showLoading('正在处理授权...');
+  const callbackUrls = callbackInput
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 
-    try {
+  showLoading("正在处理授权...");
+
+  try {
+    let successCount = 0;
+    const errors = [];
+
+    for (let index = 0; index < callbackUrls.length; index++) {
+      const callbackUrl = callbackUrls[index];
+
+      try {
         const url = new URL(callbackUrl);
-        const code = url.searchParams.get('code');
-        const port = new URL(url.origin).port || (url.protocol === 'https:' ? 443 : 80);
+        const code = url.searchParams.get("code");
+        const port =
+          new URL(url.origin).port || (url.protocol === "https:" ? 443 : 80);
 
         if (!code) {
-            hideLoading();
-            showToast('URL中未找到授权码', 'error');
-            return;
+          throw new Error("URL中未找到授权码");
         }
 
         // 使用 geminicli 模式交换 token
-        const response = await authFetch('/admin/oauth/exchange', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ code, port, mode: 'geminicli' })
+        const response = await authFetch("/admin/oauth/exchange", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ code, port, mode: "geminicli" }),
         });
 
         const result = await response.json();
-        if (result.success) {
-            const account = result.data;
-            // 添加到 Gemini CLI token 列表
-            const addResponse = await authFetch('/admin/geminicli/tokens', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(account)
-            });
-
-            const addResult = await addResponse.json();
-            hideLoading();
-            if (addResult.success) {
-                modal.remove();
-                showToast('Gemini CLI Token添加成功', 'success');
-                loadGeminiCliTokens();
-            } else {
-                showToast('添加失败: ' + addResult.message, 'error');
-            }
-        } else {
-            hideLoading();
-            showToast('交换失败: ' + result.message, 'error');
+        if (!result.success) {
+          throw new Error("交换失败: " + result.message);
         }
-    } catch (error) {
-        hideLoading();
-        showToast('处理失败: ' + error.message, 'error');
+
+        const account = result.data;
+        // 添加到 Gemini CLI token 列表
+        const addResponse = await authFetch("/admin/geminicli/tokens", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(account),
+        });
+
+        const addResult = await addResponse.json();
+        if (!addResult.success) {
+          throw new Error("添加失败: " + addResult.message);
+        }
+
+        successCount += 1;
+      } catch (error) {
+        errors.push(`第${index + 1}行: ${error.message}`);
+      }
     }
+
+    hideLoading();
+
+    if (successCount > 0) {
+      modal.remove();
+      loadGeminiCliTokens();
+      const summary = [`成功添加 ${successCount} 个 Gemini CLI Token`];
+      if (errors.length > 0) {
+        summary.push(`失败 ${errors.length} 条`);
+      }
+      showToast(summary.join("，"), errors.length > 0 ? "warning" : "success");
+    } else {
+      showToast(errors.join("；") || "处理失败", "error");
+    }
+  } catch (error) {
+    hideLoading();
+    showToast("处理失败: " + error.message, "error");
+  }
 }
 
 // 加载 Gemini CLI Token 列表
 async function loadGeminiCliTokens() {
-    try {
-        const response = await authFetch('/admin/geminicli/tokens');
-        const data = await response.json();
-        if (data.success) {
-            renderGeminiCliTokens(data.data);
-        } else {
-            showToast('加载失败: ' + (data.message || '未知错误'), 'error');
-        }
-    } catch (error) {
-        if (error.message !== 'Unauthorized') {
-            showToast('加载Gemini CLI Token失败: ' + error.message, 'error');
-        }
+  try {
+    const response = await authFetch("/admin/geminicli/tokens");
+    const data = await response.json();
+    if (data.success) {
+      renderGeminiCliTokens(data.data);
+    } else {
+      showToast("加载失败: " + (data.message || "未知错误"), "error");
     }
+  } catch (error) {
+    if (error.message !== "Unauthorized") {
+      showToast("加载Gemini CLI Token失败: " + error.message, "error");
+    }
+  }
 }
 
 // 渲染 Gemini CLI Token 列表
 function renderGeminiCliTokens(tokens) {
-    cachedGeminiCliTokens = tokens;
+  cachedGeminiCliTokens = tokens;
 
-    document.getElementById('geminicliTotalTokens').textContent = tokens.length;
-    document.getElementById('geminicliEnabledTokens').textContent = tokens.filter(t => t.enable).length;
-    document.getElementById('geminicliDisabledTokens').textContent = tokens.filter(t => !t.enable).length;
+  document.getElementById("geminicliTotalTokens").textContent = tokens.length;
+  document.getElementById("geminicliEnabledTokens").textContent = tokens.filter(
+    (t) => t.enable,
+  ).length;
+  document.getElementById("geminicliDisabledTokens").textContent =
+    tokens.filter((t) => !t.enable).length;
 
-    // 根据筛选条件过滤
-    let filteredTokens = tokens;
-    if (currentGeminiCliFilter === 'enabled') {
-        filteredTokens = tokens.filter(t => t.enable);
-    } else if (currentGeminiCliFilter === 'disabled') {
-        filteredTokens = tokens.filter(t => !t.enable);
-    }
+  // 根据筛选条件过滤
+  let filteredTokens = tokens;
+  if (currentGeminiCliFilter === "enabled") {
+    filteredTokens = tokens.filter((t) => t.enable);
+  } else if (currentGeminiCliFilter === "disabled") {
+    filteredTokens = tokens.filter((t) => !t.enable);
+  }
 
-    const tokenList = document.getElementById('geminicliTokenList');
-    if (filteredTokens.length === 0) {
-        const emptyText = currentGeminiCliFilter === 'all' ? '暂无Token' :
-            currentGeminiCliFilter === 'enabled' ? '暂无启用的Token' : '暂无禁用的Token';
-        const emptyHint = currentGeminiCliFilter === 'all' ? '点击上方OAuth按钮添加Token' : '点击上方"总数"查看全部';
-        tokenList.innerHTML = `
+  const tokenList = document.getElementById("geminicliTokenList");
+  if (filteredTokens.length === 0) {
+    const emptyText =
+      currentGeminiCliFilter === "all"
+        ? "暂无Token"
+        : currentGeminiCliFilter === "enabled"
+          ? "暂无启用的Token"
+          : "暂无禁用的Token";
+    const emptyHint =
+      currentGeminiCliFilter === "all"
+        ? "点击上方OAuth按钮添加Token"
+        : '点击上方"总数"查看全部';
+    tokenList.innerHTML = `
             <div class="empty-state">
                 <div class="empty-state-icon">📦</div>
                 <div class="empty-state-text">${emptyText}</div>
                 <div class="empty-state-hint">${emptyHint}</div>
             </div>
         `;
-        return;
-    }
+    return;
+  }
 
-    tokenList.innerHTML = filteredTokens.map((token, index) => {
-        const tokenId = token.id;
-        const cardId = tokenId.substring(0, 8);
-        const originalIndex = cachedGeminiCliTokens.findIndex(t => t.id === token.id);
-        const tokenNumber = originalIndex + 1;
+  tokenList.innerHTML = filteredTokens
+    .map((token, index) => {
+      const tokenId = token.id;
+      const cardId = tokenId.substring(0, 8);
+      const originalIndex = cachedGeminiCliTokens.findIndex(
+        (t) => t.id === token.id,
+      );
+      const tokenNumber = originalIndex + 1;
 
-        const safeTokenId = escapeJs(tokenId);
-        const safeEmail = escapeHtml(token.email || '');
-        const safeEmailJs = escapeJs(token.email || '');
-        const safeProjectId = escapeHtml(token.projectId || '');
-        const hasProjectId = !!token.projectId;
+      const safeTokenId = escapeJs(tokenId);
+      const safeEmail = escapeHtml(token.email || "");
+      const safeEmailJs = escapeJs(token.email || "");
+      const safeProjectId = escapeHtml(token.projectId || "");
+      const hasProjectId = !!token.projectId;
 
-        return `
-        <div class="token-card ${!token.enable ? 'disabled' : ''}" id="geminicli-card-${escapeHtml(cardId)}">
+      return `
+        <div class="token-card ${!token.enable ? "disabled" : ""}" id="geminicli-card-${escapeHtml(cardId)}">
             <div class="token-header">
                 <div class="token-header-left">
-                    <span class="status ${token.enable ? 'enabled' : 'disabled'}">
-                        ${token.enable ? '✅ 启用' : '❌ 禁用'}
+                    <span class="status ${token.enable ? "enabled" : "disabled"}">
+                        ${token.enable ? "✅ 启用" : "❌ 禁用"}
                     </span>
                     <button class="btn-icon token-refresh-btn" onclick="refreshGeminiCliToken('${safeTokenId}')" title="刷新Token">🔄</button>
                 </div>
@@ -205,355 +369,386 @@ function renderGeminiCliTokens(tokens) {
             <div class="token-info">
                 <div class="info-row editable sensitive-row" onclick="editGeminiCliField(event, '${safeTokenId}', 'email', '${safeEmailJs}')" title="点击编辑">
                     <span class="info-label">📧</span>
-                    <span class="info-value sensitive-info">${safeEmail || '点击设置'}</span>
+                    <span class="info-value sensitive-info">${safeEmail || "点击设置"}</span>
                     <span class="info-edit-icon">✏️</span>
                 </div>
-                <div class="info-row ${hasProjectId ? '' : 'warning'}" title="${hasProjectId ? 'Project ID' : '缺少 Project ID，点击获取'}">
+                <div class="info-row ${hasProjectId ? "" : "warning"}" title="${hasProjectId ? "Project ID" : "缺少 Project ID，点击获取"}">
                     <span class="info-label">📁</span>
-                    <span class="info-value ${hasProjectId ? '' : 'text-warning'}">${safeProjectId || '未获取'}</span>
-                    ${!hasProjectId ? `<button class="btn btn-info btn-xs" onclick="fetchGeminiCliProjectId('${safeTokenId}')" style="margin-left: auto;">获取</button>` : ''}
+                    <span class="info-value ${hasProjectId ? "" : "text-warning"}">${safeProjectId || "未获取"}</span>
+                    ${!hasProjectId ? `<button class="btn btn-info btn-xs" onclick="fetchGeminiCliProjectId('${safeTokenId}')" style="margin-left: auto;">获取</button>` : ""}
                 </div>
             </div>
             <div class="token-id-row" title="Token ID: ${escapeHtml(tokenId)}">
                 <span class="token-id-label">🔑</span>
-                <span class="token-id-value">${escapeHtml(tokenId.length > 24 ? tokenId.substring(0, 12) + '...' + tokenId.substring(tokenId.length - 8) : tokenId)}</span>
+                <span class="token-id-value">${escapeHtml(tokenId.length > 24 ? tokenId.substring(0, 12) + "..." + tokenId.substring(tokenId.length - 8) : tokenId)}</span>
             </div>
             <div class="token-actions">
-                <button class="btn ${token.enable ? 'btn-warning' : 'btn-success'} btn-xs" onclick="toggleGeminiCliToken('${safeTokenId}', ${!token.enable})" title="${token.enable ? '禁用' : '启用'}">
-                    ${token.enable ? '⏸️ 禁用' : '▶️ 启用'}
+                <button class="btn ${token.enable ? "btn-warning" : "btn-success"} btn-xs" onclick="toggleGeminiCliToken('${safeTokenId}', ${!token.enable})" title="${token.enable ? "禁用" : "启用"}">
+                    ${token.enable ? "⏸️ 禁用" : "▶️ 启用"}
                 </button>
                 <button class="btn btn-danger btn-xs" onclick="deleteGeminiCliToken('${safeTokenId}')" title="删除">🗑️ 删除</button>
             </div>
         </div>
-    `}).join('');
+    `;
+    })
+    .join("");
 
-    updateSensitiveInfoDisplay();
+  updateSensitiveInfoDisplay();
 }
 
 // 筛选 Gemini CLI Token
 function filterGeminiCliTokens(filter) {
-    currentGeminiCliFilter = filter;
-    localStorage.setItem('geminicliTokenFilter', filter);
-    updateGeminiCliFilterButtonState(filter);
-    renderGeminiCliTokens(cachedGeminiCliTokens);
+  currentGeminiCliFilter = filter;
+  localStorage.setItem("geminicliTokenFilter", filter);
+  updateGeminiCliFilterButtonState(filter);
+  renderGeminiCliTokens(cachedGeminiCliTokens);
 }
 
 // 更新筛选按钮状态
 function updateGeminiCliFilterButtonState(filter) {
-    document.querySelectorAll('#geminicliPage .stat-item').forEach(item => {
-        item.classList.remove('active');
-    });
-    const filterMap = { 'all': 'geminicliTotalTokens', 'enabled': 'geminicliEnabledTokens', 'disabled': 'geminicliDisabledTokens' };
-    const activeElement = document.getElementById(filterMap[filter]);
-    if (activeElement) {
-        activeElement.closest('.stat-item').classList.add('active');
-    }
+  document.querySelectorAll("#geminicliPage .stat-item").forEach((item) => {
+    item.classList.remove("active");
+  });
+  const filterMap = {
+    all: "geminicliTotalTokens",
+    enabled: "geminicliEnabledTokens",
+    disabled: "geminicliDisabledTokens",
+  };
+  const activeElement = document.getElementById(filterMap[filter]);
+  if (activeElement) {
+    activeElement.closest(".stat-item").classList.add("active");
+  }
 }
 
 // 刷新 Gemini CLI Token
 async function refreshGeminiCliToken(tokenId) {
-    try {
-        const response = await authFetch(`/admin/geminicli/tokens/${encodeURIComponent(tokenId)}/refresh`, {
-            method: 'POST'
-        });
-        const data = await response.json();
-        if (data.success) {
-            showToast('Token 刷新成功', 'success');
-            loadGeminiCliTokens();
-        } else {
-            showToast(`刷新失败: ${data.message || '未知错误'}`, 'error');
-        }
-    } catch (error) {
-        if (error.message !== 'Unauthorized') {
-            showToast(`刷新失败: ${error.message}`, 'error');
-        }
+  try {
+    const response = await authFetch(
+      `/admin/geminicli/tokens/${encodeURIComponent(tokenId)}/refresh`,
+      {
+        method: "POST",
+      },
+    );
+    const data = await response.json();
+    if (data.success) {
+      showToast("Token 刷新成功", "success");
+      loadGeminiCliTokens();
+    } else {
+      showToast(`刷新失败: ${data.message || "未知错误"}`, "error");
     }
+  } catch (error) {
+    if (error.message !== "Unauthorized") {
+      showToast(`刷新失败: ${error.message}`, "error");
+    }
+  }
 }
 
 // 获取 Gemini CLI Token 的 Project ID
 async function fetchGeminiCliProjectId(tokenId) {
-    showLoading('正在获取 Project ID...');
-    try {
-        const response = await authFetch(`/admin/geminicli/tokens/${encodeURIComponent(tokenId)}/fetch-project-id`, {
-            method: 'POST'
-        });
-        const data = await response.json();
-        hideLoading();
-        if (data.success) {
-            showToast(`Project ID 获取成功: ${data.projectId}`, 'success');
-            loadGeminiCliTokens();
-        } else {
-            showToast(`获取失败: ${data.message || '未知错误'}`, 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        if (error.message !== 'Unauthorized') {
-            showToast(`获取失败: ${error.message}`, 'error');
-        }
+  showLoading("正在获取 Project ID...");
+  try {
+    const response = await authFetch(
+      `/admin/geminicli/tokens/${encodeURIComponent(tokenId)}/fetch-project-id`,
+      {
+        method: "POST",
+      },
+    );
+    const data = await response.json();
+    hideLoading();
+    if (data.success) {
+      showToast(`Project ID 获取成功: ${data.projectId}`, "success");
+      loadGeminiCliTokens();
+    } else {
+      showToast(`获取失败: ${data.message || "未知错误"}`, "error");
     }
+  } catch (error) {
+    hideLoading();
+    if (error.message !== "Unauthorized") {
+      showToast(`获取失败: ${error.message}`, "error");
+    }
+  }
 }
 
 // 编辑 Gemini CLI Token 字段
 function editGeminiCliField(event, tokenId, field, currentValue) {
-    event.stopPropagation();
-    const row = event.currentTarget;
-    const valueSpan = row.querySelector('.info-value');
+  event.stopPropagation();
+  const row = event.currentTarget;
+  const valueSpan = row.querySelector(".info-value");
 
-    if (row.querySelector('input')) return;
+  if (row.querySelector("input")) return;
 
-    const fieldLabels = { email: '邮箱' };
+  const fieldLabels = { email: "邮箱" };
 
-    const input = document.createElement('input');
-    input.type = 'email';
-    input.value = currentValue;
-    input.className = 'inline-edit-input';
-    input.placeholder = `输入${fieldLabels[field]}`;
+  const input = document.createElement("input");
+  input.type = "email";
+  input.value = currentValue;
+  input.className = "inline-edit-input";
+  input.placeholder = `输入${fieldLabels[field]}`;
 
-    valueSpan.style.display = 'none';
-    row.insertBefore(input, valueSpan.nextSibling);
-    input.focus();
-    input.select();
+  valueSpan.style.display = "none";
+  row.insertBefore(input, valueSpan.nextSibling);
+  input.focus();
+  input.select();
 
-    const save = async () => {
-        const newValue = input.value.trim();
-        input.disabled = true;
+  const save = async () => {
+    const newValue = input.value.trim();
+    input.disabled = true;
 
-        try {
-            const response = await authFetch(`/admin/geminicli/tokens/${encodeURIComponent(tokenId)}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ [field]: newValue })
-            });
+    try {
+      const response = await authFetch(
+        `/admin/geminicli/tokens/${encodeURIComponent(tokenId)}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ [field]: newValue }),
+        },
+      );
 
-            const data = await response.json();
-            if (data.success) {
-                showToast('已保存', 'success');
-                loadGeminiCliTokens();
-            } else {
-                showToast(data.message || '保存失败', 'error');
-                cancel();
-            }
-        } catch (error) {
-            showToast('保存失败', 'error');
-            cancel();
+      const data = await response.json();
+      if (data.success) {
+        showToast("已保存", "success");
+        loadGeminiCliTokens();
+      } else {
+        showToast(data.message || "保存失败", "error");
+        cancel();
+      }
+    } catch (error) {
+      showToast("保存失败", "error");
+      cancel();
+    }
+  };
+
+  const cancel = () => {
+    input.remove();
+    valueSpan.style.display = "";
+  };
+
+  input.addEventListener("blur", () => {
+    setTimeout(() => {
+      if (document.activeElement !== input) {
+        if (input.value.trim() !== currentValue) {
+          save();
+        } else {
+          cancel();
         }
-    };
+      }
+    }, 100);
+  });
 
-    const cancel = () => {
-        input.remove();
-        valueSpan.style.display = '';
-    };
-
-    input.addEventListener('blur', () => {
-        setTimeout(() => {
-            if (document.activeElement !== input) {
-                if (input.value.trim() !== currentValue) {
-                    save();
-                } else {
-                    cancel();
-                }
-            }
-        }, 100);
-    });
-
-    input.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            save();
-        } else if (e.key === 'Escape') {
-            cancel();
-        }
-    });
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      save();
+    } else if (e.key === "Escape") {
+      cancel();
+    }
+  });
 }
 
 // 切换 Gemini CLI Token 状态
 async function toggleGeminiCliToken(tokenId, enable) {
-    const action = enable ? '启用' : '禁用';
-    const confirmed = await showConfirm(`确定要${action}这个Token吗？`, `${action}确认`);
-    if (!confirmed) return;
+  const action = enable ? "启用" : "禁用";
+  const confirmed = await showConfirm(
+    `确定要${action}这个Token吗？`,
+    `${action}确认`,
+  );
+  if (!confirmed) return;
 
-    showLoading(`正在${action}...`);
-    try {
-        const response = await authFetch(`/admin/geminicli/tokens/${encodeURIComponent(tokenId)}`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ enable })
-        });
+  showLoading(`正在${action}...`);
+  try {
+    const response = await authFetch(
+      `/admin/geminicli/tokens/${encodeURIComponent(tokenId)}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ enable }),
+      },
+    );
 
-        const data = await response.json();
-        hideLoading();
-        if (data.success) {
-            showToast(`已${action}`, 'success');
-            loadGeminiCliTokens();
-        } else {
-            showToast(data.message || '操作失败', 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('操作失败: ' + error.message, 'error');
+    const data = await response.json();
+    hideLoading();
+    if (data.success) {
+      showToast(`已${action}`, "success");
+      loadGeminiCliTokens();
+    } else {
+      showToast(data.message || "操作失败", "error");
     }
+  } catch (error) {
+    hideLoading();
+    showToast("操作失败: " + error.message, "error");
+  }
 }
 
 // 删除 Gemini CLI Token
 async function deleteGeminiCliToken(tokenId) {
-    const confirmed = await showConfirm('删除后无法恢复，确定删除？', '⚠️ 删除确认');
-    if (!confirmed) return;
+  const confirmed = await showConfirm(
+    "删除后无法恢复，确定删除？",
+    "⚠️ 删除确认",
+  );
+  if (!confirmed) return;
 
-    showLoading('正在删除...');
-    try {
-        const response = await authFetch(`/admin/geminicli/tokens/${encodeURIComponent(tokenId)}`, {
-            method: 'DELETE'
-        });
+  showLoading("正在删除...");
+  try {
+    const response = await authFetch(
+      `/admin/geminicli/tokens/${encodeURIComponent(tokenId)}`,
+      {
+        method: "DELETE",
+      },
+    );
 
-        const data = await response.json();
-        hideLoading();
-        if (data.success) {
-            showToast('已删除', 'success');
-            loadGeminiCliTokens();
-        } else {
-            showToast(data.message || '删除失败', 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('删除失败: ' + error.message, 'error');
+    const data = await response.json();
+    hideLoading();
+    if (data.success) {
+      showToast("已删除", "success");
+      loadGeminiCliTokens();
+    } else {
+      showToast(data.message || "删除失败", "error");
     }
+  } catch (error) {
+    hideLoading();
+    showToast("删除失败: " + error.message, "error");
+  }
 }
 
 // 导出 Gemini CLI Token
 async function exportGeminiCliTokens() {
-    const password = await showPasswordPrompt('请输入管理员密码以导出 Gemini CLI Token');
-    if (!password) return;
+  const password = await showPasswordPrompt(
+    "请输入管理员密码以导出 Gemini CLI Token",
+  );
+  if (!password) return;
 
-    showLoading('正在导出...');
-    try {
-        const response = await authFetch('/admin/geminicli/tokens/export', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ password })
-        });
+  showLoading("正在导出...");
+  try {
+    const response = await authFetch("/admin/geminicli/tokens/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
 
-        const data = await response.json();
-        hideLoading();
+    const data = await response.json();
+    hideLoading();
 
-        if (data.success) {
-            const blob = new Blob([JSON.stringify(data.data, null, 2)], { type: 'application/json' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `geminicli-tokens-export-${new Date().toISOString().slice(0, 10)}.json`;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            showToast('导出成功', 'success');
-        } else {
-            if (response.status === 403) {
-                showToast('密码错误，请重新输入', 'error');
-            } else {
-                showToast(data.message || '导出失败', 'error');
-            }
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('导出失败: ' + error.message, 'error');
+    if (data.success) {
+      const blob = new Blob([JSON.stringify(data.data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `geminicli-tokens-export-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      showToast("导出成功", "success");
+    } else {
+      if (response.status === 403) {
+        showToast("密码错误，请重新输入", "error");
+      } else {
+        showToast(data.message || "导出失败", "error");
+      }
     }
+  } catch (error) {
+    hideLoading();
+    showToast("导出失败: " + error.message, "error");
+  }
 }
 
 // 重载 Gemini CLI Token
 async function reloadGeminiCliTokens() {
-    showLoading('正在重载...');
-    try {
-        const response = await authFetch('/admin/geminicli/tokens/reload', {
-            method: 'POST'
-        });
-        const data = await response.json();
-        hideLoading();
-        if (data.success) {
-            showToast('重载成功', 'success');
-            loadGeminiCliTokens();
-        } else {
-            showToast(data.message || '重载失败', 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('重载失败: ' + error.message, 'error');
+  showLoading("正在重载...");
+  try {
+    const response = await authFetch("/admin/geminicli/tokens/reload", {
+      method: "POST",
+    });
+    const data = await response.json();
+    hideLoading();
+    if (data.success) {
+      showToast("重载成功", "success");
+      loadGeminiCliTokens();
+    } else {
+      showToast(data.message || "重载失败", "error");
     }
+  } catch (error) {
+    hideLoading();
+    showToast("重载失败: " + error.message, "error");
+  }
 }
 
 // 初始化 Gemini CLI 页面
 function initGeminiCliPage() {
-    updateGeminiCliFilterButtonState(currentGeminiCliFilter);
-    loadGeminiCliTokens();
+  updateGeminiCliFilterButtonState(currentGeminiCliFilter);
+  loadGeminiCliTokens();
 }
 
 // ==================== 导入 Gemini CLI Token ====================
 
-let geminicliImportTab = 'file';
+let geminicliImportTab = "file";
 let geminicliImportFile = null;
 
 // 存储导入弹窗的事件处理器引用，便于清理
 let geminicliImportModalHandlers = null;
 
 async function importGeminiCliTokens() {
-    showGeminiCliImportModal();
+  showGeminiCliImportModal();
 }
 
 function closeGeminiCliImportModal() {
-    try {
-        const h = geminicliImportModalHandlers;
-        if (typeof h?.cleanup === 'function') {
-            h.cleanup();
-        }
-    } catch {
-        // ignore
+  try {
+    const h = geminicliImportModalHandlers;
+    if (typeof h?.cleanup === "function") {
+      h.cleanup();
     }
+  } catch {
+    // ignore
+  }
 
-    geminicliImportModalHandlers = null;
+  geminicliImportModalHandlers = null;
 
-    const modal = document.getElementById('geminicliImportModal');
-    if (modal) modal.remove();
+  const modal = document.getElementById("geminicliImportModal");
+  if (modal) modal.remove();
 
-    // 重置状态，避免下次打开沿用旧值
-    geminicliImportTab = 'file';
-    geminicliImportFile = null;
+  // 重置状态，避免下次打开沿用旧值
+  geminicliImportTab = "file";
+  geminicliImportFile = null;
 }
 
 function switchGeminiCliImportTab(tab) {
-    geminicliImportTab = tab;
+  geminicliImportTab = tab;
 
-    const tabs = document.querySelectorAll('#geminicliImportModal .import-tab');
-    tabs.forEach(t => {
-        const isActive = t.getAttribute('data-tab') === tab;
-        t.classList.toggle('active', isActive);
-    });
+  const tabs = document.querySelectorAll("#geminicliImportModal .import-tab");
+  tabs.forEach((t) => {
+    const isActive = t.getAttribute("data-tab") === tab;
+    t.classList.toggle("active", isActive);
+  });
 
-    const filePanel = document.getElementById('geminicliImportTabFile');
-    const jsonPanel = document.getElementById('geminicliImportTabJson');
-    if (filePanel) filePanel.classList.toggle('hidden', tab !== 'file');
-    if (jsonPanel) jsonPanel.classList.toggle('hidden', tab !== 'json');
+  const filePanel = document.getElementById("geminicliImportTabFile");
+  const jsonPanel = document.getElementById("geminicliImportTabJson");
+  if (filePanel) filePanel.classList.toggle("hidden", tab !== "file");
+  if (jsonPanel) jsonPanel.classList.toggle("hidden", tab !== "json");
 }
 
 function clearGeminiCliImportFile() {
-    geminicliImportFile = null;
-    const info = document.getElementById('geminicliImportFileInfo');
-    const input = document.getElementById('geminicliImportFileInput');
-    if (input) input.value = '';
-    if (info) info.classList.add('hidden');
+  geminicliImportFile = null;
+  const info = document.getElementById("geminicliImportFileInfo");
+  const input = document.getElementById("geminicliImportFileInput");
+  if (input) input.value = "";
+  if (info) info.classList.add("hidden");
 }
 
 function showGeminiCliImportModal() {
-    // 如果已存在，先按“可清理”方式关闭
-    const existing = document.getElementById('geminicliImportModal');
-    if (existing) closeGeminiCliImportModal();
+  // 如果已存在，先按“可清理”方式关闭
+  const existing = document.getElementById("geminicliImportModal");
+  if (existing) closeGeminiCliImportModal();
 
-    const modal = document.createElement('div');
-    modal.className = 'modal form-modal';
-    modal.id = 'geminicliImportModal';
-    modal.innerHTML = `
+  const modal = document.createElement("div");
+  modal.className = "modal form-modal";
+  modal.id = "geminicliImportModal";
+  modal.innerHTML = `
         <div class="modal-content modal-lg">
             <div class="modal-title">📥 导入 Gemini CLI Token</div>
 
@@ -605,125 +800,139 @@ function showGeminiCliImportModal() {
             </div>
         </div>
     `;
-    document.body.appendChild(modal);
+  document.body.appendChild(modal);
 
-    // wire dropzone
-    const dropzone = document.getElementById('geminicliImportDropzone');
-    const fileInput = document.getElementById('geminicliImportFileInput');
-    const fileInfo = document.getElementById('geminicliImportFileInfo');
-    const fileName = document.getElementById('geminicliImportFileName');
+  // wire dropzone
+  const dropzone = document.getElementById("geminicliImportDropzone");
+  const fileInput = document.getElementById("geminicliImportFileInput");
+  const fileInfo = document.getElementById("geminicliImportFileInfo");
+  const fileName = document.getElementById("geminicliImportFileName");
 
-    const setFile = (file) => {
-        geminicliImportFile = file;
-        if (fileName) fileName.textContent = file?.name || '-';
-        if (fileInfo) fileInfo.classList.toggle('hidden', !file);
-    };
+  const setFile = (file) => {
+    geminicliImportFile = file;
+    if (fileName) fileName.textContent = file?.name || "-";
+    if (fileInfo) fileInfo.classList.toggle("hidden", !file);
+  };
 
-    const cleanupDropzone = (typeof wireJsonFileDropzone === 'function')
-        ? wireJsonFileDropzone({
-            dropzone,
-            fileInput,
-            onFile: (file) => setFile(file),
-            onError: (message) => showToast(message, 'warning')
+  const cleanupDropzone =
+    typeof wireJsonFileDropzone === "function"
+      ? wireJsonFileDropzone({
+          dropzone,
+          fileInput,
+          onFile: (file) => setFile(file),
+          onError: (message) => showToast(message, "warning"),
         })
-        : null;
-    const cleanupBackdrop = (typeof wireModalBackdropClose === 'function')
-        ? wireModalBackdropClose(modal, closeGeminiCliImportModal)
-        : null;
+      : null;
+  const cleanupBackdrop =
+    typeof wireModalBackdropClose === "function"
+      ? wireModalBackdropClose(modal, closeGeminiCliImportModal)
+      : null;
 
-    geminicliImportModalHandlers = {
-        cleanup: () => {
-            try { cleanupDropzone && cleanupDropzone(); } catch { /* ignore */ }
-            try { cleanupBackdrop && cleanupBackdrop(); } catch { /* ignore */ }
-        }
-    };
+  geminicliImportModalHandlers = {
+    cleanup: () => {
+      try {
+        cleanupDropzone && cleanupDropzone();
+      } catch {
+        /* ignore */
+      }
+      try {
+        cleanupBackdrop && cleanupBackdrop();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
 
-    // reset state
-    geminicliImportTab = 'file';
-    geminicliImportFile = null;
-    switchGeminiCliImportTab('file');
+  // reset state
+  geminicliImportTab = "file";
+  geminicliImportFile = null;
+  switchGeminiCliImportTab("file");
 }
 
 function normalizeGeminiCliImportData(parsed) {
-    // 后端期望: { tokens: [...] }
-    if (Array.isArray(parsed)) return { tokens: parsed };
-    if (parsed && typeof parsed === 'object') {
-        if (Array.isArray(parsed.tokens)) return { tokens: parsed.tokens };
-        if (Array.isArray(parsed.accounts)) return { tokens: parsed.accounts };
-        // 允许用户直接粘贴 export 返回中的 data
-        if (parsed.data && Array.isArray(parsed.data.tokens)) return { tokens: parsed.data.tokens };
-        if (parsed.data && Array.isArray(parsed.data.accounts)) return { tokens: parsed.data.accounts };
+  // 后端期望: { tokens: [...] }
+  if (Array.isArray(parsed)) return { tokens: parsed };
+  if (parsed && typeof parsed === "object") {
+    if (Array.isArray(parsed.tokens)) return { tokens: parsed.tokens };
+    if (Array.isArray(parsed.accounts)) return { tokens: parsed.accounts };
+    // 允许用户直接粘贴 export 返回中的 data
+    if (parsed.data && Array.isArray(parsed.data.tokens))
+      return { tokens: parsed.data.tokens };
+    if (parsed.data && Array.isArray(parsed.data.accounts))
+      return { tokens: parsed.data.accounts };
 
-        // 兼容 gcli 单文件凭证：直接是一个 credential 对象
-        // 常见字段：refresh_token / refreshToken / token / access_token / accessToken
-        const hasRefresh = (parsed.refresh_token || parsed.refreshToken);
-        const hasAccess = (parsed.access_token || parsed.accessToken || parsed.token);
-        if (hasRefresh || hasAccess) return { tokens: [parsed] };
-    }
-    return null;
+    // 兼容 gcli 单文件凭证：直接是一个 credential 对象
+    // 常见字段：refresh_token / refreshToken / token / access_token / accessToken
+    const hasRefresh = parsed.refresh_token || parsed.refreshToken;
+    const hasAccess = parsed.access_token || parsed.accessToken || parsed.token;
+    if (hasRefresh || hasAccess) return { tokens: [parsed] };
+  }
+  return null;
 }
 
 async function submitGeminiCliImport() {
-    const password = document.getElementById('geminicliImportPassword')?.value?.trim();
-    const mode = document.getElementById('geminicliImportMode')?.value || 'merge';
+  const password = document
+    .getElementById("geminicliImportPassword")
+    ?.value?.trim();
+  const mode = document.getElementById("geminicliImportMode")?.value || "merge";
 
-    if (!password) {
-        showToast('请输入管理员密码', 'warning');
-        return;
+  if (!password) {
+    showToast("请输入管理员密码", "warning");
+    return;
+  }
+
+  let rawText = "";
+  if (geminicliImportTab === "file") {
+    if (!geminicliImportFile) {
+      showToast("请选择要导入的 JSON 文件", "warning");
+      return;
     }
+    rawText = await geminicliImportFile.text();
+  } else {
+    rawText = document.getElementById("geminicliImportJsonInput")?.value || "";
+    if (!rawText.trim()) {
+      showToast("请粘贴 JSON 内容", "warning");
+      return;
+    }
+  }
 
-    let rawText = '';
-    if (geminicliImportTab === 'file') {
-        if (!geminicliImportFile) {
-            showToast('请选择要导入的 JSON 文件', 'warning');
-            return;
-        }
-        rawText = await geminicliImportFile.text();
+  let parsed;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (e) {
+    showToast("JSON 解析失败: " + (e?.message || e), "error");
+    return;
+  }
+
+  const data = normalizeGeminiCliImportData(parsed);
+  if (!data) {
+    showToast('无效的导入格式：需要 {"tokens": [...]} 或 token 数组', "error");
+    return;
+  }
+
+  showLoading("正在导入...");
+  try {
+    const response = await authFetch("/admin/geminicli/tokens/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password, mode, data }),
+    });
+    const result = await response.json();
+    hideLoading();
+
+    if (result.success) {
+      closeGeminiCliImportModal();
+      showToast(result.message || "导入成功", "success");
+      loadGeminiCliTokens();
     } else {
-        rawText = document.getElementById('geminicliImportJsonInput')?.value || '';
-        if (!rawText.trim()) {
-            showToast('请粘贴 JSON 内容', 'warning');
-            return;
-        }
+      if (response.status === 403) {
+        showToast("密码错误，请重新输入", "error");
+      } else {
+        showToast(result.message || "导入失败", "error");
+      }
     }
-
-    let parsed;
-    try {
-        parsed = JSON.parse(rawText);
-    } catch (e) {
-        showToast('JSON 解析失败: ' + (e?.message || e), 'error');
-        return;
-    }
-
-    const data = normalizeGeminiCliImportData(parsed);
-    if (!data) {
-        showToast('无效的导入格式：需要 {"tokens": [...]} 或 token 数组', 'error');
-        return;
-    }
-
-    showLoading('正在导入...');
-    try {
-        const response = await authFetch('/admin/geminicli/tokens/import', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ password, mode, data })
-        });
-        const result = await response.json();
-        hideLoading();
-
-        if (result.success) {
-            closeGeminiCliImportModal();
-            showToast(result.message || '导入成功', 'success');
-            loadGeminiCliTokens();
-        } else {
-            if (response.status === 403) {
-                showToast('密码错误，请重新输入', 'error');
-            } else {
-                showToast(result.message || '导入失败', 'error');
-            }
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('导入失败: ' + error.message, 'error');
-    }
+  } catch (error) {
+    hideLoading();
+    showToast("导入失败: " + error.message, "error");
+  }
 }

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -16,6 +16,8 @@ const GEMINICLI_SCOPES = [
 
 let geminicliOauthPort = null;
 
+const GEMINICLI_QUOTA_CARD_ID_PREFIX = "geminicli";
+
 // 获取 Gemini CLI OAuth URL
 function generateGeminiCliOAuthPorts(count = 1) {
   const ports = new Set();
@@ -326,7 +328,7 @@ function renderGeminiCliTokens(tokens) {
   tokenList.innerHTML = filteredTokens
     .map((token, index) => {
       const tokenId = token.id;
-      const cardId = tokenId.substring(0, 8);
+      const cardId = `${GEMINICLI_QUOTA_CARD_ID_PREFIX}-${tokenId.substring(0, 8)}`;
       const originalIndex = cachedGeminiCliTokens.findIndex(
         (t) => t.id === token.id,
       );
@@ -367,7 +369,15 @@ function renderGeminiCliTokens(tokens) {
                 <span class="token-id-label">🔑</span>
                 <span class="token-id-value">${escapeHtml(tokenId.length > 24 ? tokenId.substring(0, 12) + "..." + tokenId.substring(tokenId.length - 8) : tokenId)}</span>
             </div>
+            <div class="token-quota-inline" id="quota-inline-${escapeHtml(cardId)}">
+                <div class="quota-inline-header" onclick="toggleQuotaExpand('${escapeJs(cardId)}', '${safeTokenId}', 'geminicli')">
+                    <span class="quota-inline-summary" id="quota-summary-${escapeHtml(cardId)}">📊 加载中...</span>
+                    <span class="quota-inline-toggle" id="quota-toggle-${escapeHtml(cardId)}">▼</span>
+                </div>
+                <div class="quota-inline-detail hidden" id="quota-detail-${escapeHtml(cardId)}"></div>
+            </div>
             <div class="token-actions">
+                <button class="btn btn-info btn-xs" onclick="showQuotaModal('${safeTokenId}', 'geminicli')" title="查看额度">📊 详情</button>
                 <button class="btn ${token.enable ? "btn-warning" : "btn-success"} btn-xs" onclick="toggleGeminiCliToken('${safeTokenId}', ${!token.enable})" title="${token.enable ? "禁用" : "启用"}">
                     ${token.enable ? "⏸️ 禁用" : "▶️ 启用"}
                 </button>
@@ -377,6 +387,14 @@ function renderGeminiCliTokens(tokens) {
     `;
     })
     .join("");
+
+  filteredTokens.forEach((token) => {
+    loadTokenQuotaSummary(
+      token.id,
+      "geminicli",
+      `${GEMINICLI_QUOTA_CARD_ID_PREFIX}-${token.id.substring(0, 8)}`,
+    );
+  });
 
   updateSensitiveInfoDisplay();
 }

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -507,6 +507,51 @@ async function fetchGeminiCliProjectId(tokenId) {
   }
 }
 
+// 批量获取所有已启用 Gemini CLI Token 的 Project ID
+async function batchFetchGeminiCliProjectIds() {
+  if (!cachedGeminiCliTokens || cachedGeminiCliTokens.length === 0) {
+    showToast("没有可用的 Gemini CLI Token", "warning");
+    return;
+  }
+
+  const enabledTokens = cachedGeminiCliTokens.filter((token) => token.enable);
+  if (enabledTokens.length === 0) {
+    showToast("没有已启用的 Gemini CLI Token", "warning");
+    return;
+  }
+
+  showLoading(`正在批量获取 Project ID (0/${enabledTokens.length})...`);
+
+  try {
+    const response = await authFetch(
+      "/admin/geminicli/tokens/batch-fetch-project-ids",
+      {
+        method: "POST",
+      },
+    );
+    const data = await response.json();
+
+    hideLoading();
+
+    if (data.success) {
+      const successCount = Number(data.successCount) || 0;
+      const failCount = Number(data.failCount) || 0;
+      showToast(
+        `批量获取完成: 成功 ${successCount} 个，失败 ${failCount} 个`,
+        successCount > 0 ? "success" : "warning",
+      );
+      loadGeminiCliTokens();
+    } else {
+      showToast(`批量获取失败: ${data.message || "未知错误"}`, "error");
+    }
+  } catch (error) {
+    hideLoading();
+    if (error.message !== "Unauthorized") {
+      showToast(`批量获取失败: ${error.message}`, "error");
+    }
+  }
+}
+
 // 编辑 Gemini CLI Token 字段
 function editGeminiCliField(event, tokenId, field, currentValue) {
   event.stopPropagation();

--- a/public/js/geminicli.js
+++ b/public/js/geminicli.js
@@ -243,6 +243,11 @@ async function processGeminiCliOAuthCallback() {
         }
 
         successCount += 1;
+        if (result.disabled) {
+          errors.push(
+            `第${index + 1}行: 已导入但测试消息校验失败，凭证已放入禁用池 - ${result.message || "未知错误"}`,
+          );
+        }
       } catch (error) {
         errors.push(`第${index + 1}行: ${error.message}`);
       }
@@ -253,7 +258,11 @@ async function processGeminiCliOAuthCallback() {
     if (successCount > 0) {
       modal.remove();
       loadGeminiCliTokens();
-      const summary = [`成功添加 ${successCount} 个 Gemini CLI Token`];
+      const activeCount = Math.max(successCount - errors.length, 0);
+      const summary = [`成功接收 ${successCount} 个 Gemini CLI Token`];
+      if (activeCount > 0) {
+        summary.push(`其中 ${activeCount} 个通过测试并已启用`);
+      }
       if (errors.length > 0) {
         summary.push(`失败 ${errors.length} 条`);
       }
@@ -369,7 +378,9 @@ function renderGeminiCliTokens(tokens) {
                 ? "请求"
                 : token.lastErrorStage === "enable_test"
                   ? "启用验证"
-                  : token.lastErrorStage || "";
+                  : token.lastErrorStage === "oauth_submit"
+                    ? "OAuth提交校验"
+                    : token.lastErrorStage || "";
 
       return `
         <div class="token-card ${!token.enable ? "disabled" : ""}" id="geminicli-card-${escapeHtml(cardId)}">

--- a/public/js/quota.js
+++ b/public/js/quota.js
@@ -1,275 +1,328 @@
 // 额度管理：查看、刷新、缓存
 
 let currentQuotaToken = null;
+let currentQuotaMode = "antigravity";
 
 const quotaCache = {
-    data: {},
-    ttl: 5 * 60 * 1000,
-    maxSize: 50, // 最大缓存条目数
-    cleanupTimer: null,
+  data: {},
+  ttl: 5 * 60 * 1000,
+  maxSize: 50, // 最大缓存条目数
+  cleanupTimer: null,
 
-    get(tokenId) {
-        const cached = this.data[tokenId];
-        if (!cached) return null;
-        if (Date.now() - cached.timestamp > this.ttl) {
-            delete this.data[tokenId];
-            return null;
-        }
-        return cached.data;
-    },
-
-    set(tokenId, data) {
-        // 检查缓存大小，超出时清理最旧的条目
-        const keys = Object.keys(this.data);
-        if (keys.length >= this.maxSize) {
-            this._evictOldest(Math.ceil(this.maxSize * 0.2)); // 清理20%
-        }
-        this.data[tokenId] = { data, timestamp: Date.now() };
-    },
-
-    clear(tokenId) {
-        if (tokenId) {
-            delete this.data[tokenId];
-        } else {
-            this.data = {};
-        }
-    },
-
-    // 清理过期缓存
-    cleanup() {
-        const now = Date.now();
-        const keys = Object.keys(this.data);
-        let cleaned = 0;
-        for (const key of keys) {
-            if (now - this.data[key].timestamp > this.ttl) {
-                delete this.data[key];
-                cleaned++;
-            }
-        }
-        return cleaned;
-    },
-
-    // 清理最旧的 n 个条目
-    _evictOldest(n) {
-        const entries = Object.entries(this.data)
-            .sort((a, b) => a[1].timestamp - b[1].timestamp);
-        for (let i = 0; i < Math.min(n, entries.length); i++) {
-            delete this.data[entries[i][0]];
-        }
-    },
-
-    // 启动定期清理
-    startCleanupTimer() {
-        if (this.cleanupTimer) return;
-        this.cleanupTimer = setInterval(() => {
-            this.cleanup();
-        }, 60 * 1000); // 每分钟清理一次过期缓存
-    },
-
-    // 停止定期清理
-    stopCleanupTimer() {
-        if (this.cleanupTimer) {
-            clearInterval(this.cleanupTimer);
-            this.cleanupTimer = null;
-        }
-    },
-
-    // 获取缓存统计信息
-    getStats() {
-        return {
-            size: Object.keys(this.data).length,
-            maxSize: this.maxSize
-        };
+  get(tokenId) {
+    const cached = this.data[tokenId];
+    if (!cached) return null;
+    if (Date.now() - cached.timestamp > this.ttl) {
+      delete this.data[tokenId];
+      return null;
     }
+    return cached.data;
+  },
+
+  set(tokenId, data) {
+    // 检查缓存大小，超出时清理最旧的条目
+    const keys = Object.keys(this.data);
+    if (keys.length >= this.maxSize) {
+      this._evictOldest(Math.ceil(this.maxSize * 0.2)); // 清理20%
+    }
+    this.data[tokenId] = { data, timestamp: Date.now() };
+  },
+
+  clear(tokenId) {
+    if (tokenId) {
+      delete this.data[tokenId];
+    } else {
+      this.data = {};
+    }
+  },
+
+  // 清理过期缓存
+  cleanup() {
+    const now = Date.now();
+    const keys = Object.keys(this.data);
+    let cleaned = 0;
+    for (const key of keys) {
+      if (now - this.data[key].timestamp > this.ttl) {
+        delete this.data[key];
+        cleaned++;
+      }
+    }
+    return cleaned;
+  },
+
+  // 清理最旧的 n 个条目
+  _evictOldest(n) {
+    const entries = Object.entries(this.data).sort(
+      (a, b) => a[1].timestamp - b[1].timestamp,
+    );
+    for (let i = 0; i < Math.min(n, entries.length); i++) {
+      delete this.data[entries[i][0]];
+    }
+  },
+
+  // 启动定期清理
+  startCleanupTimer() {
+    if (this.cleanupTimer) return;
+    this.cleanupTimer = setInterval(() => {
+      this.cleanup();
+    }, 60 * 1000); // 每分钟清理一次过期缓存
+  },
+
+  // 停止定期清理
+  stopCleanupTimer() {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  },
+
+  // 获取缓存统计信息
+  getStats() {
+    return {
+      size: Object.keys(this.data).length,
+      maxSize: this.maxSize,
+    };
+  },
 };
 
 // 页面加载时启动缓存清理定时器
-if (typeof document !== 'undefined') {
-    quotaCache.startCleanupTimer();
+if (typeof document !== "undefined") {
+  quotaCache.startCleanupTimer();
 
-    // 页面卸载时清理
-    window.addEventListener('beforeunload', () => {
-        quotaCache.stopCleanupTimer();
-        quotaCache.clear();
-    });
+  // 页面卸载时清理
+  window.addEventListener("beforeunload", () => {
+    quotaCache.stopCleanupTimer();
+    quotaCache.clear();
+  });
 }
 
 const QUOTA_GROUPS = [
-    {
-        key: 'claude',
-        label: 'Claude',
-        iconSrc: '/assets/icons/claude.svg',
-        match: (modelId) => modelId.toLowerCase().includes('claude')
-    },
-    {
-        key: 'banana',
-        label: 'banana',
-        iconSrc: '/assets/icons/banana.svg',
-        match: (modelId) => modelId.toLowerCase().includes('gemini-3.1-flash-image')
-    },
-    {
-        key: 'gemini',
-        label: 'Gemini',
-        iconSrc: '/assets/icons/gemini.svg',
-        match: (modelId) => modelId.toLowerCase().includes('gemini') || modelId.toLowerCase().includes('publishers/google/')
-    },
-    {
-        key: 'other',
-        label: '其他',
-        iconSrc: '',
-        match: () => true
-    }
+  {
+    key: "claude",
+    label: "Claude",
+    iconSrc: "/assets/icons/claude.svg",
+    match: (modelId) => modelId.toLowerCase().includes("claude"),
+  },
+  {
+    key: "banana",
+    label: "banana",
+    iconSrc: "/assets/icons/banana.svg",
+    match: (modelId) =>
+      modelId.toLowerCase().includes("gemini-3.1-flash-image"),
+  },
+  {
+    key: "gemini",
+    label: "Gemini",
+    iconSrc: "/assets/icons/gemini.svg",
+    match: (modelId) =>
+      modelId.toLowerCase().includes("gemini") ||
+      modelId.toLowerCase().includes("publishers/google/"),
+  },
+  {
+    key: "other",
+    label: "其他",
+    iconSrc: "",
+    match: () => true,
+  },
 ];
 
-const QUOTA_SUMMARY_KEYS = ['claude', 'gemini', 'banana'];
+const QUOTA_SUMMARY_KEYS = ["claude", "gemini", "banana"];
 
 function getGroupIconHtml(group) {
-    const src = group?.iconSrc || '';
-    const alt = escapeHtml(group?.label || '');
-    const safeSrc = escapeHtml(src);
-    if (!safeSrc) return '';
-    return `<img class="quota-icon-img" src="${safeSrc}" alt="${alt}" loading="lazy" decoding="async">`;
+  const src = group?.iconSrc || "";
+  const alt = escapeHtml(group?.label || "");
+  const safeSrc = escapeHtml(src);
+  if (!safeSrc) return "";
+  return `<img class="quota-icon-img" src="${safeSrc}" alt="${alt}" loading="lazy" decoding="async">`;
 }
 
 function clamp01(value) {
-    const numberValue = Number(value);
-    if (!Number.isFinite(numberValue)) return 0;
-    return Math.min(1, Math.max(0, numberValue));
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) return 0;
+  return Math.min(1, Math.max(0, numberValue));
 }
 
 function toPercentage(fraction01) {
-    return clamp01(fraction01) * 100;
+  return clamp01(fraction01) * 100;
 }
 
 function formatPercentage(fraction01) {
-    return `${toPercentage(fraction01).toFixed(2)}%`;
+  return `${toPercentage(fraction01).toFixed(2)}%`;
 }
 
 function getBarColor(percentage) {
-    if (percentage > 50) return '#10b981';
-    if (percentage > 20) return '#f59e0b';
-    return '#ef4444';
+  if (percentage > 50) return "#10b981";
+  if (percentage > 20) return "#f59e0b";
+  return "#ef4444";
 }
 
 function groupModels(models) {
-    const grouped = { claude: [], gemini: [], banana: [], other: [] };
+  const grouped = { claude: [], gemini: [], banana: [], other: [] };
 
-    Object.entries(models || {}).forEach(([modelId, quota]) => {
-        const groupKey = (QUOTA_GROUPS.find(g => g.match(modelId)) || QUOTA_GROUPS[QUOTA_GROUPS.length - 1]).key;
-        if (!grouped[groupKey]) grouped[groupKey] = [];
-        grouped[groupKey].push({ modelId, quota });
-    });
+  Object.entries(models || {}).forEach(([modelId, quota]) => {
+    const groupKey = (
+      QUOTA_GROUPS.find((g) => g.match(modelId)) ||
+      QUOTA_GROUPS[QUOTA_GROUPS.length - 1]
+    ).key;
+    if (!grouped[groupKey]) grouped[groupKey] = [];
+    grouped[groupKey].push({ modelId, quota });
+  });
 
-    return grouped;
+  return grouped;
 }
 
 // 不同模型系列的每次请求消耗百分比（与后端 GROUP_COST_PERCENT 保持一致）
 const GROUP_COST_PERCENT = {
-    claude: 0.6667,
-    gemini: 0.6667,
-    banana: 5.0,    // 图片生成模型消耗更高，约 20 次/满额
-    other: 0.6667
+  claude: 0.6667,
+  gemini: 0.6667,
+  banana: 5.0, // 图片生成模型消耗更高，约 20 次/满额
+  other: 0.6667,
 };
 
 function summarizeGroup(items, requestCount = 0, groupKey = null) {
-    if (!items || items.length === 0) {
-        return { percentage: 0, percentageText: '--', resetTime: '--', estimatedRequests: 0 };
-    }
-
-    let minRemaining = 1;
-    let earliestResetMs = null;
-    let earliestResetText = null;
-
-    items.forEach(({ quota }) => {
-        const remaining = clamp01(quota?.remaining);
-        if (remaining < minRemaining) minRemaining = remaining;
-
-        const resetRaw = quota?.resetTimeRaw;
-        const resetText = quota?.resetTime;
-
-        if (resetRaw) {
-            const ms = Date.parse(resetRaw);
-            if (Number.isFinite(ms) && (earliestResetMs === null || ms < earliestResetMs)) {
-                earliestResetMs = ms;
-                earliestResetText = resetText || null;
-            }
-        } else if (!earliestResetText && resetText) {
-            earliestResetText = resetText;
-        }
-    });
-
-    // 根据模型系列使用不同的消耗率
-    const costPercent = (groupKey && GROUP_COST_PERCENT[groupKey]) || 0.6667;
-    // 基于当前阈值计算总的可用次数，然后减去已记录的请求次数
-    const percentageValue = toPercentage(minRemaining);
-    const totalFromThreshold = Math.floor(percentageValue / costPercent);
-    const estimatedRequests = Math.max(0, totalFromThreshold - requestCount);
-
+  if (!items || items.length === 0) {
     return {
-        percentage: percentageValue,
-        percentageText: formatPercentage(minRemaining),
-        resetTime: earliestResetText || '--',
-        estimatedRequests
+      percentage: 0,
+      percentageText: "--",
+      resetTime: "--",
+      estimatedRequests: 0,
     };
+  }
+
+  let minRemaining = 1;
+  let earliestResetMs = null;
+  let earliestResetText = null;
+
+  items.forEach(({ quota }) => {
+    const remaining = clamp01(quota?.remaining);
+    if (remaining < minRemaining) minRemaining = remaining;
+
+    const resetRaw = quota?.resetTimeRaw;
+    const resetText = quota?.resetTime;
+
+    if (resetRaw) {
+      const ms = Date.parse(resetRaw);
+      if (
+        Number.isFinite(ms) &&
+        (earliestResetMs === null || ms < earliestResetMs)
+      ) {
+        earliestResetMs = ms;
+        earliestResetText = resetText || null;
+      }
+    } else if (!earliestResetText && resetText) {
+      earliestResetText = resetText;
+    }
+  });
+
+  // 根据模型系列使用不同的消耗率
+  const costPercent = (groupKey && GROUP_COST_PERCENT[groupKey]) || 0.6667;
+  // 基于当前阈值计算总的可用次数，然后减去已记录的请求次数
+  const percentageValue = toPercentage(minRemaining);
+  const totalFromThreshold = Math.floor(percentageValue / costPercent);
+  const estimatedRequests = Math.max(0, totalFromThreshold - requestCount);
+
+  return {
+    percentage: percentageValue,
+    percentageText: formatPercentage(minRemaining),
+    resetTime: earliestResetText || "--",
+    estimatedRequests,
+  };
+}
+
+function getQuotaCacheKey(tokenId, mode = "antigravity") {
+  return `${mode}:${tokenId}`;
+}
+
+function getQuotaEndpoint(tokenId, mode = "antigravity", forceRefresh = false) {
+  const base =
+    mode === "geminicli"
+      ? `/admin/geminicli/tokens/${encodeURIComponent(tokenId)}/quotas`
+      : `/admin/tokens/${encodeURIComponent(tokenId)}/quotas`;
+  return forceRefresh ? `${base}?refresh=true` : base;
+}
+
+function getTokenListByMode(mode = "antigravity") {
+  if (mode === "geminicli") {
+    if (typeof cachedGeminiCliTokens !== "undefined") {
+      return cachedGeminiCliTokens || [];
+    }
+    return [];
+  }
+  return typeof cachedTokens !== "undefined" ? cachedTokens : [];
 }
 
 // 使用 tokenId 加载额度摘要
-async function loadTokenQuotaSummary(tokenId) {
-    const cardId = tokenId.substring(0, 8);
-    const summaryEl = document.getElementById(`quota-summary-${cardId}`);
-    if (!summaryEl) return;
+async function loadTokenQuotaSummary(
+  tokenId,
+  mode = "antigravity",
+  cardIdOverride = null,
+) {
+  const cardId = cardIdOverride || tokenId.substring(0, 8);
+  const summaryEl = document.getElementById(`quota-summary-${cardId}`);
+  if (!summaryEl) return;
 
-    const cached = quotaCache.get(tokenId);
-    if (cached) {
-        renderQuotaSummary(summaryEl, cached);
-        return;
+  const cacheKey = getQuotaCacheKey(tokenId, mode);
+  const cached = quotaCache.get(cacheKey);
+  if (cached) {
+    renderQuotaSummary(summaryEl, cached);
+    return;
+  }
+
+  try {
+    const response = await authFetch(getQuotaEndpoint(tokenId, mode));
+    const data = await response.json();
+
+    if (data.success && data.data && data.data.models) {
+      quotaCache.set(cacheKey, data.data);
+      renderQuotaSummary(summaryEl, data.data);
+    } else if (data.success && data.data) {
+      // 禁用的 token 可能返回空数据
+      renderQuotaSummary(summaryEl, data.data);
+    } else {
+      const errMsg = escapeHtml(data.message || "未知错误");
+      summaryEl.innerHTML = `<span class="quota-summary-error">📊 ${errMsg}</span>`;
     }
-
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}/quotas`);
-        const data = await response.json();
-
-        if (data.success && data.data && data.data.models) {
-            quotaCache.set(tokenId, data.data);
-            renderQuotaSummary(summaryEl, data.data);
-        } else if (data.success && data.data) {
-            // 禁用的 token 可能返回空数据
-            renderQuotaSummary(summaryEl, data.data);
-        } else {
-            const errMsg = escapeHtml(data.message || '未知错误');
-            summaryEl.innerHTML = `<span class="quota-summary-error">📊 ${errMsg}</span>`;
-        }
-    } catch (error) {
-        if (error.message !== 'Unauthorized') {
-            console.error('加载额度摘要失败:', error);
-            summaryEl.innerHTML = `<span class="quota-summary-error">📊 加载失败</span>`;
-        }
+  } catch (error) {
+    if (error.message !== "Unauthorized") {
+      console.error("加载额度摘要失败:", error);
+      summaryEl.innerHTML = `<span class="quota-summary-error">📊 加载失败</span>`;
     }
+  }
 }
 
 function renderQuotaSummary(summaryEl, quotaData) {
-    const models = quotaData.models;
-    const requestCounts = quotaData.requestCounts || {};
-    const modelEntries = Object.entries(models || {});
+  const models = quotaData.models;
+  const requestCounts = quotaData.requestCounts || {};
+  const modelEntries = Object.entries(models || {});
 
-    if (modelEntries.length === 0) {
-        summaryEl.textContent = '📊 暂无额度';
-        return;
-    }
+  if (modelEntries.length === 0) {
+    summaryEl.textContent = "📊 暂无额度";
+    return;
+  }
 
-    const grouped = groupModels(models);
-    const groupByKey = Object.fromEntries(QUOTA_GROUPS.map(g => [g.key, g]));
+  const grouped = groupModels(models);
+  const groupByKey = Object.fromEntries(QUOTA_GROUPS.map((g) => [g.key, g]));
 
-    const rowsHtml = QUOTA_SUMMARY_KEYS.map((groupKey) => {
-        const group = groupByKey[groupKey];
-        const summary = summarizeGroup(grouped[groupKey], requestCounts[groupKey] || 0, groupKey);
-        const barColor = summary.percentageText === '--' ? '#9ca3af' : getBarColor(summary.percentage);
-        const safeResetTime = escapeHtml(summary.resetTime);
-        const resetText = safeResetTime === '--' ? '--' : `重置: ${safeResetTime}`;
-        const estimatedText = summary.estimatedRequests > 0 ? ` · 约${summary.estimatedRequests}次` : '';
-        const safeLabel = escapeHtml(group?.label || groupKey);
-        const title = `${group?.label || groupKey} - 重置: ${summary.resetTime} - 预估可用: ${summary.estimatedRequests}次`;
-        return `
+  const rowsHtml = QUOTA_SUMMARY_KEYS.map((groupKey) => {
+    const group = groupByKey[groupKey];
+    const summary = summarizeGroup(
+      grouped[groupKey],
+      requestCounts[groupKey] || 0,
+      groupKey,
+    );
+    const barColor =
+      summary.percentageText === "--"
+        ? "#9ca3af"
+        : getBarColor(summary.percentage);
+    const safeResetTime = escapeHtml(summary.resetTime);
+    const resetText = safeResetTime === "--" ? "--" : `重置: ${safeResetTime}`;
+    const estimatedText =
+      summary.estimatedRequests > 0
+        ? ` · 约${summary.estimatedRequests}次`
+        : "";
+    const safeLabel = escapeHtml(group?.label || groupKey);
+    const title = `${group?.label || groupKey} - 重置: ${summary.resetTime} - 预估可用: ${summary.estimatedRequests}次`;
+    return `
             <div class="quota-summary-row" title="${escapeHtml(title)}">
                 <span class="quota-summary-icon">${getGroupIconHtml(group)}</span>
                 <span class="quota-summary-label">${safeLabel}</span>
@@ -278,77 +331,84 @@ function renderQuotaSummary(summaryEl, quotaData) {
                 <span class="quota-summary-reset">${resetText}${estimatedText}</span>
             </div>
         `;
-    }).join('');
+  }).join("");
 
-    summaryEl.innerHTML = `
+  summaryEl.innerHTML = `
         <div class="quota-summary-grid">
             ${rowsHtml}
         </div>
     `;
 }
 
-async function toggleQuotaExpand(cardId, tokenId) {
-    const detailEl = document.getElementById(`quota-detail-${cardId}`);
-    const toggleEl = document.getElementById(`quota-toggle-${cardId}`);
-    if (!detailEl || !toggleEl) return;
+async function toggleQuotaExpand(cardId, tokenId, mode = "antigravity") {
+  const detailEl = document.getElementById(`quota-detail-${cardId}`);
+  const toggleEl = document.getElementById(`quota-toggle-${cardId}`);
+  if (!detailEl || !toggleEl) return;
 
-    const isHidden = detailEl.classList.contains('hidden');
+  const isHidden = detailEl.classList.contains("hidden");
 
-    if (isHidden) {
-        detailEl.classList.remove('hidden');
-        detailEl.classList.remove('collapsing');
-        toggleEl.classList.add('expanded');
+  if (isHidden) {
+    detailEl.classList.remove("hidden");
+    detailEl.classList.remove("collapsing");
+    toggleEl.classList.add("expanded");
 
-        if (!detailEl.dataset.loaded) {
-            detailEl.innerHTML = '<div class="quota-loading-small">加载中...</div>';
-            await loadQuotaDetail(cardId, tokenId);
-            detailEl.dataset.loaded = 'true';
-        }
-    } else {
-        // 添加收起动画
-        detailEl.classList.add('collapsing');
-        toggleEl.classList.remove('expanded');
-
-        // 动画结束后隐藏
-        setTimeout(() => {
-            detailEl.classList.add('hidden');
-            detailEl.classList.remove('collapsing');
-        }, 200);
+    if (!detailEl.dataset.loaded) {
+      detailEl.innerHTML = '<div class="quota-loading-small">加载中...</div>';
+      await loadQuotaDetail(cardId, tokenId, mode);
+      detailEl.dataset.loaded = "true";
     }
+  } else {
+    // 添加收起动画
+    detailEl.classList.add("collapsing");
+    toggleEl.classList.remove("expanded");
+
+    // 动画结束后隐藏
+    setTimeout(() => {
+      detailEl.classList.add("hidden");
+      detailEl.classList.remove("collapsing");
+    }, 200);
+  }
 }
 
-async function loadQuotaDetail(cardId, tokenId) {
-    const detailEl = document.getElementById(`quota-detail-${cardId}`);
-    if (!detailEl) return;
+async function loadQuotaDetail(cardId, tokenId, mode = "antigravity") {
+  const detailEl = document.getElementById(`quota-detail-${cardId}`);
+  if (!detailEl) return;
 
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}/quotas`);
-        const data = await response.json();
+  try {
+    const response = await authFetch(getQuotaEndpoint(tokenId, mode));
+    const data = await response.json();
 
-        if (data.success && data.data && data.data.models) {
-            const models = data.data.models;
-            const modelEntries = Object.entries(models);
+    if (data.success && data.data && data.data.models) {
+      const models = data.data.models;
+      const modelEntries = Object.entries(models);
 
-            if (modelEntries.length === 0) {
-                detailEl.innerHTML = '<div class="quota-empty-small">暂无额度信息</div>';
-                return;
-            }
+      if (modelEntries.length === 0) {
+        detailEl.innerHTML =
+          '<div class="quota-empty-small">暂无额度信息</div>';
+        return;
+      }
 
-            const grouped = groupModels(models);
+      const grouped = groupModels(models);
 
-            let html = '<div class="quota-detail-grid">';
+      let html = '<div class="quota-detail-grid">';
 
-            const renderGroup = (items, icon) => {
-                if (items.length === 0) return '';
-                let groupHtml = '';
-                items.forEach(({ modelId, quota }) => {
-                    const percentage = toPercentage(quota?.remaining);
-                    const percentageText = formatPercentage(quota?.remaining);
-                    const barColor = getBarColor(percentage);
-                    const shortName = escapeHtml(modelId.replace('models/', '').replace('publishers/google/', '').split('/').pop());
-                    const safeModelId = escapeHtml(modelId);
-                    const safeResetTime = escapeHtml(quota.resetTime);
-                    groupHtml += `
+      const renderGroup = (items, icon) => {
+        if (items.length === 0) return "";
+        let groupHtml = "";
+        items.forEach(({ modelId, quota }) => {
+          const percentage = toPercentage(quota?.remaining);
+          const percentageText = formatPercentage(quota?.remaining);
+          const barColor = getBarColor(percentage);
+          const shortName = escapeHtml(
+            modelId
+              .replace("models/", "")
+              .replace("publishers/google/", "")
+              .split("/")
+              .pop(),
+          );
+          const safeModelId = escapeHtml(modelId);
+          const safeResetTime = escapeHtml(quota.resetTime);
+          groupHtml += `
                         <div class="quota-detail-row" title="${safeModelId} - 重置: ${safeResetTime}">
                             <span class="quota-detail-icon">${icon}</span>
                             <span class="quota-detail-name">${shortName}</span>
@@ -356,72 +416,81 @@ async function loadQuotaDetail(cardId, tokenId) {
                             <span class="quota-detail-pct">${percentageText}</span>
                         </div>
                     `;
-                });
-                return groupHtml;
-            };
+        });
+        return groupHtml;
+      };
 
-            const groupByKey = Object.fromEntries(QUOTA_GROUPS.map(g => [g.key, g]));
-            html += renderGroup(grouped.claude, getGroupIconHtml(groupByKey.claude));
-            html += renderGroup(grouped.gemini, getGroupIconHtml(groupByKey.gemini));
-            html += renderGroup(grouped.banana, getGroupIconHtml(groupByKey.banana));
-            html += renderGroup(grouped.other, '');
-            html += '</div>';
-            html += `<button class="btn btn-info btn-xs quota-refresh-btn" onclick="refreshInlineQuota('${escapeJs(cardId)}', '${escapeJs(tokenId)}')">🔄 刷新额度</button>`;
+      const groupByKey = Object.fromEntries(
+        QUOTA_GROUPS.map((g) => [g.key, g]),
+      );
+      html += renderGroup(grouped.claude, getGroupIconHtml(groupByKey.claude));
+      html += renderGroup(grouped.gemini, getGroupIconHtml(groupByKey.gemini));
+      html += renderGroup(grouped.banana, getGroupIconHtml(groupByKey.banana));
+      html += renderGroup(grouped.other, "");
+      html += "</div>";
+      html += `<button class="btn btn-info btn-xs quota-refresh-btn" onclick="refreshInlineQuota('${escapeJs(cardId)}', '${escapeJs(tokenId)}', '${escapeJs(mode)}')">🔄 刷新额度</button>`;
 
-            detailEl.innerHTML = html;
-        } else {
-            const errMsg = escapeHtml(data.message || '未知错误');
-            detailEl.innerHTML = `<div class="quota-error-small">加载失败: ${errMsg}</div>`;
-        }
-    } catch (error) {
-        if (error.message !== 'Unauthorized') {
-            detailEl.innerHTML = `<div class="quota-error-small">网络错误</div>`;
-        }
+      detailEl.innerHTML = html;
+    } else {
+      const errMsg = escapeHtml(data.message || "未知错误");
+      detailEl.innerHTML = `<div class="quota-error-small">加载失败: ${errMsg}</div>`;
     }
+  } catch (error) {
+    if (error.message !== "Unauthorized") {
+      detailEl.innerHTML = `<div class="quota-error-small">网络错误</div>`;
+    }
+  }
 }
 
-async function refreshInlineQuota(cardId, tokenId) {
-    const detailEl = document.getElementById(`quota-detail-${cardId}`);
-    const summaryEl = document.getElementById(`quota-summary-${cardId}`);
+async function refreshInlineQuota(cardId, tokenId, mode = "antigravity") {
+  const detailEl = document.getElementById(`quota-detail-${cardId}`);
+  const summaryEl = document.getElementById(`quota-summary-${cardId}`);
 
-    if (detailEl) detailEl.innerHTML = '<div class="quota-loading-small">刷新中...</div>';
-    if (summaryEl) summaryEl.textContent = '📊 刷新中...';
+  if (detailEl)
+    detailEl.innerHTML = '<div class="quota-loading-small">刷新中...</div>';
+  if (summaryEl) summaryEl.textContent = "📊 刷新中...";
 
-    quotaCache.clear(tokenId);
+  const cacheKey = getQuotaCacheKey(tokenId, mode);
+  quotaCache.clear(cacheKey);
 
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}/quotas?refresh=true`);
-        const data = await response.json();
-        if (data.success && data.data) {
-            quotaCache.set(tokenId, data.data);
-        }
-    } catch (e) { }
+  try {
+    const response = await authFetch(getQuotaEndpoint(tokenId, mode, true));
+    const data = await response.json();
+    if (data.success && data.data) {
+      quotaCache.set(cacheKey, data.data);
+    }
+  } catch (e) {}
 
-    await loadTokenQuotaSummary(tokenId);
-    await loadQuotaDetail(cardId, tokenId);
+  await loadTokenQuotaSummary(tokenId, mode, cardId);
+  await loadQuotaDetail(cardId, tokenId, mode);
 }
 
 // 存储当前弹窗的事件处理器引用，便于清理
 let quotaModalWheelHandler = null;
 
-async function showQuotaModal(tokenId) {
-    currentQuotaToken = tokenId;
+async function showQuotaModal(tokenId, mode = "antigravity") {
+  currentQuotaToken = tokenId;
+  currentQuotaMode = mode;
 
-    const activeIndex = cachedTokens.findIndex(t => t.id === tokenId);
+  const tokenList = getTokenListByMode(mode);
+  const activeIndex = tokenList.findIndex((t) => t.id === tokenId);
 
-    const emailTabs = cachedTokens.map((t, index) => {
-        const email = t.email || '未知';
-        const shortEmail = email.length > 20 ? email.substring(0, 17) + '...' : email;
-        const isActive = index === activeIndex;
-        const safeEmail = escapeHtml(email);
-        const safeShortEmail = escapeHtml(shortEmail);
-        return `<button type="button" class="quota-tab${isActive ? ' active' : ''}" data-index="${index}" onclick="switchQuotaAccountByIndex(${index})" title="${safeEmail}">${safeShortEmail}</button>`;
-    }).join('');
+  const emailTabs = tokenList
+    .map((t, index) => {
+      const email = t.email || "未知";
+      const shortEmail =
+        email.length > 20 ? email.substring(0, 17) + "..." : email;
+      const isActive = index === activeIndex;
+      const safeEmail = escapeHtml(email);
+      const safeShortEmail = escapeHtml(shortEmail);
+      return `<button type="button" class="quota-tab${isActive ? " active" : ""}" data-index="${index}" onclick="switchQuotaAccountByIndex(${index})" title="${safeEmail}">${safeShortEmail}</button>`;
+    })
+    .join("");
 
-    const modal = document.createElement('div');
-    modal.className = 'modal';
-    modal.id = 'quotaModal';
-    modal.innerHTML = `
+  const modal = document.createElement("div");
+  modal.className = "modal";
+  modal.id = "quotaModal";
+  modal.innerHTML = `
         <div class="modal-content modal-xl">
             <div class="quota-modal-header">
                 <div class="modal-title">📊 模型额度</div>
@@ -439,214 +508,243 @@ async function showQuotaModal(tokenId) {
             </div>
         </div>
     `;
-    document.body.appendChild(modal);
+  document.body.appendChild(modal);
 
-    // 关闭弹窗时清理事件监听器
-    modal.onclick = (e) => {
-        if (e.target === modal) {
-            closeQuotaModal();
-        }
-    };
-
-    await loadQuotaData(tokenId);
-
-    const tabsContainer = document.getElementById('quotaEmailList');
-    if (tabsContainer) {
-        // 创建事件处理器并保存引用
-        quotaModalWheelHandler = (e) => {
-            if (e.deltaY !== 0) {
-                e.preventDefault();
-                tabsContainer.scrollLeft += e.deltaY;
-            }
-        };
-        tabsContainer.addEventListener('wheel', quotaModalWheelHandler, { passive: false });
+  // 关闭弹窗时清理事件监听器
+  modal.onclick = (e) => {
+    if (e.target === modal) {
+      closeQuotaModal();
     }
+  };
+
+  await loadQuotaData(tokenId, false, mode);
+
+  const tabsContainer = document.getElementById("quotaEmailList");
+  if (tabsContainer) {
+    // 创建事件处理器并保存引用
+    quotaModalWheelHandler = (e) => {
+      if (e.deltaY !== 0) {
+        e.preventDefault();
+        tabsContainer.scrollLeft += e.deltaY;
+      }
+    };
+    tabsContainer.addEventListener("wheel", quotaModalWheelHandler, {
+      passive: false,
+    });
+  }
 }
 
 // 关闭额度弹窗并清理事件监听器
 function closeQuotaModal() {
-    const modal = document.getElementById('quotaModal');
+  const modal = document.getElementById("quotaModal");
 
-    // 清理滚轮事件监听器
-    if (quotaModalWheelHandler) {
-        const tabsContainer = document.getElementById('quotaEmailList');
-        if (tabsContainer) {
-            tabsContainer.removeEventListener('wheel', quotaModalWheelHandler);
-        }
-        quotaModalWheelHandler = null;
+  // 清理滚轮事件监听器
+  if (quotaModalWheelHandler) {
+    const tabsContainer = document.getElementById("quotaEmailList");
+    if (tabsContainer) {
+      tabsContainer.removeEventListener("wheel", quotaModalWheelHandler);
     }
+    quotaModalWheelHandler = null;
+  }
 
-    if (modal) {
-        modal.remove();
-    }
+  if (modal) {
+    modal.remove();
+  }
 
-    currentQuotaToken = null;
+  currentQuotaToken = null;
 }
 
 async function switchQuotaAccountByIndex(index) {
-    if (index < 0 || index >= cachedTokens.length) return;
+  const tokenList = getTokenListByMode(currentQuotaMode);
+  if (index < 0 || index >= tokenList.length) return;
 
-    const token = cachedTokens[index];
-    currentQuotaToken = token.id;
+  const token = tokenList[index];
+  currentQuotaToken = token.id;
 
-    document.querySelectorAll('.quota-tab').forEach((tab, i) => {
-        if (i === index) {
-            tab.classList.add('active');
-        } else {
-            tab.classList.remove('active');
-        }
-    });
-
-    await loadQuotaData(token.id);
-}
-
-async function switchQuotaAccount(tokenId) {
-    const index = cachedTokens.findIndex(t => t.id === tokenId);
-    if (index >= 0) {
-        await switchQuotaAccountByIndex(index);
-    }
-}
-
-async function loadQuotaData(tokenId, forceRefresh = false) {
-    const quotaContent = document.getElementById('quotaContent');
-    if (!quotaContent) return;
-
-    const refreshBtn = document.getElementById('quotaRefreshBtn');
-    if (refreshBtn) {
-        refreshBtn.disabled = true;
-        refreshBtn.textContent = '⏳ 加载中...';
-    }
-
-    if (!forceRefresh) {
-        const cached = quotaCache.get(tokenId);
-        if (cached) {
-            renderQuotaModal(quotaContent, cached);
-            if (refreshBtn) {
-                refreshBtn.disabled = false;
-                refreshBtn.textContent = '🔄 刷新';
-            }
-            return;
-        }
+  document.querySelectorAll(".quota-tab").forEach((tab, i) => {
+    if (i === index) {
+      tab.classList.add("active");
     } else {
-        quotaCache.clear(tokenId);
+      tab.classList.remove("active");
     }
+  });
 
-    quotaContent.innerHTML = '<div class="quota-loading">加载中...</div>';
+  await loadQuotaData(token.id, false, currentQuotaMode);
+}
 
-    try {
-        const url = `/admin/tokens/${encodeURIComponent(tokenId)}/quotas${forceRefresh ? '?refresh=true' : ''}`;
-        const response = await authFetch(url);
+async function switchQuotaAccount(tokenId, mode = "antigravity") {
+  currentQuotaMode = mode;
+  const tokenList = getTokenListByMode(mode);
+  const index = tokenList.findIndex((t) => t.id === tokenId);
+  if (index >= 0) {
+    await switchQuotaAccountByIndex(index);
+  }
+}
 
-        const data = await response.json();
+async function loadQuotaData(
+  tokenId,
+  forceRefresh = false,
+  mode = "antigravity",
+) {
+  const quotaContent = document.getElementById("quotaContent");
+  if (!quotaContent) return;
 
-        if (data.success) {
-            quotaCache.set(tokenId, data.data);
-            renderQuotaModal(quotaContent, data.data);
-        } else {
-            quotaContent.innerHTML = `<div class="quota-error">加载失败: ${escapeHtml(data.message)}</div>`;
-        }
-    } catch (error) {
-        if (quotaContent) {
-            quotaContent.innerHTML = `<div class="quota-error">加载失败: ${escapeHtml(error.message)}</div>`;
-        }
-    } finally {
-        if (refreshBtn) {
-            refreshBtn.disabled = false;
-            refreshBtn.textContent = '🔄 刷新';
-        }
+  const refreshBtn = document.getElementById("quotaRefreshBtn");
+  if (refreshBtn) {
+    refreshBtn.disabled = true;
+    refreshBtn.textContent = "⏳ 加载中...";
+  }
+
+  if (!forceRefresh) {
+    const cached = quotaCache.get(getQuotaCacheKey(tokenId, mode));
+    if (cached) {
+      renderQuotaModal(quotaContent, cached);
+      if (refreshBtn) {
+        refreshBtn.disabled = false;
+        refreshBtn.textContent = "🔄 刷新";
+      }
+      return;
     }
+  } else {
+    quotaCache.clear(getQuotaCacheKey(tokenId, mode));
+  }
+
+  quotaContent.innerHTML = '<div class="quota-loading">加载中...</div>';
+
+  try {
+    const response = await authFetch(
+      getQuotaEndpoint(tokenId, mode, forceRefresh),
+    );
+
+    const data = await response.json();
+
+    if (data.success) {
+      quotaCache.set(getQuotaCacheKey(tokenId, mode), data.data);
+      renderQuotaModal(quotaContent, data.data);
+    } else {
+      quotaContent.innerHTML = `<div class="quota-error">加载失败: ${escapeHtml(data.message)}</div>`;
+    }
+  } catch (error) {
+    if (quotaContent) {
+      quotaContent.innerHTML = `<div class="quota-error">加载失败: ${escapeHtml(error.message)}</div>`;
+    }
+  } finally {
+    if (refreshBtn) {
+      refreshBtn.disabled = false;
+      refreshBtn.textContent = "🔄 刷新";
+    }
+  }
 }
 
 async function refreshQuotaData() {
-    if (currentQuotaToken) {
-        await loadQuotaData(currentQuotaToken, true);
-    }
+  if (currentQuotaToken) {
+    await loadQuotaData(currentQuotaToken, true, currentQuotaMode);
+  }
 }
 
 // 刷新所有 Token 的额度数据
-async function refreshAllQuotas() {
-    if (!cachedTokens || cachedTokens.length === 0) {
-        showToast('没有可刷新的 Token', 'warning');
-        return;
-    }
+async function refreshAllQuotas(mode = "antigravity") {
+  const tokenList = getTokenListByMode(mode);
+  if (!tokenList || tokenList.length === 0) {
+    showToast("没有可刷新的 Token", "warning");
+    return;
+  }
 
-    // 过滤出启用的 token，禁用的不刷新
-    const enabledTokens = cachedTokens.filter(t => t.enable !== false);
-    if (enabledTokens.length === 0) {
-        showToast('没有已启用的 Token 可刷新', 'warning');
-        return;
-    }
+  // 过滤出启用的 token，禁用的不刷新
+  const enabledTokens = tokenList.filter((t) => t.enable !== false);
+  if (enabledTokens.length === 0) {
+    showToast("没有已启用的 Token 可刷新", "warning");
+    return;
+  }
 
-    const btn = document.getElementById('refreshQuotasBtn');
-    if (btn) {
-        btn.disabled = true;
-        btn.textContent = '⏳ 刷新中...';
-    }
+  const btn = document.getElementById("refreshQuotasBtn");
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = "⏳ 刷新中...";
+  }
 
-    // 只清除启用 token 的缓存
-    enabledTokens.forEach(t => quotaCache.clear(t.id));
+  // 只清除启用 token 的缓存
+  enabledTokens.forEach((t) => quotaCache.clear(getQuotaCacheKey(t.id, mode)));
 
-    try {
-        // 并行刷新已启用 Token 的额度
-        const refreshPromises = enabledTokens.map(async (token) => {
-            try {
-                const response = await authFetch(`/admin/tokens/${encodeURIComponent(token.id)}/quotas?refresh=true`);
-                const data = await response.json();
-                if (data.success && data.data) {
-                    quotaCache.set(token.id, data.data);
-                }
-            } catch (e) {
-                // 单个 Token 刷新失败不影响其他
-                console.error(`刷新 Token ${token.email || token.id.substring(0, 8)} 额度失败:`, e);
-            }
-        });
-
-        await Promise.all(refreshPromises);
-
-        // 重新渲染启用 token 的额度摘要
-        enabledTokens.forEach(token => {
-            loadTokenQuotaSummary(token.id);
-        });
-
-        showToast(`已刷新 ${enabledTokens.length} 个 Token 的额度`, 'success');
-    } catch (error) {
-        showToast('刷新额度失败: ' + error.message, 'error');
-    } finally {
-        if (btn) {
-            btn.disabled = false;
-            btn.textContent = '📊 刷新额度';
+  try {
+    // 并行刷新已启用 Token 的额度
+    const refreshPromises = enabledTokens.map(async (token) => {
+      try {
+        const response = await authFetch(
+          getQuotaEndpoint(token.id, mode, true),
+        );
+        const data = await response.json();
+        if (data.success && data.data) {
+          quotaCache.set(getQuotaCacheKey(token.id, mode), data.data);
         }
+      } catch (e) {
+        // 单个 Token 刷新失败不影响其他
+        console.error(
+          `刷新 Token ${token.email || token.id.substring(0, 8)} 额度失败:`,
+          e,
+        );
+      }
+    });
+
+    await Promise.all(refreshPromises);
+
+    // 重新渲染启用 token 的额度摘要
+    enabledTokens.forEach((token) => {
+      loadTokenQuotaSummary(token.id, mode);
+    });
+
+    showToast(`已刷新 ${enabledTokens.length} 个 Token 的额度`, "success");
+  } catch (error) {
+    showToast("刷新额度失败: " + error.message, "error");
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = "📊 刷新额度";
     }
+  }
 }
 
 function renderQuotaModal(quotaContent, quotaData) {
-    const models = quotaData.models;
-    const requestCounts = quotaData.requestCounts || {};
+  const models = quotaData.models;
+  const requestCounts = quotaData.requestCounts || {};
 
-    const updateTimeEl = document.getElementById('quotaUpdateTime');
-    if (updateTimeEl && quotaData.lastUpdated) {
-        const lastUpdated = new Date(quotaData.lastUpdated).toLocaleString('zh-CN', {
-            month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'
-        });
-        updateTimeEl.textContent = `更新于 ${lastUpdated}`;
-    }
+  const updateTimeEl = document.getElementById("quotaUpdateTime");
+  if (updateTimeEl && quotaData.lastUpdated) {
+    const lastUpdated = new Date(quotaData.lastUpdated).toLocaleString(
+      "zh-CN",
+      {
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+      },
+    );
+    updateTimeEl.textContent = `更新于 ${lastUpdated}`;
+  }
 
-    if (Object.keys(models).length === 0) {
-        quotaContent.innerHTML = '<div class="quota-empty">暂无额度信息</div>';
-        return;
-    }
+  if (Object.keys(models).length === 0) {
+    quotaContent.innerHTML = '<div class="quota-empty">暂无额度信息</div>';
+    return;
+  }
 
-    const grouped = groupModels(models);
+  const grouped = groupModels(models);
 
-    let html = '';
+  let html = "";
 
-    const renderGroup = (items, group, groupKey) => {
-        const summary = summarizeGroup(items, requestCounts[groupKey] || 0, groupKey);
-        const safeLabel = escapeHtml(group.label);
-        const safeResetTime = escapeHtml(summary.resetTime);
-        const estimatedText = summary.estimatedRequests > 0 ? ` · 约${summary.estimatedRequests}次` : '';
-        const iconHtml = getGroupIconHtml(group);
-        let groupHtml = `
+  const renderGroup = (items, group, groupKey) => {
+    const summary = summarizeGroup(
+      items,
+      requestCounts[groupKey] || 0,
+      groupKey,
+    );
+    const safeLabel = escapeHtml(group.label);
+    const safeResetTime = escapeHtml(summary.resetTime);
+    const estimatedText =
+      summary.estimatedRequests > 0
+        ? ` · 约${summary.estimatedRequests}次`
+        : "";
+    const iconHtml = getGroupIconHtml(group);
+    let groupHtml = `
             <div class="quota-group-title">
                 <span class="quota-group-left">
                     <span class="quota-group-icon">${iconHtml}</span>
@@ -656,20 +754,22 @@ function renderQuotaModal(quotaContent, quotaData) {
             </div>
         `;
 
-        if (items.length === 0) {
-            groupHtml += '<div class="quota-empty-small">暂无</div>';
-            return groupHtml;
-        }
+    if (items.length === 0) {
+      groupHtml += '<div class="quota-empty-small">暂无</div>';
+      return groupHtml;
+    }
 
-        groupHtml += '<div class="quota-grid">';
-        items.forEach(({ modelId, quota }) => {
-            const percentage = toPercentage(quota?.remaining);
-            const percentageText = formatPercentage(quota?.remaining);
-            const barColor = getBarColor(percentage);
-            const shortName = escapeHtml(modelId.replace('models/', '').replace('publishers/google/', ''));
-            const safeModelId = escapeHtml(modelId);
-            const safeResetTime = escapeHtml(quota.resetTime);
-            groupHtml += `
+    groupHtml += '<div class="quota-grid">';
+    items.forEach(({ modelId, quota }) => {
+      const percentage = toPercentage(quota?.remaining);
+      const percentageText = formatPercentage(quota?.remaining);
+      const barColor = getBarColor(percentage);
+      const shortName = escapeHtml(
+        modelId.replace("models/", "").replace("publishers/google/", ""),
+      );
+      const safeModelId = escapeHtml(modelId);
+      const safeResetTime = escapeHtml(quota.resetTime);
+      groupHtml += `
                 <div class="quota-item">
                     <div class="quota-model-name" title="${safeModelId}">
                         <span class="quota-model-icon">${iconHtml}</span>
@@ -684,18 +784,18 @@ function renderQuotaModal(quotaContent, quotaData) {
                     </div>
                 </div>
             `;
-        });
-        groupHtml += '</div>';
-        return groupHtml;
-    };
+    });
+    groupHtml += "</div>";
+    return groupHtml;
+  };
 
-    const groupByKey = Object.fromEntries(QUOTA_GROUPS.map(g => [g.key, g]));
-    html += renderGroup(grouped.claude, groupByKey.claude, 'claude');
-    html += renderGroup(grouped.gemini, groupByKey.gemini, 'gemini');
-    html += renderGroup(grouped.banana, groupByKey.banana, 'banana');
-    if (grouped.other && grouped.other.length > 0) {
-        html += renderGroup(grouped.other, groupByKey.other, 'other');
-    }
+  const groupByKey = Object.fromEntries(QUOTA_GROUPS.map((g) => [g.key, g]));
+  html += renderGroup(grouped.claude, groupByKey.claude, "claude");
+  html += renderGroup(grouped.gemini, groupByKey.gemini, "gemini");
+  html += renderGroup(grouped.banana, groupByKey.banana, "banana");
+  if (grouped.other && grouped.other.length > 0) {
+    html += renderGroup(grouped.other, groupByKey.other, "other");
+  }
 
-    quotaContent.innerHTML = html;
+  quotaContent.innerHTML = html;
 }

--- a/public/js/tokens.js
+++ b/public/js/tokens.js
@@ -1314,7 +1314,7 @@ function showTokenDetail(tokenId) {
                 ? `
             <div class="form-group compact">
                 <label>🧾 最近错误</label>
-                <div class="token-error-detail">
+                <div class="token-error-detail" style="max-height: 8em; overflow-y: auto;">
                     ${lastError}
                     ${lastErrorTimeStr || lastErrorStageLabel ? `<br><span class="token-error-meta">${lastErrorTimeStr ? "记录时间: " + lastErrorTimeStr : ""}${lastErrorTimeStr && lastErrorStageLabel ? " · " : ""}${lastErrorStageLabel ? "来源: " + lastErrorStageLabel : ""}</span>` : ""}
                 </div>
@@ -1327,7 +1327,7 @@ function showTokenDetail(tokenId) {
                 ? `
             <div class="form-group compact">
                 <label>⚠️ 禁用原因</label>
-                <div class="token-disable-detail" style="padding: 0.5rem; background: var(--danger-bg, rgba(220,53,69,0.1)); border-radius: 6px; font-size: 0.85rem; color: var(--danger, #dc3545); word-break: break-all;">${disableReason}${disableTimeStr ? '<br><span style="color: var(--text-light); font-size: 0.8rem;">禁用时间: ' + disableTimeStr + "</span>" : ""}</div>
+                <div class="token-disable-detail" style="padding: 0.5rem; background: var(--danger-bg, rgba(220,53,69,0.1)); border-radius: 6px; font-size: 0.85rem; color: var(--danger, #dc3545); word-break: break-all; max-height: 8em; overflow-y: auto;">${disableReason}${disableTimeStr ? '<br><span style="color: var(--text-light); font-size: 0.8rem;">禁用时间: ' + disableTimeStr + "</span>" : ""}</div>
             </div>
             `
                 : ""

--- a/public/js/tokens.js
+++ b/public/js/tokens.js
@@ -920,6 +920,10 @@ function renderTokens(tokens) {
         const safeProjectIdJs = escapeJs(token.projectId || '');
         const safeEmailJs = escapeJs(token.email || '');
 
+        // 禁用原因相关
+        const disableReason = token.disableReason ? escapeHtml(token.disableReason) : '';
+        const disableTimeStr = token.disableTime ? new Date(token.disableTime).toLocaleString('zh-CN') : '';
+
         return `
         <div class="token-card ${!token.enable ? 'disabled' : ''} ${isRefreshing ? 'refreshing' : ''} ${skipAnimation ? 'no-animation' : ''}" id="card-${escapeHtml(cardId)}">
             <div class="token-header">
@@ -934,6 +938,7 @@ function renderTokens(tokens) {
                     <span class="token-id">#${tokenNumber}</span>
                 </div>
             </div>
+            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? '禁用时间: ' + disableTimeStr : ''}">⚠️ ${disableReason}${disableTimeStr ? ' (' + disableTimeStr + ')' : ''}</div>` : ''}
             <div class="token-info">
                 <div class="info-row editable sensitive-row" onclick="editField(event, '${safeTokenId}', 'projectId', '${safeProjectIdJs}')" title="点击编辑">
                     <span class="info-label">📦</span>
@@ -1150,6 +1155,8 @@ function showTokenDetail(tokenId) {
     const safeProjectId = escapeHtml(token.projectId || '');
     const safeEmail = escapeHtml(token.email || '');
     const updatedAtStr = escapeHtml(token.timestamp ? new Date(token.timestamp).toLocaleString('zh-CN') : '未知');
+    const disableReason = token.disableReason ? escapeHtml(token.disableReason) : '';
+    const disableTimeStr = token.disableTime ? new Date(token.disableTime).toLocaleString('zh-CN') : '';
 
     const modal = document.createElement('div');
     modal.className = 'modal form-modal';
@@ -1172,6 +1179,12 @@ function showTokenDetail(tokenId) {
                 <label>🕒 最后更新时间</label>
                 <input type="text" value="${updatedAtStr}" readonly style="background: var(--bg); cursor: not-allowed;">
             </div>
+            ${!token.enable && disableReason ? `
+            <div class="form-group compact">
+                <label>⚠️ 禁用原因</label>
+                <div class="token-disable-detail" style="padding: 0.5rem; background: var(--danger-bg, rgba(220,53,69,0.1)); border-radius: 6px; font-size: 0.85rem; color: var(--danger, #dc3545); word-break: break-all;">${disableReason}${disableTimeStr ? '<br><span style="color: var(--text-light); font-size: 0.8rem;">禁用时间: ' + disableTimeStr + '</span>' : ''}</div>
+            </div>
+            ` : ''}
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="this.closest('.modal').remove()">取消</button>
                 <button class="btn btn-success" onclick="saveTokenDetail('${safeTokenId}')">💾 保存</button>

--- a/public/js/tokens.js
+++ b/public/js/tokens.js
@@ -1034,7 +1034,7 @@ function renderTokens(tokens) {
                     <span class="token-id">#${tokenNumber}</span>
                 </div>
             </div>
-            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? "禁用时间: " + disableTimeStr : ""}">⚠️ ${disableReason}${disableTimeStr ? " (" + disableTimeStr + ")" : ""}</div>` : ""}
+            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? "禁用时间: " + disableTimeStr : ""}">⚠️ ${disableReason}${disableTimeStr ? " (" + disableTimeStr + ")" : ""}</div>${render403ActionUrls(token.disableReason || "")}` : ""}
             <div class="token-info">
                 <div class="info-row editable sensitive-row" onclick="editField(event, '${safeTokenId}', 'projectId', '${safeProjectIdJs}')" title="点击编辑">
                     <span class="info-label">📦</span>
@@ -1318,6 +1318,7 @@ function showTokenDetail(tokenId) {
                     ${lastError}
                     ${lastErrorTimeStr || lastErrorStageLabel ? `<br><span class="token-error-meta">${lastErrorTimeStr ? "记录时间: " + lastErrorTimeStr : ""}${lastErrorTimeStr && lastErrorStageLabel ? " · " : ""}${lastErrorStageLabel ? "来源: " + lastErrorStageLabel : ""}</span>` : ""}
                 </div>
+                ${render403ActionUrls(token.lastError || '')}
             </div>
             `
                 : ""
@@ -1328,6 +1329,7 @@ function showTokenDetail(tokenId) {
             <div class="form-group compact">
                 <label>⚠️ 禁用原因</label>
                 <div class="token-disable-detail" style="padding: 0.5rem; background: var(--danger-bg, rgba(220,53,69,0.1)); border-radius: 6px; font-size: 0.85rem; color: var(--danger, #dc3545); word-break: break-all; max-height: 8em; overflow-y: auto;">${disableReason}${disableTimeStr ? '<br><span style="color: var(--text-light); font-size: 0.8rem;">禁用时间: ' + disableTimeStr + "</span>" : ""}</div>
+                ${render403ActionUrls(token.disableReason || '')}
             </div>
             `
                 : ""

--- a/public/js/tokens.js
+++ b/public/js/tokens.js
@@ -1,191 +1,204 @@
 // Token管理：增删改查、启用禁用
 
 let cachedTokens = [];
-let currentFilter = localStorage.getItem('tokenFilter') || 'all'; // 'all', 'enabled', 'disabled'
+let currentFilter = localStorage.getItem("tokenFilter") || "all"; // 'all', 'enabled', 'disabled'
 let skipAnimation = false; // 是否跳过动画
 
 // 移动端操作区手动收起/展开
-let actionBarCollapsed = localStorage.getItem('actionBarCollapsed') === 'true';
+let actionBarCollapsed = localStorage.getItem("actionBarCollapsed") === "true";
 
 // 存储事件监听器引用，便于清理
 const eventListenerRegistry = new WeakMap();
 
 // 注册事件监听器（便于后续清理）
 function registerEventListener(element, event, handler, options) {
-    if (!element) return;
-    element.addEventListener(event, handler, options);
+  if (!element) return;
+  element.addEventListener(event, handler, options);
 
-    if (!eventListenerRegistry.has(element)) {
-        eventListenerRegistry.set(element, []);
-    }
-    eventListenerRegistry.get(element).push({ event, handler, options });
+  if (!eventListenerRegistry.has(element)) {
+    eventListenerRegistry.set(element, []);
+  }
+  eventListenerRegistry.get(element).push({ event, handler, options });
 }
 
 // 清理元素上的所有注册事件监听器
 function cleanupEventListeners(element) {
-    if (!element || !eventListenerRegistry.has(element)) return;
+  if (!element || !eventListenerRegistry.has(element)) return;
 
-    const listeners = eventListenerRegistry.get(element);
-    for (const { event, handler, options } of listeners) {
-        element.removeEventListener(event, handler, options);
-    }
-    eventListenerRegistry.delete(element);
+  const listeners = eventListenerRegistry.get(element);
+  for (const { event, handler, options } of listeners) {
+    element.removeEventListener(event, handler, options);
+  }
+  eventListenerRegistry.delete(element);
 }
 
 // 判断是否为随机生成的 projectId（旧格式：adjective-noun-random）
 function isRandomProjectId(projectId) {
-    if (!projectId) return true;
-    // 随机格式匹配：word-word-alphanumeric (如 useful-fuze-abc12)
-    const randomPattern = /^[a-z]+-[a-z]+-[a-z0-9]{5}$/;
-    return randomPattern.test(projectId);
+  if (!projectId) return true;
+  // 随机格式匹配：word-word-alphanumeric (如 useful-fuze-abc12)
+  const randomPattern = /^[a-z]+-[a-z]+-[a-z0-9]{5}$/;
+  return randomPattern.test(projectId);
 }
 
 // 手动获取 Project ID（从 API）
 async function fetchProjectId(event, tokenId) {
-    event.stopPropagation(); // 阻止触发父元素的点击事件
+  event.stopPropagation(); // 阻止触发父元素的点击事件
 
-    const btn = event.target;
-    btn.disabled = true;
-    btn.textContent = '⏳';
+  const btn = event.target;
+  btn.disabled = true;
+  btn.textContent = "⏳";
 
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}/fetch-project-id`, {
-            method: 'POST'
-        });
+  try {
+    const response = await authFetch(
+      `/admin/tokens/${encodeURIComponent(tokenId)}/fetch-project-id`,
+      {
+        method: "POST",
+      },
+    );
 
-        const data = await response.json();
-        if (data.success) {
-            showToast(`Project ID 获取成功: ${data.projectId}`, 'success');
-            loadTokens(); // 刷新列表
-        } else {
-            showToast(`获取失败: ${data.message || '未知错误'}`, 'error');
-            btn.disabled = false;
-            btn.textContent = '🔍';
-        }
-    } catch (error) {
-        if (error.message !== 'Unauthorized') {
-            showToast(`获取失败: ${error.message}`, 'error');
-        }
-        btn.disabled = false;
-        btn.textContent = '🔍';
+    const data = await response.json();
+    if (data.success) {
+      showToast(`Project ID 获取成功: ${data.projectId}`, "success");
+      loadTokens(); // 刷新列表
+    } else {
+      showToast(`获取失败: ${data.message || "未知错误"}`, "error");
+      btn.disabled = false;
+      btn.textContent = "🔍";
     }
+  } catch (error) {
+    if (error.message !== "Unauthorized") {
+      showToast(`获取失败: ${error.message}`, "error");
+    }
+    btn.disabled = false;
+    btn.textContent = "🔍";
+  }
 }
 
 // 批量获取所有 Token 的 Project ID
 async function batchFetchProjectIds() {
-    if (!cachedTokens || cachedTokens.length === 0) {
-        showToast('没有可用的 Token', 'warning');
-        return;
+  if (!cachedTokens || cachedTokens.length === 0) {
+    showToast("没有可用的 Token", "warning");
+    return;
+  }
+
+  // 只获取启用的 Token
+  const enabledTokens = cachedTokens.filter((t) => t.enable);
+  if (enabledTokens.length === 0) {
+    showToast("没有启用的 Token", "warning");
+    return;
+  }
+
+  showLoading(`正在批量获取 Project ID (0/${enabledTokens.length})...`);
+
+  let successCount = 0;
+  let failCount = 0;
+
+  for (let i = 0; i < enabledTokens.length; i++) {
+    const token = enabledTokens[i];
+    updateLoadingText(
+      `正在批量获取 Project ID (${i + 1}/${enabledTokens.length})...`,
+    );
+
+    try {
+      const response = await authFetch(
+        `/admin/tokens/${encodeURIComponent(token.id)}/fetch-project-id`,
+        {
+          method: "POST",
+        },
+      );
+      const data = await response.json();
+      if (data.success) {
+        successCount++;
+      } else {
+        failCount++;
+      }
+    } catch (error) {
+      failCount++;
     }
 
-    // 只获取启用的 Token
-    const enabledTokens = cachedTokens.filter(t => t.enable);
-    if (enabledTokens.length === 0) {
-        showToast('没有启用的 Token', 'warning');
-        return;
+    // 防止请求过快，每个请求间隔 500ms
+    if (i < enabledTokens.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
     }
+  }
 
-    showLoading(`正在批量获取 Project ID (0/${enabledTokens.length})...`);
-
-    let successCount = 0;
-    let failCount = 0;
-
-    for (let i = 0; i < enabledTokens.length; i++) {
-        const token = enabledTokens[i];
-        updateLoadingText(`正在批量获取 Project ID (${i + 1}/${enabledTokens.length})...`);
-
-        try {
-            const response = await authFetch(`/admin/tokens/${encodeURIComponent(token.id)}/fetch-project-id`, {
-                method: 'POST'
-            });
-            const data = await response.json();
-            if (data.success) {
-                successCount++;
-            } else {
-                failCount++;
-            }
-        } catch (error) {
-            failCount++;
-        }
-
-        // 防止请求过快，每个请求间隔 500ms
-        if (i < enabledTokens.length - 1) {
-            await new Promise(resolve => setTimeout(resolve, 500));
-        }
-    }
-
-    hideLoading();
-    showToast(`批量获取完成: 成功 ${successCount} 个，失败 ${failCount} 个`, successCount > 0 ? 'success' : 'error');
-    loadTokens(); // 刷新列表
+  hideLoading();
+  showToast(
+    `批量获取完成: 成功 ${successCount} 个，失败 ${failCount} 个`,
+    successCount > 0 ? "success" : "error",
+  );
+  loadTokens(); // 刷新列表
 }
 
 // 更新 Loading 文本
 function updateLoadingText(text) {
-    const loadingText = document.querySelector('.loading-overlay .loading-text');
-    if (loadingText) {
-        loadingText.textContent = text;
-    }
+  const loadingText = document.querySelector(".loading-overlay .loading-text");
+  if (loadingText) {
+    loadingText.textContent = text;
+  }
 }
 
 // 导出 Token（需要密码验证）
 async function exportTokens() {
-    const password = await showPasswordPrompt('请输入管理员密码以导出 Token');
-    if (!password) return;
+  const password = await showPasswordPrompt("请输入管理员密码以导出 Token");
+  if (!password) return;
 
-    showLoading('正在导出...');
-    try {
-        const response = await authFetch('/admin/tokens/export', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ password })
-        });
+  showLoading("正在导出...");
+  try {
+    const response = await authFetch("/admin/tokens/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
 
-        const data = await response.json();
-        hideLoading();
+    const data = await response.json();
+    hideLoading();
 
-        if (data.success) {
-            // 创建下载
-            const blob = new Blob([JSON.stringify(data.data, null, 2)], { type: 'application/json' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `tokens-export-${new Date().toISOString().slice(0, 10)}.json`;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-            showToast('导出成功', 'success');
-        } else {
-            // 密码错误或其他错误时显示具体错误信息
-            if (response.status === 403) {
-                showToast('密码错误，请重新输入', 'error');
-            } else {
-                showToast(data.message || '导出失败', 'error');
-            }
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('导出失败: ' + error.message, 'error');
+    if (data.success) {
+      // 创建下载
+      const blob = new Blob([JSON.stringify(data.data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `tokens-export-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      showToast("导出成功", "success");
+    } else {
+      // 密码错误或其他错误时显示具体错误信息
+      if (response.status === 403) {
+        showToast("密码错误，请重新输入", "error");
+      } else {
+        showToast(data.message || "导出失败", "error");
+      }
     }
+  } catch (error) {
+    hideLoading();
+    showToast("导出失败: " + error.message, "error");
+  }
 }
 
 // 导入 Token（需要密码验证）- 打开拖拽上传弹窗
 async function importTokens() {
-    showImportUploadModal();
+  showImportUploadModal();
 }
 
 // 当前导入模式：'file' | 'json' | 'manual'
-let currentImportTab = 'file';
+let currentImportTab = "file";
 
 // 存储导入弹窗的事件处理器引用
 let importModalHandlers = null;
 
 // 显示导入上传弹窗（支持拖拽、手动输入JSON和手动填入Token）
 function showImportUploadModal() {
-    const modal = document.createElement('div');
-    modal.className = 'modal form-modal';
-    modal.id = 'importUploadModal';
-    modal.innerHTML = `
+  const modal = document.createElement("div");
+  modal.className = "modal form-modal";
+  modal.id = "importUploadModal";
+  modal.innerHTML = `
         <div class="modal-content modal-lg">
             <div class="modal-title">📥 添加/导入 Token</div>
             
@@ -272,255 +285,295 @@ function showImportUploadModal() {
             </div>
         </div>
     `;
-    document.body.appendChild(modal);
+  document.body.appendChild(modal);
 
-    // 初始化当前标签
-    currentImportTab = 'file';
+  // 初始化当前标签
+  currentImportTab = "file";
 
-    // 绑定事件（保存引用以便清理）
-    const dropzone = document.getElementById('importDropzone');
-    const fileInput = document.getElementById('importFileInput');
-    const manualAccessToken = document.getElementById('manualAccessToken');
-    const manualRefreshToken = document.getElementById('manualRefreshToken');
+  // 绑定事件（保存引用以便清理）
+  const dropzone = document.getElementById("importDropzone");
+  const fileInput = document.getElementById("importFileInput");
+  const manualAccessToken = document.getElementById("manualAccessToken");
+  const manualRefreshToken = document.getElementById("manualRefreshToken");
 
-    // 通用绑定：dropzone + 遮罩点击关闭
-    const cleanupDropzone = (typeof wireJsonFileDropzone === 'function')
-        ? wireJsonFileDropzone({
-            dropzone,
-            fileInput,
-            onFile: (file) => handleImportFile(file),
-            onError: (message) => showToast(message, 'warning')
+  // 通用绑定：dropzone + 遮罩点击关闭
+  const cleanupDropzone =
+    typeof wireJsonFileDropzone === "function"
+      ? wireJsonFileDropzone({
+          dropzone,
+          fileInput,
+          onFile: (file) => handleImportFile(file),
+          onError: (message) => showToast(message, "warning"),
         })
-        : null;
-    const cleanupBackdrop = (typeof wireModalBackdropClose === 'function')
-        ? wireModalBackdropClose(modal, closeImportModal)
-        : null;
+      : null;
+  const cleanupBackdrop =
+    typeof wireModalBackdropClose === "function"
+      ? wireModalBackdropClose(modal, closeImportModal)
+      : null;
 
-    // 创建事件处理器
-    const handlers = {
-        updateManualBtnState: () => {
-            if (currentImportTab === 'manual') {
-                const confirmBtn = document.getElementById('confirmImportBtn');
-                confirmBtn.disabled = !manualAccessToken.value.trim() || !manualRefreshToken.value.trim();
-            }
-        }
-    };
+  // 创建事件处理器
+  const handlers = {
+    updateManualBtnState: () => {
+      if (currentImportTab === "manual") {
+        const confirmBtn = document.getElementById("confirmImportBtn");
+        confirmBtn.disabled =
+          !manualAccessToken.value.trim() || !manualRefreshToken.value.trim();
+      }
+    },
+  };
 
-    // 保存处理器引用
-    importModalHandlers = {
-        modal,
-        dropzone,
-        fileInput,
-        manualAccessToken,
-        manualRefreshToken,
-        handlers,
-        cleanup: () => {
-            try { cleanupDropzone && cleanupDropzone(); } catch { /* ignore */ }
-            try { cleanupBackdrop && cleanupBackdrop(); } catch { /* ignore */ }
-        }
-    };
+  // 保存处理器引用
+  importModalHandlers = {
+    modal,
+    dropzone,
+    fileInput,
+    manualAccessToken,
+    manualRefreshToken,
+    handlers,
+    cleanup: () => {
+      try {
+        cleanupDropzone && cleanupDropzone();
+      } catch {
+        /* ignore */
+      }
+      try {
+        cleanupBackdrop && cleanupBackdrop();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
 
-    // 绑定事件（手动填入模式仍保留现有逻辑）
-    manualAccessToken.addEventListener('input', handlers.updateManualBtnState);
-    manualRefreshToken.addEventListener('input', handlers.updateManualBtnState);
+  // 绑定事件（手动填入模式仍保留现有逻辑）
+  manualAccessToken.addEventListener("input", handlers.updateManualBtnState);
+  manualRefreshToken.addEventListener("input", handlers.updateManualBtnState);
 }
 
 // 切换导入方式标签
 function switchImportTab(tab) {
-    currentImportTab = tab;
+  currentImportTab = tab;
 
-    // 更新标签状态
-    document.querySelectorAll('.import-tab').forEach(t => t.classList.remove('active'));
-    document.querySelector(`.import-tab[data-tab="${tab}"]`).classList.add('active');
+  // 更新标签状态
+  document
+    .querySelectorAll(".import-tab")
+    .forEach((t) => t.classList.remove("active"));
+  document
+    .querySelector(`.import-tab[data-tab="${tab}"]`)
+    .classList.add("active");
 
-    // 切换内容显示
-    document.getElementById('importTabFile').classList.toggle('hidden', tab !== 'file');
-    document.getElementById('importTabJson').classList.toggle('hidden', tab !== 'json');
-    document.getElementById('importTabManual').classList.toggle('hidden', tab !== 'manual');
+  // 切换内容显示
+  document
+    .getElementById("importTabFile")
+    .classList.toggle("hidden", tab !== "file");
+  document
+    .getElementById("importTabJson")
+    .classList.toggle("hidden", tab !== "json");
+  document
+    .getElementById("importTabManual")
+    .classList.toggle("hidden", tab !== "manual");
 
-    // 切换导入模式和密码输入的显示
-    const importModeGroup = document.getElementById('importModeGroup');
-    const importPasswordGroup = document.getElementById('importPasswordGroup');
-    const confirmBtn = document.getElementById('confirmImportBtn');
+  // 切换导入模式和密码输入的显示
+  const importModeGroup = document.getElementById("importModeGroup");
+  const importPasswordGroup = document.getElementById("importPasswordGroup");
+  const confirmBtn = document.getElementById("confirmImportBtn");
 
-    if (tab === 'manual') {
-        // 手动填入模式：隐藏导入模式和密码
-        importModeGroup.classList.add('hidden');
-        importPasswordGroup.classList.add('hidden');
-        // 更新按钮状态
-        const accessToken = document.getElementById('manualAccessToken').value.trim();
-        const refreshToken = document.getElementById('manualRefreshToken').value.trim();
-        confirmBtn.disabled = !accessToken || !refreshToken;
-        confirmBtn.textContent = '✅ 添加';
-    } else {
-        // 文件上传或JSON导入模式：显示导入模式和密码
-        importModeGroup.classList.remove('hidden');
-        importPasswordGroup.classList.remove('hidden');
-        confirmBtn.textContent = '✅ 确认导入';
+  if (tab === "manual") {
+    // 手动填入模式：隐藏导入模式和密码
+    importModeGroup.classList.add("hidden");
+    importPasswordGroup.classList.add("hidden");
+    // 更新按钮状态
+    const accessToken = document
+      .getElementById("manualAccessToken")
+      .value.trim();
+    const refreshToken = document
+      .getElementById("manualRefreshToken")
+      .value.trim();
+    confirmBtn.disabled = !accessToken || !refreshToken;
+    confirmBtn.textContent = "✅ 添加";
+  } else {
+    // 文件上传或JSON导入模式：显示导入模式和密码
+    importModeGroup.classList.remove("hidden");
+    importPasswordGroup.classList.remove("hidden");
+    confirmBtn.textContent = "✅ 确认导入";
 
-        // 清除之前的数据
-        if (tab === 'file') {
-            // 切换到文件上传时，清除JSON输入和手动输入
-            document.getElementById('importJsonInput').value = '';
-            document.getElementById('importJsonStatus').textContent = '';
-            document.getElementById('manualAccessToken').value = '';
-            document.getElementById('manualRefreshToken').value = '';
-            document.getElementById('manualExpiresIn').value = '3599';
-            // 按钮状态由文件选择决定
-            confirmBtn.disabled = !pendingImportData;
-        } else if (tab === 'json') {
-            // 切换到JSON输入时，清除文件选择和手动输入
-            clearImportFile();
-            document.getElementById('manualAccessToken').value = '';
-            document.getElementById('manualRefreshToken').value = '';
-            document.getElementById('manualExpiresIn').value = '3599';
-            // 按钮状态由JSON解析决定
-            confirmBtn.disabled = !pendingImportData;
-        }
+    // 清除之前的数据
+    if (tab === "file") {
+      // 切换到文件上传时，清除JSON输入和手动输入
+      document.getElementById("importJsonInput").value = "";
+      document.getElementById("importJsonStatus").textContent = "";
+      document.getElementById("manualAccessToken").value = "";
+      document.getElementById("manualRefreshToken").value = "";
+      document.getElementById("manualExpiresIn").value = "3599";
+      // 按钮状态由文件选择决定
+      confirmBtn.disabled = !pendingImportData;
+    } else if (tab === "json") {
+      // 切换到JSON输入时，清除文件选择和手动输入
+      clearImportFile();
+      document.getElementById("manualAccessToken").value = "";
+      document.getElementById("manualRefreshToken").value = "";
+      document.getElementById("manualExpiresIn").value = "3599";
+      // 按钮状态由JSON解析决定
+      confirmBtn.disabled = !pendingImportData;
     }
+  }
 }
 
 // 智能查找字段值（不分大小写，包含匹配）
 function findFieldByKeyword(obj, keyword) {
-    if (!obj || typeof obj !== 'object') return undefined;
-    const lowerKeyword = keyword.toLowerCase();
-    for (const key of Object.keys(obj)) {
-        if (key.toLowerCase().includes(lowerKeyword)) {
-            return obj[key];
-        }
+  if (!obj || typeof obj !== "object") return undefined;
+  const lowerKeyword = keyword.toLowerCase();
+  for (const key of Object.keys(obj)) {
+    if (key.toLowerCase().includes(lowerKeyword)) {
+      return obj[key];
     }
-    return undefined;
+  }
+  return undefined;
 }
 
 // 智能解析单个 Token 对象
 function smartParseToken(rawToken) {
-    if (!rawToken || typeof rawToken !== 'object') return null;
+  if (!rawToken || typeof rawToken !== "object") return null;
 
-    // 必需字段：包含 refresh 的认为是 refresh_token，包含 project 的认为是 projectId
-    const refresh_token = findFieldByKeyword(rawToken, 'refresh');
-    const projectId = findFieldByKeyword(rawToken, 'project');
+  // 必需字段：包含 refresh 的认为是 refresh_token，包含 project 的认为是 projectId
+  const refresh_token = findFieldByKeyword(rawToken, "refresh");
+  const projectId = findFieldByKeyword(rawToken, "project");
 
-    // 必须同时包含这两个字段
-    if (!refresh_token || !projectId) return null;
+  // 必须同时包含这两个字段
+  if (!refresh_token || !projectId) return null;
 
-    // 构建标准化的 token 对象
-    const token = { refresh_token, projectId };
+  // 构建标准化的 token 对象
+  const token = { refresh_token, projectId };
 
-    // 可选字段自动获取
-    const access_token = findFieldByKeyword(rawToken, 'access');
-    const email = findFieldByKeyword(rawToken, 'email') || findFieldByKeyword(rawToken, 'mail');
-    const expires_in = findFieldByKeyword(rawToken, 'expire');
-    const enable = findFieldByKeyword(rawToken, 'enable');
-    const timestamp = findFieldByKeyword(rawToken, 'time') || findFieldByKeyword(rawToken, 'stamp');
-    const hasQuota = findFieldByKeyword(rawToken, 'quota');
+  // 可选字段自动获取
+  const access_token = findFieldByKeyword(rawToken, "access");
+  const email =
+    findFieldByKeyword(rawToken, "email") ||
+    findFieldByKeyword(rawToken, "mail");
+  const expires_in = findFieldByKeyword(rawToken, "expire");
+  const enable = findFieldByKeyword(rawToken, "enable");
+  const timestamp =
+    findFieldByKeyword(rawToken, "time") ||
+    findFieldByKeyword(rawToken, "stamp");
+  const hasQuota = findFieldByKeyword(rawToken, "quota");
 
-    if (access_token) token.access_token = access_token;
-    if (email) token.email = email;
-    if (expires_in !== undefined) token.expires_in = parseInt(expires_in) || 3599;
-    if (enable !== undefined) token.enable = enable === true || enable === 'true' || enable === 1;
-    if (timestamp) token.timestamp = typeof timestamp === 'number' ? timestamp : new Date(timestamp).getTime();
-    if (hasQuota !== undefined) token.hasQuota = hasQuota === true || hasQuota === 'true' || hasQuota === 1;
+  if (access_token) token.access_token = access_token;
+  if (email) token.email = email;
+  if (expires_in !== undefined) token.expires_in = parseInt(expires_in) || 3599;
+  if (enable !== undefined)
+    token.enable = enable === true || enable === "true" || enable === 1;
+  if (timestamp)
+    token.timestamp =
+      typeof timestamp === "number" ? timestamp : new Date(timestamp).getTime();
+  if (hasQuota !== undefined)
+    token.hasQuota = hasQuota === true || hasQuota === "true" || hasQuota === 1;
 
-    return token;
+  return token;
 }
 
 // 智能解析导入数据（支持多种格式）
 function smartParseImportData(jsonText) {
-    let data;
-    let cleanText = jsonText.trim();
+  let data;
+  let cleanText = jsonText.trim();
 
-    // 预处理：移除尾随逗号（常见的 JSON 格式错误）
-    cleanText = cleanText.replace(/,(\s*[}\]])/g, '$1');
+  // 预处理：移除尾随逗号（常见的 JSON 格式错误）
+  cleanText = cleanText.replace(/,(\s*[}\]])/g, "$1");
 
+  try {
+    data = JSON.parse(cleanText);
+  } catch (e) {
+    // 尝试处理多个 JSON 对象（用户可能粘贴了多个对象，没有用数组包裹）
     try {
-        data = JSON.parse(cleanText);
-    } catch (e) {
-        // 尝试处理多个 JSON 对象（用户可能粘贴了多个对象，没有用数组包裹）
-        try {
-            // 尝试将多个对象包装成数组
-            // 匹配 }{  或 }\n{ 的情况，替换为 },{
-            const arrayText = '[' + cleanText.replace(/\}\s*\{/g, '},{') + ']';
-            data = JSON.parse(arrayText);
-        } catch (e2) {
-            return { success: false, message: `JSON 解析错误: ${e.message}` };
-        }
+      // 尝试将多个对象包装成数组
+      // 匹配 }{  或 }\n{ 的情况，替换为 },{
+      const arrayText = "[" + cleanText.replace(/\}\s*\{/g, "},{") + "]";
+      data = JSON.parse(arrayText);
+    } catch (e2) {
+      return { success: false, message: `JSON 解析错误: ${e.message}` };
     }
+  }
 
-    // 识别数据结构：数组或对象中的数组
-    let tokensArray = [];
-    if (Array.isArray(data)) {
-        tokensArray = data;
-    } else if (typeof data === 'object' && data !== null) {
-        // 查找任何包含数组的字段
-        for (const key of Object.keys(data)) {
-            if (Array.isArray(data[key])) {
-                tokensArray = data[key];
-                break;
-            }
-        }
-        // 如果没找到数组，尝试作为单个 token 解析
-        if (tokensArray.length === 0) {
-            const single = smartParseToken(data);
-            if (single) tokensArray = [data];
-        }
+  // 识别数据结构：数组或对象中的数组
+  let tokensArray = [];
+  if (Array.isArray(data)) {
+    tokensArray = data;
+  } else if (typeof data === "object" && data !== null) {
+    // 查找任何包含数组的字段
+    for (const key of Object.keys(data)) {
+      if (Array.isArray(data[key])) {
+        tokensArray = data[key];
+        break;
+      }
     }
-
+    // 如果没找到数组，尝试作为单个 token 解析
     if (tokensArray.length === 0) {
-        return { success: false, message: '未找到有效数据，请确保包含 refresh_token 和 projectId' };
+      const single = smartParseToken(data);
+      if (single) tokensArray = [data];
     }
+  }
 
-    // 解析每个 token
-    const validTokens = [];
-    let invalidCount = 0;
-    for (const raw of tokensArray) {
-        const parsed = smartParseToken(raw);
-        if (parsed) {
-            validTokens.push(parsed);
-        } else {
-            invalidCount++;
-        }
+  if (tokensArray.length === 0) {
+    return {
+      success: false,
+      message: "未找到有效数据，请确保包含 refresh_token 和 projectId",
+    };
+  }
+
+  // 解析每个 token
+  const validTokens = [];
+  let invalidCount = 0;
+  for (const raw of tokensArray) {
+    const parsed = smartParseToken(raw);
+    if (parsed) {
+      validTokens.push(parsed);
+    } else {
+      invalidCount++;
     }
+  }
 
-    if (validTokens.length === 0) {
-        return { success: false, message: `所有 ${tokensArray.length} 条数据都缺少必需字段 (refresh_token 和 projectId)` };
-    }
+  if (validTokens.length === 0) {
+    return {
+      success: false,
+      message: `所有 ${tokensArray.length} 条数据都缺少必需字段 (refresh_token 和 projectId)`,
+    };
+  }
 
-    const message = invalidCount > 0
-        ? `解析成功：${validTokens.length} 个有效，${invalidCount} 个无效`
-        : `解析成功：${validTokens.length} 个 Token`;
+  const message =
+    invalidCount > 0
+      ? `解析成功：${validTokens.length} 个有效，${invalidCount} 个无效`
+      : `解析成功：${validTokens.length} 个 Token`;
 
-    return { success: true, tokens: validTokens, message };
+  return { success: true, tokens: validTokens, message };
 }
 
 // 解析手动输入的JSON
 function parseImportJson() {
-    const jsonInput = document.getElementById('importJsonInput');
-    const statusEl = document.getElementById('importJsonStatus');
-    const confirmBtn = document.getElementById('confirmImportBtn');
+  const jsonInput = document.getElementById("importJsonInput");
+  const statusEl = document.getElementById("importJsonStatus");
+  const confirmBtn = document.getElementById("confirmImportBtn");
 
-    const jsonText = jsonInput.value.trim();
-    if (!jsonText) {
-        statusEl.textContent = '❌ 请输入 JSON 内容';
-        statusEl.className = 'import-json-status error';
-        pendingImportData = null;
-        confirmBtn.disabled = true;
-        return;
-    }
+  const jsonText = jsonInput.value.trim();
+  if (!jsonText) {
+    statusEl.textContent = "❌ 请输入 JSON 内容";
+    statusEl.className = "import-json-status error";
+    pendingImportData = null;
+    confirmBtn.disabled = true;
+    return;
+  }
 
-    const result = smartParseImportData(jsonText);
+  const result = smartParseImportData(jsonText);
 
-    if (result.success) {
-        // 保存待导入数据（转换为标准格式）
-        pendingImportData = { tokens: result.tokens };
-        statusEl.textContent = `✅ ${result.message}`;
-        statusEl.className = 'import-json-status success';
-        confirmBtn.disabled = false;
-    } else {
-        statusEl.textContent = `❌ ${result.message}`;
-        statusEl.className = 'import-json-status error';
-        pendingImportData = null;
-        confirmBtn.disabled = true;
-    }
+  if (result.success) {
+    // 保存待导入数据（转换为标准格式）
+    pendingImportData = { tokens: result.tokens };
+    statusEl.textContent = `✅ ${result.message}`;
+    statusEl.className = "import-json-status success";
+    confirmBtn.disabled = false;
+  } else {
+    statusEl.textContent = `❌ ${result.message}`;
+    statusEl.className = "import-json-status error";
+    pendingImportData = null;
+    confirmBtn.disabled = true;
+  }
 }
 
 // 当前待导入的数据
@@ -528,187 +581,209 @@ let pendingImportData = null;
 
 // 处理导入文件（使用智能解析）
 async function handleImportFile(file) {
-    try {
-        const text = await file.text();
-        const result = smartParseImportData(text);
+  try {
+    const text = await file.text();
+    const result = smartParseImportData(text);
 
-        if (!result.success) {
-            showToast(result.message, 'error');
-            return;
-        }
-
-        // 保存待导入数据（转换为标准格式）
-        pendingImportData = { tokens: result.tokens };
-
-        // 更新UI显示文件信息
-        const dropzone = document.getElementById('importDropzone');
-        const fileInfo = document.getElementById('importFileInfo');
-        const fileName = document.getElementById('importFileName');
-        const fileMeta = document.getElementById('importFileMeta');
-        const confirmBtn = document.getElementById('confirmImportBtn');
-
-        dropzone.classList.add('hidden');
-        fileInfo.classList.remove('hidden');
-        fileName.textContent = file.name;
-        fileMeta.textContent = result.message;
-        confirmBtn.disabled = false;
-
-    } catch (error) {
-        showToast('读取文件失败: ' + error.message, 'error');
+    if (!result.success) {
+      showToast(result.message, "error");
+      return;
     }
+
+    // 保存待导入数据（转换为标准格式）
+    pendingImportData = { tokens: result.tokens };
+
+    // 更新UI显示文件信息
+    const dropzone = document.getElementById("importDropzone");
+    const fileInfo = document.getElementById("importFileInfo");
+    const fileName = document.getElementById("importFileName");
+    const fileMeta = document.getElementById("importFileMeta");
+    const confirmBtn = document.getElementById("confirmImportBtn");
+
+    dropzone.classList.add("hidden");
+    fileInfo.classList.remove("hidden");
+    fileName.textContent = file.name;
+    fileMeta.textContent = result.message;
+    confirmBtn.disabled = false;
+  } catch (error) {
+    showToast("读取文件失败: " + error.message, "error");
+  }
 }
 
 // 清除已选文件
 function clearImportFile() {
-    pendingImportData = null;
+  pendingImportData = null;
 
-    const dropzone = document.getElementById('importDropzone');
-    const fileInfo = document.getElementById('importFileInfo');
-    const fileInput = document.getElementById('importFileInput');
-    const confirmBtn = document.getElementById('confirmImportBtn');
+  const dropzone = document.getElementById("importDropzone");
+  const fileInfo = document.getElementById("importFileInfo");
+  const fileInput = document.getElementById("importFileInput");
+  const confirmBtn = document.getElementById("confirmImportBtn");
 
-    dropzone.classList.remove('hidden');
-    fileInfo.classList.add('hidden');
-    fileInput.value = '';
-    confirmBtn.disabled = true;
+  dropzone.classList.remove("hidden");
+  fileInfo.classList.add("hidden");
+  fileInput.value = "";
+  confirmBtn.disabled = true;
 }
 
 // 关闭导入弹窗
 function closeImportModal() {
-    // 清理事件监听器
-    if (importModalHandlers) {
-        const { manualAccessToken, manualRefreshToken, handlers, cleanup } = importModalHandlers;
+  // 清理事件监听器
+  if (importModalHandlers) {
+    const { manualAccessToken, manualRefreshToken, handlers, cleanup } =
+      importModalHandlers;
 
-        // 新模式：统一 cleanup（dropzone/backdrop 等）
-        if (typeof cleanup === 'function') {
-            try { cleanup(); } catch { /* ignore */ }
-        } else {
-            // 旧模式兼容（保留，以防外部改动导致未注入 cleanup）
-            const { modal, dropzone, fileInput } = importModalHandlers;
-            if (dropzone && handlers) {
-                if (handlers.dropzoneClick) dropzone.removeEventListener('click', handlers.dropzoneClick);
-                if (handlers.dragover) dropzone.removeEventListener('dragover', handlers.dragover);
-                if (handlers.dragleave) dropzone.removeEventListener('dragleave', handlers.dragleave);
-                if (handlers.drop) dropzone.removeEventListener('drop', handlers.drop);
-            }
-            if (fileInput && handlers?.fileChange) {
-                fileInput.removeEventListener('change', handlers.fileChange);
-            }
-            if (modal && handlers?.modalClick) {
-                modal.removeEventListener('click', handlers.modalClick);
-            }
-        }
-
-        // 手动填入模式的监听解绑
-        if (manualAccessToken && handlers?.updateManualBtnState) {
-            manualAccessToken.removeEventListener('input', handlers.updateManualBtnState);
-        }
-        if (manualRefreshToken && handlers?.updateManualBtnState) {
-            manualRefreshToken.removeEventListener('input', handlers.updateManualBtnState);
-        }
-
-        importModalHandlers = null;
+    // 新模式：统一 cleanup（dropzone/backdrop 等）
+    if (typeof cleanup === "function") {
+      try {
+        cleanup();
+      } catch {
+        /* ignore */
+      }
+    } else {
+      // 旧模式兼容（保留，以防外部改动导致未注入 cleanup）
+      const { modal, dropzone, fileInput } = importModalHandlers;
+      if (dropzone && handlers) {
+        if (handlers.dropzoneClick)
+          dropzone.removeEventListener("click", handlers.dropzoneClick);
+        if (handlers.dragover)
+          dropzone.removeEventListener("dragover", handlers.dragover);
+        if (handlers.dragleave)
+          dropzone.removeEventListener("dragleave", handlers.dragleave);
+        if (handlers.drop) dropzone.removeEventListener("drop", handlers.drop);
+      }
+      if (fileInput && handlers?.fileChange) {
+        fileInput.removeEventListener("change", handlers.fileChange);
+      }
+      if (modal && handlers?.modalClick) {
+        modal.removeEventListener("click", handlers.modalClick);
+      }
     }
 
-    const modal = document.getElementById('importUploadModal');
-    if (modal) {
-        modal.remove();
+    // 手动填入模式的监听解绑
+    if (manualAccessToken && handlers?.updateManualBtnState) {
+      manualAccessToken.removeEventListener(
+        "input",
+        handlers.updateManualBtnState,
+      );
     }
-    pendingImportData = null;
+    if (manualRefreshToken && handlers?.updateManualBtnState) {
+      manualRefreshToken.removeEventListener(
+        "input",
+        handlers.updateManualBtnState,
+      );
+    }
+
+    importModalHandlers = null;
+  }
+
+  const modal = document.getElementById("importUploadModal");
+  if (modal) {
+    modal.remove();
+  }
+  pendingImportData = null;
 }
 
 // 从弹窗确认导入/添加
 async function confirmImportFromModal() {
-    // 手动填入模式
-    if (currentImportTab === 'manual') {
-        const accessToken = document.getElementById('manualAccessToken').value.trim();
-        const refreshToken = document.getElementById('manualRefreshToken').value.trim();
-        const projectId = document.getElementById('manualProjectId').value.trim();
-        const expiresIn = parseInt(document.getElementById('manualExpiresIn').value) || 3599;
+  // 手动填入模式
+  if (currentImportTab === "manual") {
+    const accessToken = document
+      .getElementById("manualAccessToken")
+      .value.trim();
+    const refreshToken = document
+      .getElementById("manualRefreshToken")
+      .value.trim();
+    const projectId = document.getElementById("manualProjectId").value.trim();
+    const expiresIn =
+      parseInt(document.getElementById("manualExpiresIn").value) || 3599;
 
-        if (!accessToken || !refreshToken) {
-            showToast('请填写完整的Token信息', 'warning');
-            return;
-        }
-
-        showLoading('正在添加Token...');
-        try {
-            const tokenData = { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn };
-            if (projectId) {
-                tokenData.projectId = projectId;
-            }
-            const response = await authFetch('/admin/tokens', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(tokenData)
-            });
-
-            const data = await response.json();
-            hideLoading();
-
-            if (data.success) {
-                closeImportModal();
-                showToast('Token添加成功', 'success');
-                loadTokens();
-            } else {
-                showToast(data.message || '添加失败', 'error');
-            }
-        } catch (error) {
-            hideLoading();
-            showToast('添加失败: ' + error.message, 'error');
-        }
-        return;
+    if (!accessToken || !refreshToken) {
+      showToast("请填写完整的Token信息", "warning");
+      return;
     }
 
-    // 文件上传或JSON导入模式
-    if (!pendingImportData) {
-        showToast('请先选择文件或解析JSON', 'warning');
-        return;
-    }
-
-    const mode = document.getElementById('importMode').value;
-    const password = document.getElementById('importPassword').value;
-
-    if (!password) {
-        showToast('请输入管理员密码', 'warning');
-        return;
-    }
-
-    showLoading('正在导入...');
+    showLoading("正在添加Token...");
     try {
-        const response = await authFetch('/admin/tokens/import', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ password, data: pendingImportData, mode })
-        });
+      const tokenData = {
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        expires_in: expiresIn,
+      };
+      if (projectId) {
+        tokenData.projectId = projectId;
+      }
+      const response = await authFetch("/admin/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(tokenData),
+      });
 
-        const data = await response.json();
-        hideLoading();
+      const data = await response.json();
+      hideLoading();
 
-        if (data.success) {
-            closeImportModal();
-            showToast(data.message, 'success');
-            loadTokens();
-        } else {
-            // 密码错误时显示具体提示
-            if (response.status === 403) {
-                showToast('密码错误，请重新输入', 'error');
-            } else {
-                showToast(data.message || '导入失败', 'error');
-            }
-        }
+      if (data.success) {
+        closeImportModal();
+        showToast("Token添加成功", "success");
+        loadTokens();
+      } else {
+        showToast(data.message || "添加失败", "error");
+      }
     } catch (error) {
-        hideLoading();
-        showToast('导入失败: ' + error.message, 'error');
+      hideLoading();
+      showToast("添加失败: " + error.message, "error");
     }
+    return;
+  }
+
+  // 文件上传或JSON导入模式
+  if (!pendingImportData) {
+    showToast("请先选择文件或解析JSON", "warning");
+    return;
+  }
+
+  const mode = document.getElementById("importMode").value;
+  const password = document.getElementById("importPassword").value;
+
+  if (!password) {
+    showToast("请输入管理员密码", "warning");
+    return;
+  }
+
+  showLoading("正在导入...");
+  try {
+    const response = await authFetch("/admin/tokens/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password, data: pendingImportData, mode }),
+    });
+
+    const data = await response.json();
+    hideLoading();
+
+    if (data.success) {
+      closeImportModal();
+      showToast(data.message, "success");
+      loadTokens();
+    } else {
+      // 密码错误时显示具体提示
+      if (response.status === 403) {
+        showToast("密码错误，请重新输入", "error");
+      } else {
+        showToast(data.message || "导入失败", "error");
+      }
+    }
+  } catch (error) {
+    hideLoading();
+    showToast("导入失败: " + error.message, "error");
+  }
 }
 
 // 密码输入提示框
 function showPasswordPrompt(message) {
-    return new Promise((resolve) => {
-        const modal = document.createElement('div');
-        modal.className = 'modal form-modal';
-        modal.innerHTML = `
+  return new Promise((resolve) => {
+    const modal = document.createElement("div");
+    modal.className = "modal form-modal";
+    modal.innerHTML = `
             <div class="modal-content">
                 <div class="modal-title">🔐 密码验证</div>
                 <p>${message}</p>
@@ -721,142 +796,146 @@ function showPasswordPrompt(message) {
                 </div>
             </div>
         `;
-        document.body.appendChild(modal);
+    document.body.appendChild(modal);
 
-        const passwordInput = document.getElementById('promptPassword');
-        const confirmBtn = document.getElementById('promptConfirmBtn');
-        const cancelBtn = document.getElementById('promptCancelBtn');
+    const passwordInput = document.getElementById("promptPassword");
+    const confirmBtn = document.getElementById("promptConfirmBtn");
+    const cancelBtn = document.getElementById("promptCancelBtn");
 
-        // 清理函数
-        const cleanup = () => {
-            confirmBtn.removeEventListener('click', handleConfirm);
-            cancelBtn.removeEventListener('click', handleCancel);
-            passwordInput.removeEventListener('keydown', handleKeydown);
-            modal.removeEventListener('click', handleModalClick);
-            modal.remove();
-        };
+    // 清理函数
+    const cleanup = () => {
+      confirmBtn.removeEventListener("click", handleConfirm);
+      cancelBtn.removeEventListener("click", handleCancel);
+      passwordInput.removeEventListener("keydown", handleKeydown);
+      modal.removeEventListener("click", handleModalClick);
+      modal.remove();
+    };
 
-        const handleConfirm = () => {
-            const password = passwordInput.value;
-            cleanup();
-            resolve(password || null);
-        };
+    const handleConfirm = () => {
+      const password = passwordInput.value;
+      cleanup();
+      resolve(password || null);
+    };
 
-        const handleCancel = () => {
-            cleanup();
-            resolve(null);
-        };
+    const handleCancel = () => {
+      cleanup();
+      resolve(null);
+    };
 
-        const handleKeydown = (e) => {
-            if (e.key === 'Enter') {
-                handleConfirm();
-            } else if (e.key === 'Escape') {
-                handleCancel();
-            }
-        };
+    const handleKeydown = (e) => {
+      if (e.key === "Enter") {
+        handleConfirm();
+      } else if (e.key === "Escape") {
+        handleCancel();
+      }
+    };
 
-        const handleModalClick = (e) => {
-            if (e.target === modal) {
-                cleanup();
-                resolve(null);
-            }
-        };
+    const handleModalClick = (e) => {
+      if (e.target === modal) {
+        cleanup();
+        resolve(null);
+      }
+    };
 
-        confirmBtn.addEventListener('click', handleConfirm);
-        cancelBtn.addEventListener('click', handleCancel);
-        passwordInput.addEventListener('keydown', handleKeydown);
-        modal.addEventListener('click', handleModalClick);
+    confirmBtn.addEventListener("click", handleConfirm);
+    cancelBtn.addEventListener("click", handleCancel);
+    passwordInput.addEventListener("keydown", handleKeydown);
+    modal.addEventListener("click", handleModalClick);
 
-        passwordInput.focus();
-    });
+    passwordInput.focus();
+  });
 }
 
 // 手动切换操作区显示/隐藏（暴露到全局）
 window.toggleActionBar = function () {
-    const actionBar = document.getElementById('actionBar');
-    const toggleBtn = document.getElementById('actionToggleBtn');
+  const actionBar = document.getElementById("actionBar");
+  const toggleBtn = document.getElementById("actionToggleBtn");
 
-    if (!actionBar || !toggleBtn) return;
+  if (!actionBar || !toggleBtn) return;
 
-    actionBarCollapsed = !actionBarCollapsed;
-    localStorage.setItem('actionBarCollapsed', actionBarCollapsed);
+  actionBarCollapsed = !actionBarCollapsed;
+  localStorage.setItem("actionBarCollapsed", actionBarCollapsed);
 
-    if (actionBarCollapsed) {
-        actionBar.classList.add('collapsed');
-        toggleBtn.classList.add('collapsed');
-        toggleBtn.title = '展开操作按钮';
-    } else {
-        actionBar.classList.remove('collapsed');
-        toggleBtn.classList.remove('collapsed');
-        toggleBtn.title = '收起操作按钮';
-    }
-}
+  if (actionBarCollapsed) {
+    actionBar.classList.add("collapsed");
+    toggleBtn.classList.add("collapsed");
+    toggleBtn.title = "展开操作按钮";
+  } else {
+    actionBar.classList.remove("collapsed");
+    toggleBtn.classList.remove("collapsed");
+    toggleBtn.title = "收起操作按钮";
+  }
+};
 
 // 初始化操作区状态（恢复保存的收起/展开状态）
 function initActionBarState() {
-    const actionBar = document.getElementById('actionBar');
-    const toggleBtn = document.getElementById('actionToggleBtn');
+  const actionBar = document.getElementById("actionBar");
+  const toggleBtn = document.getElementById("actionToggleBtn");
 
-    if (!actionBar || !toggleBtn) return;
+  if (!actionBar || !toggleBtn) return;
 
-    // 恢复保存的状态
-    if (actionBarCollapsed) {
-        actionBar.classList.add('collapsed');
-        toggleBtn.classList.add('collapsed');
-        toggleBtn.title = '展开操作按钮';
-    }
+  // 恢复保存的状态
+  if (actionBarCollapsed) {
+    actionBar.classList.add("collapsed");
+    toggleBtn.classList.add("collapsed");
+    toggleBtn.title = "展开操作按钮";
+  }
 }
 
 // 页面加载后初始化
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initActionBarState);
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initActionBarState);
 } else {
-    initActionBarState();
+  initActionBarState();
 }
 
 // 初始化筛选状态
 function initFilterState() {
-    const savedFilter = localStorage.getItem('tokenFilter') || 'all';
-    currentFilter = savedFilter;
-    updateFilterButtonState(savedFilter);
+  const savedFilter = localStorage.getItem("tokenFilter") || "all";
+  currentFilter = savedFilter;
+  updateFilterButtonState(savedFilter);
 }
 
 // 更新筛选按钮状态
 function updateFilterButtonState(filter) {
-    document.querySelectorAll('.stat-item').forEach(item => {
-        item.classList.remove('active');
-    });
-    const filterMap = { 'all': 'totalTokens', 'enabled': 'enabledTokens', 'disabled': 'disabledTokens' };
-    const activeElement = document.getElementById(filterMap[filter]);
-    if (activeElement) {
-        activeElement.closest('.stat-item').classList.add('active');
-    }
+  document.querySelectorAll(".stat-item").forEach((item) => {
+    item.classList.remove("active");
+  });
+  const filterMap = {
+    all: "totalTokens",
+    enabled: "enabledTokens",
+    disabled: "disabledTokens",
+  };
+  const activeElement = document.getElementById(filterMap[filter]);
+  if (activeElement) {
+    activeElement.closest(".stat-item").classList.add("active");
+  }
 }
 
 // 筛选 Token
 function filterTokens(filter) {
-    currentFilter = filter;
-    localStorage.setItem('tokenFilter', filter); // 持久化筛选状态
+  currentFilter = filter;
+  localStorage.setItem("tokenFilter", filter); // 持久化筛选状态
 
-    updateFilterButtonState(filter);
+  updateFilterButtonState(filter);
 
-    // 重新渲染
-    renderTokens(cachedTokens);
+  // 重新渲染
+  renderTokens(cachedTokens);
 }
 
 async function loadTokens() {
-    try {
-        const response = await authFetch('/admin/tokens');
+  try {
+    const response = await authFetch("/admin/tokens");
 
-        const data = await response.json();
-        if (data.success) {
-            renderTokens(data.data);
-        } else {
-            showToast('加载失败: ' + (data.message || '未知错误'), 'error');
-        }
-    } catch (error) {
-        showToast('加载Token失败: ' + error.message, 'error');
+    const data = await response.json();
+    if (data.success) {
+      renderTokens(data.data);
+    } else {
+      showToast("加载失败: " + (data.message || "未知错误"), "error");
     }
+  } catch (error) {
+    showToast("加载Token失败: " + error.message, "error");
+  }
 }
 
 // 正在刷新的 Token 集合（使用 tokenId）
@@ -864,97 +943,113 @@ const refreshingTokens = new Set();
 
 // 限制 refreshingTokens 集合大小，防止内存泄漏
 function cleanupRefreshingTokens() {
-    // 如果集合过大，清空它（正常情况下不应该有太多同时刷新的 token）
-    if (refreshingTokens.size > 100) {
-        refreshingTokens.clear();
-    }
+  // 如果集合过大，清空它（正常情况下不应该有太多同时刷新的 token）
+  if (refreshingTokens.size > 100) {
+    refreshingTokens.clear();
+  }
 }
 
 function renderTokens(tokens) {
-    // 只在首次加载时更新缓存
-    if (tokens !== cachedTokens) {
-        cachedTokens = tokens;
-    }
+  // 只在首次加载时更新缓存
+  if (tokens !== cachedTokens) {
+    cachedTokens = tokens;
+  }
 
-    document.getElementById('totalTokens').textContent = tokens.length;
-    document.getElementById('enabledTokens').textContent = tokens.filter(t => t.enable).length;
-    document.getElementById('disabledTokens').textContent = tokens.filter(t => !t.enable).length;
+  document.getElementById("totalTokens").textContent = tokens.length;
+  document.getElementById("enabledTokens").textContent = tokens.filter(
+    (t) => t.enable,
+  ).length;
+  document.getElementById("disabledTokens").textContent = tokens.filter(
+    (t) => !t.enable,
+  ).length;
 
-    // 根据筛选条件过滤
-    let filteredTokens = tokens;
-    if (currentFilter === 'enabled') {
-        filteredTokens = tokens.filter(t => t.enable);
-    } else if (currentFilter === 'disabled') {
-        filteredTokens = tokens.filter(t => !t.enable);
-    }
+  // 根据筛选条件过滤
+  let filteredTokens = tokens;
+  if (currentFilter === "enabled") {
+    filteredTokens = tokens.filter((t) => t.enable);
+  } else if (currentFilter === "disabled") {
+    filteredTokens = tokens.filter((t) => !t.enable);
+  }
 
-    const tokenList = document.getElementById('tokenList');
-    if (filteredTokens.length === 0) {
-        const emptyText = currentFilter === 'all' ? '暂无Token' :
-            currentFilter === 'enabled' ? '暂无启用的Token' : '暂无禁用的Token';
-        const emptyHint = currentFilter === 'all' ? '点击上方OAuth按钮添加Token' : '点击上方"总数"查看全部';
-        tokenList.innerHTML = `
+  const tokenList = document.getElementById("tokenList");
+  if (filteredTokens.length === 0) {
+    const emptyText =
+      currentFilter === "all"
+        ? "暂无Token"
+        : currentFilter === "enabled"
+          ? "暂无启用的Token"
+          : "暂无禁用的Token";
+    const emptyHint =
+      currentFilter === "all"
+        ? "点击上方OAuth按钮添加Token"
+        : '点击上方"总数"查看全部';
+    tokenList.innerHTML = `
             <div class="empty-state">
                 <div class="empty-state-icon">📦</div>
                 <div class="empty-state-text">${emptyText}</div>
                 <div class="empty-state-hint">${emptyHint}</div>
             </div>
         `;
-        return;
-    }
+    return;
+  }
 
-    tokenList.innerHTML = filteredTokens.map((token, index) => {
-        // 使用安全的 tokenId 替代 refresh_token
-        const tokenId = token.id;
-        const isRefreshing = refreshingTokens.has(tokenId);
-        const cardId = tokenId.substring(0, 8);
+  tokenList.innerHTML = filteredTokens
+    .map((token, index) => {
+      // 使用安全的 tokenId 替代 refresh_token
+      const tokenId = token.id;
+      const isRefreshing = refreshingTokens.has(tokenId);
+      const cardId = tokenId.substring(0, 8);
 
-        // 计算在原始列表中的序号（基于添加顺序）
-        const originalIndex = cachedTokens.findIndex(t => t.id === token.id);
-        const tokenNumber = originalIndex + 1;
+      // 计算在原始列表中的序号（基于添加顺序）
+      const originalIndex = cachedTokens.findIndex((t) => t.id === token.id);
+      const tokenNumber = originalIndex + 1;
 
-        // 转义所有用户数据防止 XSS
-        const safeTokenId = escapeJs(tokenId);
-        const safeProjectId = escapeHtml(token.projectId || '');
-        const safeEmail = escapeHtml(token.email || '');
-        const safeProjectIdJs = escapeJs(token.projectId || '');
-        const safeEmailJs = escapeJs(token.email || '');
+      // 转义所有用户数据防止 XSS
+      const safeTokenId = escapeJs(tokenId);
+      const safeProjectId = escapeHtml(token.projectId || "");
+      const safeEmail = escapeHtml(token.email || "");
+      const safeProjectIdJs = escapeJs(token.projectId || "");
+      const safeEmailJs = escapeJs(token.email || "");
 
-        // 禁用原因相关
-        const disableReason = token.disableReason ? escapeHtml(token.disableReason) : '';
-        const disableTimeStr = token.disableTime ? new Date(token.disableTime).toLocaleString('zh-CN') : '';
+      // 禁用原因相关
+      const disableReason = token.disableReason
+        ? escapeHtml(token.disableReason)
+        : "";
+      const disableTimeStr = token.disableTime
+        ? new Date(token.disableTime).toLocaleString("zh-CN")
+        : "";
 
-        return `
-        <div class="token-card ${!token.enable ? 'disabled' : ''} ${isRefreshing ? 'refreshing' : ''} ${skipAnimation ? 'no-animation' : ''}" id="card-${escapeHtml(cardId)}">
+      return `
+        <div class="token-card ${!token.enable ? "disabled" : ""} ${isRefreshing ? "refreshing" : ""} ${skipAnimation ? "no-animation" : ""}" id="card-${escapeHtml(cardId)}">
             <div class="token-header">
                 <div class="token-header-left">
-                    <span class="status ${token.enable ? 'enabled' : 'disabled'}">
-                        ${token.enable ? '✅ 启用' : '❌ 禁用'}
+                    <span class="status ${token.enable ? "enabled" : "disabled"}">
+                        ${token.enable ? "✅ 启用" : "❌ 禁用"}
                     </span>
-                    <button class="btn-icon token-refresh-btn ${isRefreshing ? 'loading' : ''}" id="refresh-btn-${escapeHtml(cardId)}" onclick="manualRefreshToken('${safeTokenId}')" title="刷新Token" ${isRefreshing ? 'disabled' : ''}>🔄</button>
+                    <button class="btn-icon token-refresh-btn ${isRefreshing ? "loading" : ""}" id="refresh-btn-${escapeHtml(cardId)}" onclick="manualRefreshToken('${safeTokenId}')" title="刷新Token" ${isRefreshing ? "disabled" : ""}>🔄</button>
                 </div>
                 <div class="token-header-right">
                     <button class="btn-icon" onclick="showTokenDetail('${safeTokenId}')" title="编辑">✏️</button>
                     <span class="token-id">#${tokenNumber}</span>
                 </div>
             </div>
-            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? '禁用时间: ' + disableTimeStr : ''}">⚠️ ${disableReason}${disableTimeStr ? ' (' + disableTimeStr + ')' : ''}</div>` : ''}
+            ${!token.enable && disableReason ? `<div class="token-disable-reason" title="${disableTimeStr ? "禁用时间: " + disableTimeStr : ""}">⚠️ ${disableReason}${disableTimeStr ? " (" + disableTimeStr + ")" : ""}</div>` : ""}
             <div class="token-info">
                 <div class="info-row editable sensitive-row" onclick="editField(event, '${safeTokenId}', 'projectId', '${safeProjectIdJs}')" title="点击编辑">
                     <span class="info-label">📦</span>
-                    <span class="info-value sensitive-info">${safeProjectId || '点击设置'}</span>
+                    <span class="info-value sensitive-info">${safeProjectId || "点击设置"}</span>
                     <span class="info-edit-icon">✏️</span>
                     <button class="btn btn-xs btn-info fetch-project-btn" onclick="fetchProjectId(event, '${safeTokenId}')" title="从API获取Project ID">🔍</button>
                 </div>
                 <div class="info-row editable sensitive-row" onclick="editField(event, '${safeTokenId}', 'email', '${safeEmailJs}')" title="点击编辑">
                     <span class="info-label">📧</span>
-                    <span class="info-value sensitive-info">${safeEmail || '点击设置'}</span>
+                    <span class="info-value sensitive-info">${safeEmail || "点击设置"}</span>
                     <span class="info-edit-icon">✏️</span>
                 </div>
             </div>
             <div class="token-id-row" title="Token ID: ${escapeHtml(tokenId)}">
                 <span class="token-id-label">🔑</span>
-                <span class="token-id-value">${escapeHtml(tokenId.length > 24 ? tokenId.substring(0, 12) + '...' + tokenId.substring(tokenId.length - 8) : tokenId)}</span>
+                <span class="token-id-value">${escapeHtml(tokenId.length > 24 ? tokenId.substring(0, 12) + "..." + tokenId.substring(tokenId.length - 8) : tokenId)}</span>
             </div>
             <div class="token-quota-inline" id="quota-inline-${escapeHtml(cardId)}">
                 <div class="quota-inline-header" onclick="toggleQuotaExpand('${escapeJs(cardId)}', '${safeTokenId}')">
@@ -965,202 +1060,232 @@ function renderTokens(tokens) {
             </div>
             <div class="token-actions">
                 <button class="btn btn-info btn-xs" onclick="showQuotaModal('${safeTokenId}')" title="查看额度">📊 详情</button>
-                <button class="btn ${token.enable ? 'btn-warning' : 'btn-success'} btn-xs" onclick="toggleToken('${safeTokenId}', ${!token.enable})" title="${token.enable ? '禁用' : '启用'}">
-                    ${token.enable ? '⏸️ 禁用' : '▶️ 启用'}
+                <button class="btn ${token.enable ? "btn-warning" : "btn-success"} btn-xs" onclick="toggleToken('${safeTokenId}', ${!token.enable})" title="${token.enable ? "禁用" : "启用"}">
+                    ${token.enable ? "⏸️ 禁用" : "▶️ 启用"}
                 </button>
                 <button class="btn btn-danger btn-xs" onclick="deleteToken('${safeTokenId}')" title="删除">🗑️ 删除</button>
             </div>
         </div>
-    `}).join('');
+    `;
+    })
+    .join("");
 
-    filteredTokens.forEach(token => {
-        loadTokenQuotaSummary(token.id);
-    });
+  filteredTokens.forEach((token) => {
+    loadTokenQuotaSummary(token.id);
+  });
 
-    updateSensitiveInfoDisplay();
+  updateSensitiveInfoDisplay();
 
-    // 重置动画跳过标志
-    skipAnimation = false;
+  // 重置动画跳过标志
+  skipAnimation = false;
 }
 
 // 手动刷新 Token（使用 tokenId）
 async function manualRefreshToken(tokenId) {
-    if (refreshingTokens.has(tokenId)) {
-        showToast('该 Token 正在刷新中', 'warning');
-        return;
-    }
-    await autoRefreshToken(tokenId);
+  if (refreshingTokens.has(tokenId)) {
+    showToast("该 Token 正在刷新中", "warning");
+    return;
+  }
+  await autoRefreshToken(tokenId);
 }
 
 // 刷新指定 Token（手动触发，使用 tokenId）
 async function autoRefreshToken(tokenId) {
-    if (refreshingTokens.has(tokenId)) return;
+  if (refreshingTokens.has(tokenId)) return;
 
-    refreshingTokens.add(tokenId);
-    const cardId = tokenId.substring(0, 8);
+  refreshingTokens.add(tokenId);
+  const cardId = tokenId.substring(0, 8);
 
-    // 更新 UI 显示刷新中状态
-    const card = document.getElementById(`card-${cardId}`);
-    const refreshBtn = document.getElementById(`refresh-btn-${cardId}`);
+  // 更新 UI 显示刷新中状态
+  const card = document.getElementById(`card-${cardId}`);
+  const refreshBtn = document.getElementById(`refresh-btn-${cardId}`);
+  if (card) {
+    card.classList.remove("refresh-failed");
+    card.classList.add("refreshing");
+  }
+  if (refreshBtn) {
+    refreshBtn.disabled = true;
+    refreshBtn.classList.add("loading");
+    refreshBtn.textContent = "🔄";
+  }
+
+  try {
+    const response = await authFetch(
+      `/admin/tokens/${encodeURIComponent(tokenId)}/refresh`,
+      {
+        method: "POST",
+      },
+    );
+
+    const data = await response.json();
+    if (data.success) {
+      showToast("Token 已自动刷新", "success");
+      // 刷新成功后重新加载列表
+      refreshingTokens.delete(tokenId);
+      if (card) card.classList.remove("refreshing");
+      if (refreshBtn) {
+        refreshBtn.disabled = false;
+        refreshBtn.classList.remove("loading");
+        refreshBtn.textContent = "🔄";
+      }
+      loadTokens();
+    } else {
+      showToast(`Token 刷新失败: ${data.message || "未知错误"}`, "error");
+      refreshingTokens.delete(tokenId);
+      // 更新 UI 显示刷新失败
+      if (card) {
+        card.classList.remove("refreshing");
+        card.classList.add("refresh-failed");
+      }
+      if (refreshBtn) {
+        refreshBtn.disabled = false;
+        refreshBtn.classList.remove("loading");
+        refreshBtn.textContent = "🔄";
+      }
+    }
+  } catch (error) {
+    if (error.message !== "Unauthorized") {
+      showToast(`Token 刷新失败: ${error.message}`, "error");
+    }
+    refreshingTokens.delete(tokenId);
+    // 更新 UI 显示刷新失败
     if (card) {
-        card.classList.remove('refresh-failed');
-        card.classList.add('refreshing');
+      card.classList.remove("refreshing");
+      card.classList.add("refresh-failed");
     }
     if (refreshBtn) {
-        refreshBtn.disabled = true;
-        refreshBtn.classList.add('loading');
-        refreshBtn.textContent = '🔄';
+      refreshBtn.disabled = false;
+      refreshBtn.classList.remove("loading");
+      refreshBtn.textContent = "🔄";
     }
-
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}/refresh`, {
-            method: 'POST'
-        });
-
-        const data = await response.json();
-        if (data.success) {
-            showToast('Token 已自动刷新', 'success');
-            // 刷新成功后重新加载列表
-            refreshingTokens.delete(tokenId);
-            if (card) card.classList.remove('refreshing');
-            if (refreshBtn) {
-                refreshBtn.disabled = false;
-                refreshBtn.classList.remove('loading');
-                refreshBtn.textContent = '🔄';
-            }
-            loadTokens();
-        } else {
-            showToast(`Token 刷新失败: ${data.message || '未知错误'}`, 'error');
-            refreshingTokens.delete(tokenId);
-            // 更新 UI 显示刷新失败
-            if (card) {
-                card.classList.remove('refreshing');
-                card.classList.add('refresh-failed');
-            }
-            if (refreshBtn) {
-                refreshBtn.disabled = false;
-                refreshBtn.classList.remove('loading');
-                refreshBtn.textContent = '🔄';
-            }
-        }
-    } catch (error) {
-        if (error.message !== 'Unauthorized') {
-            showToast(`Token 刷新失败: ${error.message}`, 'error');
-        }
-        refreshingTokens.delete(tokenId);
-        // 更新 UI 显示刷新失败
-        if (card) {
-            card.classList.remove('refreshing');
-            card.classList.add('refresh-failed');
-        }
-        if (refreshBtn) {
-            refreshBtn.disabled = false;
-            refreshBtn.classList.remove('loading');
-            refreshBtn.textContent = '🔄';
-        }
-    }
+  }
 }
 
 // showManualModal 已合并到 showImportUploadModal 中
 function showManualModal() {
-    // 打开导入弹窗并切换到手动填入标签
-    showImportUploadModal();
-    // 延迟切换标签，确保DOM已渲染
-    setTimeout(() => switchImportTab('manual'), 0);
+  // 打开导入弹窗并切换到手动填入标签
+  showImportUploadModal();
+  // 延迟切换标签，确保DOM已渲染
+  setTimeout(() => switchImportTab("manual"), 0);
 }
 
 function editField(event, tokenId, field, currentValue) {
-    event.stopPropagation();
-    const row = event.currentTarget;
-    const valueSpan = row.querySelector('.info-value');
+  event.stopPropagation();
+  const row = event.currentTarget;
+  const valueSpan = row.querySelector(".info-value");
 
-    if (row.querySelector('input')) return;
+  if (row.querySelector("input")) return;
 
-    const fieldLabels = { projectId: 'Project ID', email: '邮箱' };
+  const fieldLabels = { projectId: "Project ID", email: "邮箱" };
 
-    const input = document.createElement('input');
-    input.type = field === 'email' ? 'email' : 'text';
-    input.value = currentValue;
-    input.className = 'inline-edit-input';
-    input.placeholder = `输入${fieldLabels[field]}`;
+  const input = document.createElement("input");
+  input.type = field === "email" ? "email" : "text";
+  input.value = currentValue;
+  input.className = "inline-edit-input";
+  input.placeholder = `输入${fieldLabels[field]}`;
 
-    valueSpan.style.display = 'none';
-    row.insertBefore(input, valueSpan.nextSibling);
-    input.focus();
-    input.select();
+  valueSpan.style.display = "none";
+  row.insertBefore(input, valueSpan.nextSibling);
+  input.focus();
+  input.select();
 
-    const save = async () => {
-        const newValue = input.value.trim();
-        input.disabled = true;
+  const save = async () => {
+    const newValue = input.value.trim();
+    input.disabled = true;
 
-        try {
-            const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ [field]: newValue })
-            });
+    try {
+      const response = await authFetch(
+        `/admin/tokens/${encodeURIComponent(tokenId)}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ [field]: newValue }),
+        },
+      );
 
-            const data = await response.json();
-            if (data.success) {
-                showToast('已保存', 'success');
-                loadTokens();
-            } else {
-                showToast(data.message || '保存失败', 'error');
-                cancel();
-            }
-        } catch (error) {
-            showToast('保存失败', 'error');
-            cancel();
+      const data = await response.json();
+      if (data.success) {
+        showToast("已保存", "success");
+        loadTokens();
+      } else {
+        showToast(data.message || "保存失败", "error");
+        cancel();
+      }
+    } catch (error) {
+      showToast("保存失败", "error");
+      cancel();
+    }
+  };
+
+  const cancel = () => {
+    input.remove();
+    valueSpan.style.display = "";
+  };
+
+  input.addEventListener("blur", () => {
+    setTimeout(() => {
+      if (document.activeElement !== input) {
+        if (input.value.trim() !== currentValue) {
+          save();
+        } else {
+          cancel();
         }
-    };
+      }
+    }, 100);
+  });
 
-    const cancel = () => {
-        input.remove();
-        valueSpan.style.display = '';
-    };
-
-    input.addEventListener('blur', () => {
-        setTimeout(() => {
-            if (document.activeElement !== input) {
-                if (input.value.trim() !== currentValue) {
-                    save();
-                } else {
-                    cancel();
-                }
-            }
-        }, 100);
-    });
-
-    input.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            save();
-        } else if (e.key === 'Escape') {
-            cancel();
-        }
-    });
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      save();
+    } else if (e.key === "Escape") {
+      cancel();
+    }
+  });
 }
 
 function showTokenDetail(tokenId) {
-    const token = cachedTokens.find(t => t.id === tokenId);
-    if (!token) {
-        showToast('Token不存在', 'error');
-        return;
-    }
+  const token = cachedTokens.find((t) => t.id === tokenId);
+  if (!token) {
+    showToast("Token不存在", "error");
+    return;
+  }
 
-    // 转义所有用户数据防止 XSS
-    const safeTokenId = escapeJs(tokenId);
-    const safeProjectId = escapeHtml(token.projectId || '');
-    const safeEmail = escapeHtml(token.email || '');
-    const updatedAtStr = escapeHtml(token.timestamp ? new Date(token.timestamp).toLocaleString('zh-CN') : '未知');
-    const disableReason = token.disableReason ? escapeHtml(token.disableReason) : '';
-    const disableTimeStr = token.disableTime ? new Date(token.disableTime).toLocaleString('zh-CN') : '';
+  // 转义所有用户数据防止 XSS
+  const safeTokenId = escapeJs(tokenId);
+  const safeProjectId = escapeHtml(token.projectId || "");
+  const safeEmail = escapeHtml(token.email || "");
+  const updatedAtStr = escapeHtml(
+    token.timestamp
+      ? new Date(token.timestamp).toLocaleString("zh-CN")
+      : "未知",
+  );
+  const disableReason = token.disableReason
+    ? escapeHtml(token.disableReason)
+    : "";
+  const disableTimeStr = token.disableTime
+    ? new Date(token.disableTime).toLocaleString("zh-CN")
+    : "";
+  const lastError = token.lastError ? escapeHtml(token.lastError) : "";
+  const lastErrorTimeStr = token.lastErrorTime
+    ? new Date(token.lastErrorTime).toLocaleString("zh-CN")
+    : "";
+  const lastErrorStageLabel =
+    token.lastErrorStage === "startup_refresh"
+      ? "启动检测"
+      : token.lastErrorStage === "disable"
+        ? "禁用"
+        : token.lastErrorStage === "manual"
+          ? "手动"
+          : token.lastErrorStage === "request"
+            ? "请求"
+            : token.lastErrorStage || "";
 
-    const modal = document.createElement('div');
-    modal.className = 'modal form-modal';
-    modal.innerHTML = `
+  const modal = document.createElement("div");
+  modal.className = "modal form-modal";
+  modal.innerHTML = `
         <div class="modal-content">
             <div class="modal-title">📝 Token详情</div>
             <div class="form-group compact">
@@ -1179,168 +1304,206 @@ function showTokenDetail(tokenId) {
                 <label>🕒 最后更新时间</label>
                 <input type="text" value="${updatedAtStr}" readonly style="background: var(--bg); cursor: not-allowed;">
             </div>
-            ${!token.enable && disableReason ? `
+            ${
+              lastError
+                ? `
+            <div class="form-group compact">
+                <label>🧾 最近错误</label>
+                <div class="token-error-detail">
+                    ${lastError}
+                    ${lastErrorTimeStr || lastErrorStageLabel ? `<br><span class="token-error-meta">${lastErrorTimeStr ? "记录时间: " + lastErrorTimeStr : ""}${lastErrorTimeStr && lastErrorStageLabel ? " · " : ""}${lastErrorStageLabel ? "来源: " + lastErrorStageLabel : ""}</span>` : ""}
+                </div>
+            </div>
+            `
+                : ""
+            }
+            ${
+              !token.enable && disableReason
+                ? `
             <div class="form-group compact">
                 <label>⚠️ 禁用原因</label>
-                <div class="token-disable-detail" style="padding: 0.5rem; background: var(--danger-bg, rgba(220,53,69,0.1)); border-radius: 6px; font-size: 0.85rem; color: var(--danger, #dc3545); word-break: break-all;">${disableReason}${disableTimeStr ? '<br><span style="color: var(--text-light); font-size: 0.8rem;">禁用时间: ' + disableTimeStr + '</span>' : ''}</div>
+                <div class="token-disable-detail" style="padding: 0.5rem; background: var(--danger-bg, rgba(220,53,69,0.1)); border-radius: 6px; font-size: 0.85rem; color: var(--danger, #dc3545); word-break: break-all;">${disableReason}${disableTimeStr ? '<br><span style="color: var(--text-light); font-size: 0.8rem;">禁用时间: ' + disableTimeStr + "</span>" : ""}</div>
             </div>
-            ` : ''}
+            `
+                : ""
+            }
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="this.closest('.modal').remove()">取消</button>
                 <button class="btn btn-success" onclick="saveTokenDetail('${safeTokenId}')">💾 保存</button>
             </div>
         </div>
     `;
-    document.body.appendChild(modal);
-    modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
+  document.body.appendChild(modal);
+  modal.onclick = (e) => {
+    if (e.target === modal) modal.remove();
+  };
 }
 
 async function saveTokenDetail(tokenId) {
-    const projectId = document.getElementById('editProjectId').value.trim();
-    const email = document.getElementById('editEmail').value.trim();
+  const projectId = document.getElementById("editProjectId").value.trim();
+  const email = document.getElementById("editEmail").value.trim();
 
-    showLoading('保存中...');
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ projectId, email })
-        });
+  showLoading("保存中...");
+  try {
+    const response = await authFetch(
+      `/admin/tokens/${encodeURIComponent(tokenId)}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ projectId, email }),
+      },
+    );
 
-        const data = await response.json();
-        hideLoading();
-        if (data.success) {
-            document.querySelector('.form-modal').remove();
-            showToast('保存成功', 'success');
-            loadTokens();
-        } else {
-            showToast(data.message || '保存失败', 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('保存失败: ' + error.message, 'error');
+    const data = await response.json();
+    hideLoading();
+    if (data.success) {
+      document.querySelector(".form-modal").remove();
+      showToast("保存成功", "success");
+      loadTokens();
+    } else {
+      showToast(data.message || "保存失败", "error");
     }
+  } catch (error) {
+    hideLoading();
+    showToast("保存失败: " + error.message, "error");
+  }
 }
 
 async function toggleToken(tokenId, enable) {
-    const action = enable ? '启用' : '禁用';
-    const confirmMsg = enable
-        ? '确定要启用这个Token吗？\n系统将先验证凭证可用性，验证通过后才会启用。'
-        : '确定要禁用这个Token吗？';
-    const confirmed = await showConfirm(confirmMsg, `${action}确认`);
-    if (!confirmed) return;
+  const action = enable ? "启用" : "禁用";
+  const confirmMsg = enable
+    ? "确定要启用这个Token吗？\n系统将先验证凭证可用性，验证通过后才会启用。"
+    : "确定要禁用这个Token吗？";
+  const confirmed = await showConfirm(confirmMsg, `${action}确认`);
+  if (!confirmed) return;
 
-    showLoading(enable ? '正在验证凭证可用性...' : `正在${action}...`);
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(enable ? { enable, enableWithTest: true } : { enable })
-        });
+  showLoading(enable ? "正在验证凭证可用性..." : `正在${action}...`);
+  try {
+    const response = await authFetch(
+      `/admin/tokens/${encodeURIComponent(tokenId)}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          enable ? { enable, enableWithTest: true } : { enable },
+        ),
+      },
+    );
 
-        const data = await response.json();
-        hideLoading();
-        if (data.success) {
-            showToast(`已${action}`, 'success');
-            skipAnimation = true; // 跳过动画
-            loadTokens();
-        } else {
-            showToast(data.message || '操作失败', enable ? 'warning' : 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('操作失败: ' + error.message, 'error');
+    const data = await response.json();
+    hideLoading();
+    if (data.success) {
+      showToast(`已${action}`, "success");
+      skipAnimation = true; // 跳过动画
+      loadTokens();
+    } else {
+      showToast(data.message || "操作失败", enable ? "warning" : "error");
     }
+  } catch (error) {
+    hideLoading();
+    showToast("操作失败: " + error.message, "error");
+  }
 }
 
 async function deleteToken(tokenId) {
-    const confirmed = await showConfirm('删除后无法恢复，确定删除？', '⚠️ 删除确认');
-    if (!confirmed) return;
+  const confirmed = await showConfirm(
+    "删除后无法恢复，确定删除？",
+    "⚠️ 删除确认",
+  );
+  if (!confirmed) return;
 
-    showLoading('正在删除...');
-    try {
-        const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
-            method: 'DELETE'
-        });
+  showLoading("正在删除...");
+  try {
+    const response = await authFetch(
+      `/admin/tokens/${encodeURIComponent(tokenId)}`,
+      {
+        method: "DELETE",
+      },
+    );
 
-        const data = await response.json();
-        hideLoading();
-        if (data.success) {
-            showToast('已删除', 'success');
-            loadTokens();
-        } else {
-            showToast(data.message || '删除失败', 'error');
-        }
-    } catch (error) {
-        hideLoading();
-        showToast('删除失败: ' + error.message, 'error');
+    const data = await response.json();
+    hideLoading();
+    if (data.success) {
+      showToast("已删除", "success");
+      loadTokens();
+    } else {
+      showToast(data.message || "删除失败", "error");
     }
+  } catch (error) {
+    hideLoading();
+    showToast("删除失败: " + error.message, "error");
+  }
 }
 
 // 手动填入表单中自动获取 Project ID
 async function fetchProjectIdForManual() {
-    const accessToken = document.getElementById('manualAccessToken').value.trim();
-    const refreshToken = document.getElementById('manualRefreshToken').value.trim();
+  const accessToken = document.getElementById("manualAccessToken").value.trim();
+  const refreshToken = document
+    .getElementById("manualRefreshToken")
+    .value.trim();
 
-    if (!accessToken || !refreshToken) {
-        showToast('请先填写 Access Token 和 Refresh Token', 'warning');
-        return;
+  if (!accessToken || !refreshToken) {
+    showToast("请先填写 Access Token 和 Refresh Token", "warning");
+    return;
+  }
+
+  const btn = document.getElementById("fetchProjectIdBtn");
+  const originalText = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "⏳ 获取中...";
+
+  try {
+    // 先添加 Token（临时），然后获取 Project ID
+    const addResponse = await authFetch("/admin/tokens", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        expires_in: 3599,
+      }),
+    });
+
+    const addData = await addResponse.json();
+    if (!addData.success) {
+      throw new Error(addData.message || "添加 Token 失败");
     }
 
-    const btn = document.getElementById('fetchProjectIdBtn');
-    const originalText = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = '⏳ 获取中...';
+    const tokenId = addData.tokenId;
 
-    try {
-        // 先添加 Token（临时），然后获取 Project ID
-        const addResponse = await authFetch('/admin/tokens', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                access_token: accessToken,
-                refresh_token: refreshToken,
-                expires_in: 3599
-            })
-        });
+    // 获取 Project ID
+    const fetchResponse = await authFetch(
+      `/admin/tokens/${encodeURIComponent(tokenId)}/fetch-project-id`,
+      {
+        method: "POST",
+      },
+    );
 
-        const addData = await addResponse.json();
-        if (!addData.success) {
-            throw new Error(addData.message || '添加 Token 失败');
-        }
+    const fetchData = await fetchResponse.json();
 
-        const tokenId = addData.tokenId;
+    if (fetchData.success && fetchData.projectId) {
+      document.getElementById("manualProjectId").value = fetchData.projectId;
+      showToast(`获取成功: ${fetchData.projectId}`, "success");
 
-        // 获取 Project ID
-        const fetchResponse = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}/fetch-project-id`, {
-            method: 'POST'
-        });
-
-        const fetchData = await fetchResponse.json();
-
-        if (fetchData.success && fetchData.projectId) {
-            document.getElementById('manualProjectId').value = fetchData.projectId;
-            showToast(`获取成功: ${fetchData.projectId}`, 'success');
-
-            // 删除临时添加的 Token（因为用户还没确认）
-            await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
-                method: 'DELETE'
-            });
-        } else {
-            // 删除临时 Token
-            await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
-                method: 'DELETE'
-            });
-            throw new Error(fetchData.message || '该账号无法获取 Project ID');
-        }
-    } catch (error) {
-        showToast('获取失败: ' + error.message, 'error');
-    } finally {
-        btn.disabled = false;
-        btn.textContent = originalText;
+      // 删除临时添加的 Token（因为用户还没确认）
+      await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
+        method: "DELETE",
+      });
+    } else {
+      // 删除临时 Token
+      await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
+        method: "DELETE",
+      });
+      throw new Error(fetchData.message || "该账号无法获取 Project ID");
     }
+  } catch (error) {
+    showToast("获取失败: " + error.message, "error");
+  } finally {
+    btn.disabled = false;
+    btn.textContent = originalText;
+  }
 }

--- a/public/js/tokens.js
+++ b/public/js/tokens.js
@@ -1226,17 +1226,20 @@ async function saveTokenDetail(tokenId) {
 
 async function toggleToken(tokenId, enable) {
     const action = enable ? '启用' : '禁用';
-    const confirmed = await showConfirm(`确定要${action}这个Token吗？`, `${action}确认`);
+    const confirmMsg = enable
+        ? '确定要启用这个Token吗？\n系统将先验证凭证可用性，验证通过后才会启用。'
+        : '确定要禁用这个Token吗？';
+    const confirmed = await showConfirm(confirmMsg, `${action}确认`);
     if (!confirmed) return;
 
-    showLoading(`正在${action}...`);
+    showLoading(enable ? '正在验证凭证可用性...' : `正在${action}...`);
     try {
         const response = await authFetch(`/admin/tokens/${encodeURIComponent(tokenId)}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ enable })
+            body: JSON.stringify(enable ? { enable, enableWithTest: true } : { enable })
         });
 
         const data = await response.json();
@@ -1246,7 +1249,7 @@ async function toggleToken(tokenId, enable) {
             skipAnimation = true; // 跳过动画
             loadTokens();
         } else {
-            showToast(data.message || '操作失败', 'error');
+            showToast(data.message || '操作失败', enable ? 'warning' : 'error');
         }
     } catch (error) {
         hideLoading();

--- a/public/js/tokens.js
+++ b/public/js/tokens.js
@@ -723,7 +723,8 @@ async function confirmImportFromModal() {
 
       if (data.success) {
         closeImportModal();
-        showToast("Token添加成功", "success");
+        const toastType = data.disabled ? "warning" : "success";
+        showToast(data.message || "Token添加成功", toastType);
         loadTokens();
       } else {
         showToast(data.message || "添加失败", "error");
@@ -1283,7 +1284,9 @@ function showTokenDetail(tokenId) {
             ? "请求"
             : token.lastErrorStage === "enable_test"
               ? "启用验证"
-              : token.lastErrorStage || "";
+              : token.lastErrorStage === "oauth_submit"
+                ? "OAuth提交校验"
+                : token.lastErrorStage || "";
 
   const modal = document.createElement("div");
   modal.className = "modal form-modal";

--- a/public/js/tokens.js
+++ b/public/js/tokens.js
@@ -1281,7 +1281,9 @@ function showTokenDetail(tokenId) {
           ? "手动"
           : token.lastErrorStage === "request"
             ? "请求"
-            : token.lastErrorStage || "";
+            : token.lastErrorStage === "enable_test"
+              ? "启用验证"
+              : token.lastErrorStage || "";
 
   const modal = document.createElement("div");
   modal.className = "modal form-modal";
@@ -1402,6 +1404,11 @@ async function toggleToken(tokenId, enable) {
       loadTokens();
     } else {
       showToast(data.message || "操作失败", enable ? "warning" : "error");
+      // 启用验证失败时也刷新列表，以显示后端记录的错误详情
+      if (enable) {
+        skipAnimation = true;
+        loadTokens();
+      }
     }
   } catch (error) {
     hideLoading();

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,93 +1,219 @@
 // HTML 转义函数 - 防止 XSS 注入
 function escapeHtml(str) {
-    if (str === null || str === undefined) return '';
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+  if (str === null || str === undefined) return "";
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 // 转义用于 JavaScript 字符串的内容
 function escapeJs(str) {
-    if (str === null || str === undefined) return '';
-    return String(str)
-        .replace(/\\/g, '\\\\')
-        .replace(/'/g, "\\'")
-        .replace(/"/g, '\\"')
-        .replace(/\n/g, '\\n')
-        .replace(/\r/g, '\\r');
+  if (str === null || str === undefined) return "";
+  return String(str)
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
 }
 
 // 字体大小设置
 function initFontSize() {
-    const savedSize = localStorage.getItem('fontSize') || '18';
-    document.documentElement.style.setProperty('--font-size-base', savedSize + 'px');
-    updateFontSizeInputs(savedSize);
+  const savedSize = localStorage.getItem("fontSize") || "18";
+  document.documentElement.style.setProperty(
+    "--font-size-base",
+    savedSize + "px",
+  );
+  updateFontSizeInputs(savedSize);
 }
 
 function changeFontSize(size) {
-    size = Math.max(10, Math.min(24, parseInt(size) || 14));
-    document.documentElement.style.setProperty('--font-size-base', size + 'px');
-    localStorage.setItem('fontSize', size);
-    updateFontSizeInputs(size);
+  size = Math.max(10, Math.min(24, parseInt(size) || 14));
+  document.documentElement.style.setProperty("--font-size-base", size + "px");
+  localStorage.setItem("fontSize", size);
+  updateFontSizeInputs(size);
 }
 
 function updateFontSizeInputs(size) {
-    const rangeInput = document.getElementById('fontSizeRange');
-    const numberInput = document.getElementById('fontSizeInput');
-    if (rangeInput) rangeInput.value = size;
-    if (numberInput) numberInput.value = size;
+  const rangeInput = document.getElementById("fontSizeRange");
+  const numberInput = document.getElementById("fontSizeInput");
+  if (rangeInput) rangeInput.value = size;
+  if (numberInput) numberInput.value = size;
 }
 
 // 敏感信息隐藏功能
-let sensitiveInfoHidden = localStorage.getItem('sensitiveInfoHidden') !== 'false';
+let sensitiveInfoHidden =
+  localStorage.getItem("sensitiveInfoHidden") !== "false";
 
 function initSensitiveInfo() {
-    updateSensitiveInfoDisplay();
-    updateSensitiveBtn();
+  updateSensitiveInfoDisplay();
+  updateSensitiveBtn();
 }
 
 function toggleSensitiveInfo() {
-    sensitiveInfoHidden = !sensitiveInfoHidden;
-    localStorage.setItem('sensitiveInfoHidden', sensitiveInfoHidden);
-    updateSensitiveInfoDisplay();
-    updateSensitiveBtn();
+  sensitiveInfoHidden = !sensitiveInfoHidden;
+  localStorage.setItem("sensitiveInfoHidden", sensitiveInfoHidden);
+  updateSensitiveInfoDisplay();
+  updateSensitiveBtn();
 }
 
 function updateSensitiveBtn() {
-    const btn = document.getElementById('toggleSensitiveBtn');
-    if (btn) {
-        if (sensitiveInfoHidden) {
-            btn.innerHTML = '🙈 隐藏';
-            btn.title = '点击显示敏感信息';
-            btn.classList.remove('btn-info');
-            btn.classList.add('btn-secondary');
-        } else {
-            btn.innerHTML = '👁️ 显示';
-            btn.title = '点击隐藏敏感信息';
-            btn.classList.remove('btn-secondary');
-            btn.classList.add('btn-info');
-        }
+  const btn = document.getElementById("toggleSensitiveBtn");
+  if (btn) {
+    if (sensitiveInfoHidden) {
+      btn.innerHTML = "🙈 隐藏";
+      btn.title = "点击显示敏感信息";
+      btn.classList.remove("btn-info");
+      btn.classList.add("btn-secondary");
+    } else {
+      btn.innerHTML = "👁️ 显示";
+      btn.title = "点击隐藏敏感信息";
+      btn.classList.remove("btn-secondary");
+      btn.classList.add("btn-info");
     }
+  }
 }
 
 function updateSensitiveInfoDisplay() {
-    // 隐藏/显示包含敏感信息的整行
-    document.querySelectorAll('.sensitive-row').forEach(row => {
-        if (sensitiveInfoHidden) {
-            row.style.display = 'none';
-        } else {
-            row.style.display = '';
+  // 隐藏/显示包含敏感信息的整行
+  document.querySelectorAll(".sensitive-row").forEach((row) => {
+    if (sensitiveInfoHidden) {
+      row.style.display = "none";
+    } else {
+      row.style.display = "";
+    }
+  });
+  // 同时隐藏/显示 token-info 容器
+  document.querySelectorAll(".token-info").forEach((container) => {
+    if (sensitiveInfoHidden) {
+      container.style.display = "none";
+    } else {
+      container.style.display = "";
+    }
+  });
+}
+
+// 从 403 错误文本中提取 validation_url 或 appeal_url
+// 错误文本格式通常为: "API请求返回403: {JSON...}"
+function parse403ErrorUrls(errorText) {
+  if (!errorText) return null;
+  try {
+    // 尝试从错误文本中提取 JSON 部分
+    const jsonMatch = errorText.match(/\{[\s\S]*\}$/);
+    if (!jsonMatch) return null;
+
+    const parsed = JSON.parse(jsonMatch[0]);
+    if (!parsed?.error || parsed.error.code !== 403) return null;
+
+    const details = parsed.error.details;
+    if (!Array.isArray(details)) return null;
+
+    const result = {
+      message: parsed.error.message || "",
+      reason: "",
+      urls: [],
+    };
+
+    for (const detail of details) {
+      if (detail["@type"] === "type.googleapis.com/google.rpc.ErrorInfo") {
+        result.reason = detail.reason || "";
+        const metadata = detail.metadata || {};
+
+        // VALIDATION_REQUIRED 类型 - 需要验证账号
+        if (metadata.validation_url) {
+          result.urls.push({
+            type: "validation",
+            label: metadata.validation_url_link_text || "验证账号",
+            url: metadata.validation_url,
+            description: metadata.validation_error_message || "需要验证账号",
+          });
         }
-    });
-    // 同时隐藏/显示 token-info 容器
-    document.querySelectorAll('.token-info').forEach(container => {
-        if (sensitiveInfoHidden) {
-            container.style.display = 'none';
-        } else {
-            container.style.display = '';
+
+        // TOS_VIOLATION 类型 - 需要申诉
+        if (metadata.appeal_url) {
+          result.urls.push({
+            type: "appeal",
+            label: metadata.appeal_url_link_text || "提交申诉",
+            url: metadata.appeal_url,
+            description:
+              metadata.uiMessage === "true"
+                ? parsed.error.message
+                : "服务因违反条款被禁用",
+          });
         }
+      }
+    }
+
+    return result.urls.length > 0 ? result : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+// 渲染 403 错误 URL 操作区域的 HTML
+function render403ActionUrls(errorText) {
+  const parsed = parse403ErrorUrls(errorText);
+  if (!parsed) return "";
+
+  let html = '<div class="error-403-actions">';
+
+  for (const urlInfo of parsed.urls) {
+    const icon = urlInfo.type === "validation" ? "🔐" : "📋";
+    const safeUrl = escapeHtml(urlInfo.url);
+    const safeLabel = escapeHtml(urlInfo.label);
+    const safeDesc = escapeHtml(urlInfo.description);
+    const badgeClass =
+      urlInfo.type === "validation" ? "badge-validation" : "badge-appeal";
+    const badgeText =
+      urlInfo.type === "validation" ? "VALIDATION_REQUIRED" : "TOS_VIOLATION";
+
+    html += `
+            <div class="error-403-url-item">
+                <div class="error-403-url-header">
+                    <span class="error-403-badge ${badgeClass}">${icon} ${badgeText}</span>
+                </div>
+                <div class="error-403-url-desc">${safeDesc}</div>
+                <div class="error-403-url-row">
+                    <input type="text" class="error-403-url-input" value="${safeUrl}" readonly onclick="this.select()">
+                    <button class="btn btn-xs btn-info error-403-copy-btn" onclick="copy403Url(this, '${escapeJs(urlInfo.url)}')" title="复制链接">📋</button>
+                </div>
+            </div>`;
+  }
+
+  html += "</div>";
+  return html;
+}
+
+// 复制 403 错误中的 URL
+function copy403Url(btn, url) {
+  navigator.clipboard
+    .writeText(url)
+    .then(() => {
+      const originalText = btn.textContent;
+      btn.textContent = "✅";
+      btn.classList.remove("btn-info");
+      btn.classList.add("btn-success");
+      setTimeout(() => {
+        btn.textContent = originalText;
+        btn.classList.remove("btn-success");
+        btn.classList.add("btn-info");
+      }, 1500);
+      if (typeof showToast === "function") {
+        showToast("链接已复制到剪贴板", "success");
+      }
+    })
+    .catch(() => {
+      // 降级方案：选中输入框内容
+      const input = btn.previousElementSibling;
+      if (input) {
+        input.select();
+        document.execCommand("copy");
+        if (typeof showToast === "function") {
+          showToast("链接已复制到剪贴板", "success");
+        }
+      }
     });
 }

--- a/public/style.css
+++ b/public/style.css
@@ -751,6 +751,8 @@ html.tab-logs .content {
   line-height: 1.4;
   word-break: break-all;
   border-left: 3px solid var(--danger, #dc3545);
+  max-height: 4.5em;
+  overflow-y: auto;
 }
 
 .token-error-detail {
@@ -760,6 +762,8 @@ html.tab-logs .content {
   font-size: 0.85rem;
   color: var(--warning, #f59e0b);
   word-break: break-all;
+  max-height: 4.5em;
+  overflow-y: auto;
 }
 
 .token-error-meta {
@@ -1448,6 +1452,8 @@ html.tab-logs .content {
   padding: 1.25rem;
   max-width: 400px;
   width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
   animation: scaleIn 0.2s;
   border: 1px solid rgba(255, 255, 255, 0.5);

--- a/public/style.css
+++ b/public/style.css
@@ -1,134 +1,143 @@
 :root {
-    --primary: #0891b2;
-    --primary-dark: #0e7490;
-    --success: #10b981;
-    --danger: #ef4444;
-    --warning: #f59e0b;
-    --info: #06b6d4;
-    --bg: #f8fafc;
-    --card: #ffffff;
-    --text: #1e293b;
-    --text-light: #64748b;
-    --border: #e2e8f0;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    --font-size-base: 18px;
+  --primary: #0891b2;
+  --primary-dark: #0e7490;
+  --success: #10b981;
+  --danger: #ef4444;
+  --warning: #f59e0b;
+  --info: #06b6d4;
+  --bg: #f8fafc;
+  --card: #ffffff;
+  --text: #1e293b;
+  --text-light: #64748b;
+  --border: #e2e8f0;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --font-size-base: 18px;
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
-        --bg: #0f172a;
-        --card: #1e293b;
-        --text: #f1f5f9;
-        --text-light: #94a3b8;
-        --border: #334155;
-    }
+  :root {
+    --bg: #0f172a;
+    --card: #1e293b;
+    --text: #f1f5f9;
+    --text-light: #94a3b8;
+    --border: #334155;
+  }
 }
 
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 /* 固定背景图片 - 使用本地图片（快速加载） */
 body::before {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--bg);
-    background-image: url('assets/bg.jpg');
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
-    z-index: -1;
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--bg);
+  background-image: url("assets/bg.jpg");
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  z-index: -1;
 }
 
 /* iOS风格滚动条 */
 ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
-    background: transparent;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 10px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.35);
+  background: rgba(0, 0, 0, 0.35);
 }
 
 ::-webkit-scrollbar-thumb:active {
-    background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.5);
 }
 
 ::-webkit-scrollbar-corner {
-    background: transparent;
+  background: transparent;
 }
 
 /* 暗色模式下的滚动条 */
 @media (prefers-color-scheme: dark) {
-    ::-webkit-scrollbar-thumb {
-        background: rgba(255, 255, 255, 0.2);
-    }
+  ::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+  }
 
-    ::-webkit-scrollbar-thumb:hover {
-        background: rgba(255, 255, 255, 0.35);
-    }
+  ::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.35);
+  }
 
-    ::-webkit-scrollbar-thumb:active {
-        background: rgba(255, 255, 255, 0.5);
-    }
+  ::-webkit-scrollbar-thumb:active {
+    background: rgba(255, 255, 255, 0.5);
+  }
 }
 
 /* Firefox 滚动条 */
 * {
-    scrollbar-width: thin;
-    scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
 }
 
 @media (prefers-color-scheme: dark) {
-    * {
-        scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
-    }
+  * {
+    scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+  }
 }
 
 html {
-    font-size: var(--font-size-base);
+  font-size: var(--font-size-base);
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Ubuntu Mono', 'MiSans';
-    background: var(--bg);
-    color: var(--text);
-    line-height: 1.5;
-    height: 100vh;
-    overflow: hidden;
-    font-size: 1rem;
-    /* 字体渲染优化 */
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-    font-weight: 400;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, "Noto Sans", sans-serif, "Ubuntu Mono", "MiSans";
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  height: 100vh;
+  overflow: hidden;
+  font-size: 1rem;
+  /* 字体渲染优化 */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-weight: 400;
 }
 
 /* 字体加载完成后应用 */
 .fonts-loaded body {
-    font-family: 'Ubuntu Mono', 'MiSans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    "Ubuntu Mono",
+    "MiSans",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
 }
 
 /* 确保所有元素继承字体 */
 *,
 *::before,
 *::after {
-    font-family: inherit;
+  font-family: inherit;
 }
 
 /* 等宽字体用于代码/Token显示 */
@@ -136,3671 +145,3696 @@ code,
 pre,
 .mono,
 .token-display {
-    font-family: 'Ubuntu Mono', 'Consolas', 'Monaco', monospace !important;
+  font-family: "Ubuntu Mono", "Consolas", "Monaco", monospace !important;
 }
 
 .container {
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 0.5rem;
-    height: 100vh;
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0.5rem;
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
 /* 登录表单 */
 .login-form {
-    margin: auto;
-    background: rgba(255, 255, 255, 0.6);
-    backdrop-filter: blur(24px) saturate(180%);
-    -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border-radius: 1rem;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-    max-width: 400px;
-    width: 100%;
-    padding: 2rem;
-    border: 1px solid rgba(255, 255, 255, 0.5);
+  margin: auto;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border-radius: 1rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  max-width: 400px;
+  width: 100%;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.5);
 }
 
 @media (prefers-color-scheme: dark) {
-    .login-form {
-        background: rgba(30, 41, 59, 0.65);
-        border: 1px solid rgba(255, 255, 255, 0.2);
-    }
+  .login-form {
+    background: rgba(30, 41, 59, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+  }
 }
 
 .login-form h2 {
-    text-align: center;
-    margin-bottom: 1.5rem;
-    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    font-size: 1.5rem;
-    font-weight: 700;
+  text-align: center;
+  margin-bottom: 1.5rem;
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  font-size: 1.5rem;
+  font-weight: 700;
 }
 
 .form-group {
-    margin-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
 label {
-    display: block;
-    margin-bottom: 0.5rem;
-    font-weight: 600;
-    color: var(--text);
-    font-size: 0.875rem;
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--text);
+  font-size: 0.875rem;
 }
 
 input,
 select,
 textarea {
-    width: 100%;
-    min-height: 40px;
-    padding: 0.5rem 0.75rem 0.5rem 0.5rem !important;
-    border: 1.5px solid var(--border);
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
-    background: var(--card);
-    color: var(--text);
-    transition: all 0.2s;
+  width: 100%;
+  min-height: 40px;
+  padding: 0.5rem 0.75rem 0.5rem 0.5rem !important;
+  border: 1.5px solid var(--border);
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  background: var(--card);
+  color: var(--text);
+  transition: all 0.2s;
 }
 
 input:focus,
 select:focus,
 textarea:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(8, 145, 178, 0.1);
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(8, 145, 178, 0.1);
 }
 
 input::placeholder,
 textarea::placeholder {
-    color: var(--text-light);
-    opacity: 0.6;
+  color: var(--text-light);
+  opacity: 0.6;
 }
 
 button {
-    width: 100%;
-    min-height: 44px;
-    padding: 0.75rem;
-    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-    color: white;
-    border: none;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    font-size: 0.95rem;
-    font-weight: 600;
-    transition: all 0.2s;
-    box-shadow: 0 2px 8px rgba(8, 145, 178, 0.2);
+  width: 100%;
+  min-height: 44px;
+  padding: 0.75rem;
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: all 0.2s;
+  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.2);
 }
 
 button:hover:not(:disabled) {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(8, 145, 178, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(8, 145, 178, 0.3);
 }
 
 button:active:not(:disabled) {
-    transform: translateY(0);
+  transform: translateY(0);
 }
 
 button:disabled {
-    opacity: 0.7;
-    cursor: not-allowed;
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 button.loading::after {
-    content: '';
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    margin-left: 8px;
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    border-top-color: white;
-    border-radius: 50%;
-    animation: spin 0.6s linear infinite;
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  margin-left: 8px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
 }
 
 @keyframes spin {
-    to {
-        transform: rotate(360deg);
-    }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* 主内容区 */
 .main-content {
-    margin: 0;
-    background: rgba(255, 255, 255, 0.6);
-    backdrop-filter: blur(24px) saturate(180%);
-    -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border-radius: 1rem;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-    width: 100%;
-    max-width: 1400px;
-    height: calc(100vh - 1rem);
-    display: flex;
-    flex-direction: column;
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    overflow: hidden;
+  margin: 0;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border-radius: 1rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 1400px;
+  height: calc(100vh - 1rem);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  overflow: hidden;
 }
 
 @media (prefers-color-scheme: dark) {
-    .main-content {
-        background: rgba(30, 41, 59, 0.65);
-        border: 1px solid rgba(255, 255, 255, 0.2);
-    }
+  .main-content {
+    background: rgba(30, 41, 59, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+  }
 }
 
 .header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 1rem;
-    border-bottom: 1.5px solid var(--border);
-    flex-shrink: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1.5px solid var(--border);
+  flex-shrink: 0;
 }
 
 .header-right {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .server-info {
-    font-size: 0.75rem;
-    color: var(--text-light);
-    background: var(--bg);
-    padding: 0.25rem 0.5rem;
-    border-radius: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-light);
+  background: var(--bg);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
 }
 
 .header button {
-    width: auto;
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    min-height: 36px;
+  width: auto;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  min-height: 36px;
 }
 
 .tabs {
-    display: flex;
-    gap: 0.25rem;
+  display: flex;
+  gap: 0.25rem;
 }
 
 .tab {
-    background: transparent;
-    color: var(--text-light);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    font-weight: 600;
-    font-size: 0.875rem;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    min-height: 36px;
-    box-shadow: none;
-    position: relative;
-    overflow: hidden;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    gap: 0.25rem;
-    white-space: nowrap;
+  background: transparent;
+  color: var(--text-light);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.875rem;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  min-height: 36px;
+  box-shadow: none;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  white-space: nowrap;
 }
 
 .tab .tab-icon {
-    font-size: 1rem;
+  font-size: 1rem;
 }
 
 .tab .tab-text {
-    font-size: 0.875rem;
+  font-size: 0.875rem;
 }
 
 .tab:hover {
-    background: var(--bg);
-    color: var(--text);
-    transform: translateY(-1px);
+  background: var(--bg);
+  color: var(--text);
+  transform: translateY(-1px);
 }
 
 .tab:active {
-    transform: translateY(0) scale(0.98);
+  transform: translateY(0) scale(0.98);
 }
 
 .tab.active {
-    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-    color: white;
-    box-shadow: 0 2px 8px rgba(8, 145, 178, 0.3);
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: white;
+  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.3);
 }
 
 .content {
-    padding: 1rem;
-    flex: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
-    display: flex;
-    flex-direction: column;
+  padding: 1rem;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 /* 日志页面时禁止 .content 滚动 */
 html.tab-logs .content {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 #tokensPage {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
 #tokensPage.page-enter {
-    animation: pageSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  animation: pageSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 #settingsPage {
-    flex: 1;
-    padding-right: 4px;
-    min-height: 0;
+  flex: 1;
+  padding-right: 4px;
+  min-height: 0;
 }
 
 #settingsPage.page-enter {
-    animation: pageSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  animation: pageSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @keyframes pageSlideIn {
-    from {
-        opacity: 0;
-        transform: translateX(20px);
-    }
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
 
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 /* 顶部栏 - 统计+操作 */
 .top-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: rgba(255, 255, 255, 0.6);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    padding: 0.75rem 1rem;
-    border-radius: 0.75rem;
-    margin-bottom: 1rem;
-    border: 1.5px solid var(--border);
-    flex-shrink: 0;
-    position: sticky;
-    top: 0;
-    z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1rem;
+  border: 1.5px solid var(--border);
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 @media (prefers-color-scheme: dark) {
-    .top-bar {
-        background: rgba(30, 41, 59, 0.95);
-    }
+  .top-bar {
+    background: rgba(30, 41, 59, 0.95);
+  }
 }
 
 .stats-inline {
-    display: flex;
-    gap: 1.5rem;
-    align-items: center;
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
 }
 
 /* 移动端操作区展开/收起按钮 */
 .action-toggle-btn {
-    display: none;
-    width: 24px;
-    height: 24px;
-    min-height: 24px;
-    min-width: 24px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    color: var(--text-light);
-    font-size: 0.65rem;
-    cursor: pointer;
-    transition: transform 0.25s ease, color 0.2s;
-    margin-left: 0.5rem;
-    flex-shrink: 0;
-    box-shadow: none;
+  display: none;
+  width: 24px;
+  height: 24px;
+  min-height: 24px;
+  min-width: 24px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--text-light);
+  font-size: 0.65rem;
+  cursor: pointer;
+  transition:
+    transform 0.25s ease,
+    color 0.2s;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
+  box-shadow: none;
 }
 
 .action-toggle-btn:hover {
-    color: var(--primary);
-    transform: scale(1.1);
+  color: var(--primary);
+  transform: scale(1.1);
 }
 
 .action-toggle-btn.collapsed {
-    transform: rotate(-90deg);
+  transform: rotate(-90deg);
 }
 
 .action-toggle-btn.collapsed:hover {
-    transform: rotate(-90deg) scale(1.1);
+  transform: rotate(-90deg) scale(1.1);
 }
 
 .stat-item {
-    display: flex;
-    align-items: baseline;
-    gap: 0.25rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
 }
 
 .stat-item.clickable {
-    cursor: pointer;
-    padding: 0.25rem 0.5rem;
-    border-radius: 0.375rem;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    border: 1.5px solid transparent;
-    position: relative;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 1.5px solid transparent;
+  position: relative;
 }
 
 .stat-item.clickable:hover {
-    background: rgba(8, 145, 178, 0.1);
-    transform: translateY(-1px);
+  background: rgba(8, 145, 178, 0.1);
+  transform: translateY(-1px);
 }
 
 .stat-item.clickable:active {
-    transform: translateY(0) scale(0.98);
+  transform: translateY(0) scale(0.98);
 }
 
 .stat-item.clickable.active {
-    background: rgba(8, 145, 178, 0.15);
-    border-color: var(--primary);
-    box-shadow: 0 2px 8px rgba(8, 145, 178, 0.2);
+  background: rgba(8, 145, 178, 0.15);
+  border-color: var(--primary);
+  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.2);
 }
 
 .stat-num {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--primary);
-    line-height: 1;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--primary);
+  line-height: 1;
 }
 
 .stat-item.success .stat-num {
-    color: var(--success);
+  color: var(--success);
 }
 
 .stat-item.danger .stat-num {
-    color: var(--danger);
+  color: var(--danger);
 }
 
 .stat-text {
-    font-size: 0.85rem;
-    color: var(--text-light);
-    line-height: 1;
+  font-size: 0.85rem;
+  color: var(--text-light);
+  line-height: 1;
 }
 
 .action-btns {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    justify-content: flex-end;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 /* 按钮样式 */
 .btn {
-    width: auto;
-    padding: 0.5rem 0.875rem;
-    border: none;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    font-size: 0.8rem;
-    font-weight: 600;
-    transition: all 0.2s;
-    white-space: nowrap;
-    text-align: center;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.25rem;
-    min-height: 36px;
-    box-shadow: none;
-    flex-shrink: 0;
+  width: auto;
+  padding: 0.5rem 0.875rem;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all 0.2s;
+  white-space: nowrap;
+  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-height: 36px;
+  box-shadow: none;
+  flex-shrink: 0;
 }
 
 .btn:hover {
-    transform: translateY(-1px);
+  transform: translateY(-1px);
 }
 
 .btn-sm {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.75rem;
-    min-height: 32px;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  min-height: 32px;
 }
 
 .btn-xs {
-    padding: 0.25rem 0.5rem;
-    font-size: 0.7rem;
-    min-height: 28px;
-    min-width: 28px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.7rem;
+  min-height: 28px;
+  min-width: 28px;
 }
 
 .btn-danger {
-    background: var(--danger);
-    color: white;
+  background: var(--danger);
+  color: white;
 }
 
 .btn-warning {
-    background: var(--warning);
-    color: white;
+  background: var(--warning);
+  color: white;
 }
 
 .btn-success {
-    background: var(--success);
-    color: white;
+  background: var(--success);
+  color: white;
 }
 
 .btn-secondary {
-    background: #6b7280;
-    color: white;
+  background: #6b7280;
+  color: white;
 }
 
 .btn-info {
-    background: var(--info);
-    color: white;
+  background: var(--info);
+  color: white;
 }
 
 /* Token网格 */
 .token-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 0.75rem;
-    align-items: start;
-    flex: 1;
-    padding: 4px 4px 1rem 4px;
-    min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+  align-items: start;
+  flex: 1;
+  padding: 4px 4px 1rem 4px;
+  min-height: 0;
 }
 
 .token-card {
-    background: rgba(255, 255, 255, 0.93);
-    border: 1.5px solid var(--border);
-    border-radius: 0.75rem;
-    padding: 0.875rem;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
-    animation: cardFadeIn 0.35s cubic-bezier(0.4, 0, 0.2, 1) backwards;
+  background: rgba(255, 255, 255, 0.93);
+  border: 1.5px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.875rem;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  animation: cardFadeIn 0.35s cubic-bezier(0.4, 0, 0.2, 1) backwards;
 }
 
 @keyframes cardFadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(10px) scale(0.98);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.98);
+  }
 
-    to {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 /* 为每个卡片添加延迟动画 */
 .token-card:nth-child(1) {
-    animation-delay: 0.02s;
+  animation-delay: 0.02s;
 }
 
 .token-card:nth-child(2) {
-    animation-delay: 0.04s;
+  animation-delay: 0.04s;
 }
 
 .token-card:nth-child(3) {
-    animation-delay: 0.06s;
+  animation-delay: 0.06s;
 }
 
 .token-card:nth-child(4) {
-    animation-delay: 0.08s;
+  animation-delay: 0.08s;
 }
 
 .token-card:nth-child(5) {
-    animation-delay: 0.1s;
+  animation-delay: 0.1s;
 }
 
 .token-card:nth-child(6) {
-    animation-delay: 0.12s;
+  animation-delay: 0.12s;
 }
 
 .token-card:nth-child(7) {
-    animation-delay: 0.14s;
+  animation-delay: 0.14s;
 }
 
 .token-card:nth-child(8) {
-    animation-delay: 0.16s;
+  animation-delay: 0.16s;
 }
 
 .token-card:nth-child(9) {
-    animation-delay: 0.18s;
+  animation-delay: 0.18s;
 }
 
 .token-card:nth-child(10) {
-    animation-delay: 0.2s;
+  animation-delay: 0.2s;
 }
 
-.token-card:nth-child(n+11) {
-    animation-delay: 0.22s;
+.token-card:nth-child(n + 11) {
+  animation-delay: 0.22s;
 }
 
 /* 跳过动画 */
 .token-card.no-animation {
-    animation: none !important;
+  animation: none !important;
 }
 
 @media (prefers-color-scheme: dark) {
-    .token-card {
-        background: rgba(30, 41, 59, 0.92);
-    }
+  .token-card {
+    background: rgba(30, 41, 59, 0.92);
+  }
 }
 
 .token-card:hover {
-    border-color: var(--primary);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-    background: rgba(255, 255, 255, 0.98);
-    transform: translateY(-4px) scale(1.01);
-    z-index: 1;
-    position: relative;
+  border-color: var(--primary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  background: rgba(255, 255, 255, 0.98);
+  transform: translateY(-4px) scale(1.01);
+  z-index: 1;
+  position: relative;
 }
 
 @media (prefers-color-scheme: dark) {
-    .token-card:hover {
-        background: rgba(30, 41, 59, 0.97);
-    }
+  .token-card:hover {
+    background: rgba(30, 41, 59, 0.97);
+  }
 }
 
 .token-card.disabled {
-    opacity: 0.9;
-    background: rgba(255, 255, 255, 0.88);
-    filter: saturate(0.92);
+  opacity: 0.9;
+  background: rgba(255, 255, 255, 0.88);
+  filter: saturate(0.92);
 }
 
 @media (prefers-color-scheme: dark) {
-    .token-card.disabled {
-        background: rgba(30, 41, 59, 0.84);
-    }
+  .token-card.disabled {
+    background: rgba(30, 41, 59, 0.84);
+  }
 }
 
 .token-card.disabled:hover {
-    background: rgba(255, 255, 255, 0.94);
+  background: rgba(255, 255, 255, 0.94);
 }
 
 @media (prefers-color-scheme: dark) {
-    .token-card.disabled:hover {
-        background: rgba(30, 41, 59, 0.92);
-    }
+  .token-card.disabled:hover {
+    background: rgba(30, 41, 59, 0.92);
+  }
 }
 
 .token-disable-reason {
-    padding: 0.35rem 0.6rem;
-    margin: 0 0.2rem 0.3rem;
-    background: rgba(220, 53, 69, 0.08);
-    border-radius: 6px;
-    font-size: 0.78rem;
-    color: var(--danger, #dc3545);
-    line-height: 1.4;
-    word-break: break-all;
-    border-left: 3px solid var(--danger, #dc3545);
+  padding: 0.35rem 0.6rem;
+  margin: 0 0.2rem 0.3rem;
+  background: rgba(220, 53, 69, 0.08);
+  border-radius: 6px;
+  font-size: 0.78rem;
+  color: var(--danger, #dc3545);
+  line-height: 1.4;
+  word-break: break-all;
+  border-left: 3px solid var(--danger, #dc3545);
+}
+
+.token-error-detail {
+  padding: 0.5rem;
+  background: rgba(245, 158, 11, 0.1);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: var(--warning, #f59e0b);
+  word-break: break-all;
+}
+
+.token-error-meta {
+  color: var(--text-light);
+  font-size: 0.8rem;
 }
 
 @media (prefers-color-scheme: dark) {
-    .token-disable-reason {
-        background: rgba(220, 53, 69, 0.12);
-        color: #f08080;
-    }
+  .token-disable-reason {
+    background: rgba(220, 53, 69, 0.12);
+    color: #f08080;
+  }
 }
 
 .token-card.refresh-failed {
-    border-color: var(--danger);
+  border-color: var(--danger);
 }
 
 .token-card.refreshing {
-    border-color: var(--warning);
-    animation: pulse 1.5s ease-in-out infinite;
+  border-color: var(--warning);
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 @keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
 
-    0%,
-    100% {
-        opacity: 1;
-    }
-
-    50% {
-        opacity: 0.7;
-    }
+  50% {
+    opacity: 0.7;
+  }
 }
 
 .token-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.375rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.375rem;
 }
 
 .token-header-left {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
 }
 
 .btn-icon.token-refresh-btn {
-    width: 22px;
-    height: 22px;
-    min-height: 22px;
-    min-width: 22px;
-    padding: 0;
-    background: transparent;
-    border: 1px solid var(--border);
-    border-radius: 0.25rem;
-    color: var(--text-light);
-    opacity: 0.8;
-    box-shadow: none;
+  width: 22px;
+  height: 22px;
+  min-height: 22px;
+  min-width: 22px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  color: var(--text-light);
+  opacity: 0.8;
+  box-shadow: none;
 }
 
 .btn-icon.token-refresh-btn:hover:not(:disabled) {
-    background: transparent;
-    border-color: var(--primary);
-    color: var(--primary);
-    opacity: 1;
+  background: transparent;
+  border-color: var(--primary);
+  color: var(--primary);
+  opacity: 1;
 }
 
 .btn-icon.token-refresh-btn.loading,
 .btn-icon.token-refresh-btn:disabled {
-    cursor: not-allowed;
-    color: var(--warning);
-    animation: spin 0.8s linear infinite;
+  cursor: not-allowed;
+  color: var(--warning);
+  animation: spin 0.8s linear infinite;
 }
 
 .token-id {
-    font-size: 0.7rem;
-    color: var(--text-light);
+  font-size: 0.7rem;
+  color: var(--text-light);
 }
 
 /* Token ID 显示行 */
 .token-id-row {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 0.8rem;
-    color: var(--text-light);
-    padding: 0.25rem;
-    margin: -0.25rem;
-    margin-bottom: 0.5rem;
-    overflow: hidden;
-    cursor: default;
-    border-radius: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8rem;
+  color: var(--text-light);
+  padding: 0.25rem;
+  margin: -0.25rem;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+  cursor: default;
+  border-radius: 0.25rem;
 }
 
 .token-id-label {
-    flex-shrink: 0;
-    width: 20px;
-    text-align: center;
+  flex-shrink: 0;
+  width: 20px;
+  text-align: center;
 }
 
 .token-id-value {
-    font-family: 'Ubuntu Mono', 'Consolas', 'Monaco', monospace;
-    font-size: 0.75rem;
-    color: var(--text-light);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    user-select: all;
+  font-family: "Ubuntu Mono", "Consolas", "Monaco", monospace;
+  font-size: 0.75rem;
+  color: var(--text-light);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  user-select: all;
 }
 
 .token-info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-    margin-bottom: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-bottom: 0.25rem;
 }
 
 .info-row {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8rem;
 }
 
 .info-label {
-    flex-shrink: 0;
-    width: 20px;
-    text-align: center;
+  flex-shrink: 0;
+  width: 20px;
+  text-align: center;
 }
 
 .info-value {
-    color: var(--text);
-    font-size: 0.75rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  color: var(--text);
+  font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .info-row.editable {
-    cursor: pointer;
-    padding: 0.25rem;
-    margin: -0.25rem;
-    border-radius: 0.25rem;
-    transition: background 0.2s;
+  cursor: pointer;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  border-radius: 0.25rem;
+  transition: background 0.2s;
 }
 
 .info-row.editable:hover {
-    background: rgba(8, 145, 178, 0.08);
+  background: rgba(8, 145, 178, 0.08);
 }
 
 .info-edit-icon {
-    font-size: 0.6rem;
-    opacity: 0;
-    transition: opacity 0.2s;
-    margin-left: auto;
-    flex-shrink: 0;
+  font-size: 0.6rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .info-row.editable:hover .info-edit-icon {
-    opacity: 0.5;
+  opacity: 0.5;
 }
 
 /* Token完整显示样式 */
 .token-display {
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 0.5rem 0.75rem;
-    font-family: 'Ubuntu Mono', 'MiSans', 'Consolas', monospace;
-    font-size: 0.75rem;
-    line-height: 1.4;
-    word-break: break-all;
-    color: var(--text-light);
-    max-height: 80px;
-    overflow-y: auto;
-    user-select: all;
-    cursor: text;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-family: "Ubuntu Mono", "MiSans", "Consolas", monospace;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  word-break: break-all;
+  color: var(--text-light);
+  max-height: 80px;
+  overflow-y: auto;
+  user-select: all;
+  cursor: text;
 }
 
 .inline-edit-input {
-    flex: 1;
-    min-height: 24px;
-    padding: 0.125rem 0.375rem;
-    font-size: 0.75rem;
-    border: 1px solid var(--primary);
-    border-radius: 0.25rem;
-    background: var(--card);
+  flex: 1;
+  min-height: 24px;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.75rem;
+  border: 1px solid var(--primary);
+  border-radius: 0.25rem;
+  background: var(--card);
 }
 
 .inline-edit-input:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(8, 145, 178, 0.2);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(8, 145, 178, 0.2);
 }
 
 /* Token卡片头部 */
 .token-header-right {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .btn-icon {
-    width: 24px;
-    height: 24px;
-    min-height: 24px;
-    min-width: 24px;
-    padding: 0;
-    background: transparent;
-    border: 1px solid var(--border);
-    border-radius: 0.25rem;
-    cursor: pointer;
-    font-size: 0.7rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.2s;
-    box-shadow: none;
+  width: 24px;
+  height: 24px;
+  min-height: 24px;
+  min-width: 24px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 0.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  box-shadow: none;
 }
 
 .btn-icon:hover {
-    background: var(--primary);
-    border-color: var(--primary);
-    transform: none;
+  background: var(--primary);
+  border-color: var(--primary);
+  transform: none;
 }
 
 .token-actions {
-    display: flex;
-    gap: 0.5rem;
-    /* 让按钮平分宽度，视觉更统一 */
+  display: flex;
+  gap: 0.5rem;
+  /* 让按钮平分宽度，视觉更统一 */
 }
 
 .token-actions .btn {
-    flex: 1;
-    justify-content: center;
+  flex: 1;
+  justify-content: center;
 }
 
 .status {
-    padding: 0.25rem 0.5rem;
-    border-radius: 9999px;
-    font-size: 0.7rem;
-    font-weight: 600;
-    display: inline-flex;
-    align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
 }
 
 .status.enabled {
-    background: rgba(16, 185, 129, 0.15);
-    color: var(--success);
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--success);
 }
 
 .status.disabled {
-    background: rgba(239, 68, 68, 0.15);
-    color: var(--danger);
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--danger);
 }
 
 /* 空状态 */
 .empty-state {
-    text-align: center;
-    padding: 3rem 1rem;
-    color: var(--text-light);
-    grid-column: 1 / -1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    min-height: 300px;
-    animation: emptyFadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-light);
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  animation: emptyFadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @keyframes emptyFadeIn {
-    from {
-        opacity: 0;
-        transform: scale(0.95);
-    }
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
 
-    to {
-        opacity: 1;
-        transform: scale(1);
-    }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .empty-state-icon {
-    font-size: 3rem;
-    margin-bottom: 0.75rem;
-    opacity: 0.5;
+  font-size: 3rem;
+  margin-bottom: 0.75rem;
+  opacity: 0.5;
 }
 
 .empty-state-text {
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: 0.375rem;
+  font-size: 1rem;
+  font-weight: 500;
+  margin-bottom: 0.375rem;
 }
 
 .empty-state-hint {
-    font-size: 0.8rem;
+  font-size: 0.8rem;
 }
 
 /* 设置页面 */
 .config-form {
-    max-width: 100%;
+  max-width: 100%;
 }
 
 .settings-layout {
-    display: grid;
-    grid-template-columns: 240px 1fr;
-    gap: 1rem;
-    align-items: start;
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 1rem;
+  align-items: start;
 }
 
 .settings-nav {
-    background: rgba(255, 255, 255, 0.6);
-    border: 1.5px solid var(--border);
-    border-radius: 0.75rem;
-    padding: 0.75rem;
-    position: sticky;
-    top: 0.5rem;
-    align-self: start;
-    max-height: calc(100vh - 180px);
-    overflow: auto;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1.5px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  position: sticky;
+  top: 0.5rem;
+  align-self: start;
+  max-height: calc(100vh - 180px);
+  overflow: auto;
 }
 
 @media (prefers-color-scheme: dark) {
-    .settings-nav {
-        background: rgba(30, 41, 59, 0.6);
-    }
+  .settings-nav {
+    background: rgba(30, 41, 59, 0.6);
+  }
 }
 
 .settings-search input {
-    min-height: 36px;
-    font-size: 0.85rem;
-    padding-left: 0.75rem !important;
+  min-height: 36px;
+  font-size: 0.85rem;
+  padding-left: 0.75rem !important;
 }
 
 .settings-section-select {
-    display: none;
-    width: 100%;
-    margin-top: 0.5rem;
-    min-height: 36px;
-    font-size: 0.85rem;
+  display: none;
+  width: 100%;
+  margin-top: 0.5rem;
+  min-height: 36px;
+  font-size: 0.85rem;
 }
 
 .settings-nav-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-    margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
 }
 
 .settings-nav-item {
-    width: 100%;
-    text-align: left;
-    padding: 0.5rem 0.6rem;
-    border-radius: 0.6rem;
-    border: 1.5px solid var(--border);
-    background: rgba(255, 255, 255, 0.7);
-    color: var(--text);
-    font-weight: 600;
-    font-size: 0.85rem;
-    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-radius: 0.6rem;
+  border: 1.5px solid var(--border);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
 }
 
 @media (prefers-color-scheme: dark) {
-    .settings-nav-item {
-        background: rgba(30, 41, 59, 0.7);
-    }
+  .settings-nav-item {
+    background: rgba(30, 41, 59, 0.7);
+  }
 }
 
 .settings-nav-item:hover {
-    border-color: var(--primary);
-    background: rgba(255, 255, 255, 0.95);
-    transform: translateY(-1px);
+  border-color: var(--primary);
+  background: rgba(255, 255, 255, 0.95);
+  transform: translateY(-1px);
 }
 
 .settings-nav-item.active {
-    border-color: var(--primary);
-    background: rgba(255, 255, 255, 0.95);
+  border-color: var(--primary);
+  background: rgba(255, 255, 255, 0.95);
 }
 
 @media (prefers-color-scheme: dark) {
-    .settings-nav-item:hover {
-        background: rgba(30, 41, 59, 0.92);
-    }
+  .settings-nav-item:hover {
+    background: rgba(30, 41, 59, 0.92);
+  }
 
-    .settings-nav-item.active {
-        background: rgba(30, 41, 59, 0.92);
-    }
+  .settings-nav-item.active {
+    background: rgba(30, 41, 59, 0.92);
+  }
 }
 
 .settings-content {
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .config-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1rem;
-    margin-bottom: 1rem;
-    align-items: stretch;
-    max-width: 980px;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+  align-items: stretch;
+  max-width: 980px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .config-section {
-    background: rgba(255, 255, 255, 0.6);
-    padding: 1rem;
-    border-radius: 0.75rem;
-    border: 1.5px solid var(--border);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid var(--border);
 }
 
 @media (prefers-color-scheme: dark) {
-    .config-section {
-        background: rgba(30, 41, 59, 0.6);
-    }
+  .config-section {
+    background: rgba(30, 41, 59, 0.6);
+  }
 }
 
 .config-section h4 {
-    margin-bottom: 0.75rem;
-    color: var(--primary);
-    font-size: 0.95rem;
-    font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--primary);
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
 .form-row-inline {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .form-group.compact {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .form-group.compact label {
-    font-size: 0.75rem;
-    margin-bottom: 0.25rem;
-    color: var(--text-light);
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+  color: var(--text-light);
 }
 
 .form-group.compact input,
 .form-group.compact select {
-    min-height: 36px;
-    padding: 0.375rem 0.5rem;
-    font-size: 0.8rem;
+  min-height: 36px;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.8rem;
 }
 
 .form-group.compact textarea {
-    min-height: 60px;
-    max-height: 300px;
-    padding: 0.375rem 0.5rem;
-    font-size: 0.8rem;
-    resize: vertical;
-    height: auto;
-    /* 自适应内容高度 - 纯CSS方案，零JS资源消耗 */
-    field-sizing: content;
+  min-height: 60px;
+  max-height: 300px;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.8rem;
+  resize: vertical;
+  height: auto;
+  /* 自适应内容高度 - 纯CSS方案，零JS资源消耗 */
+  field-sizing: content;
 }
 
 /* 锁定状态样式 */
 .form-group.compact textarea[readonly] {
-    background-color: rgba(0, 0, 0, 0.03);
-    color: var(--text-light);
-    cursor: not-allowed;
-    border-color: var(--border);
-    box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.03);
+  color: var(--text-light);
+  cursor: not-allowed;
+  border-color: var(--border);
+  box-shadow: none;
 }
 
 /* 暗色模式下的锁定背景 */
 @media (prefers-color-scheme: dark) {
-    .form-group.compact textarea[readonly] {
-        background-color: rgba(255, 255, 255, 0.05);
-    }
+  .form-group.compact textarea[readonly] {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
 }
 
 /* 解锁状态样式 */
 .form-group.compact textarea.unlocked {
-    background-color: var(--card);
-    color: var(--text);
-    cursor: text;
-    border-color: var(--warning);
-    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+  background-color: var(--card);
+  color: var(--text);
+  cursor: text;
+  border-color: var(--warning);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
 }
 
 .form-group.highlight {
-    background: rgba(8, 145, 178, 0.08);
-    padding: 0.5rem;
-    border-radius: 0.5rem;
-    margin-top: 0.5rem;
+  background: rgba(8, 145, 178, 0.08);
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .form-group.highlight label {
-    color: var(--primary);
-    font-weight: 600;
+  color: var(--primary);
+  font-weight: 600;
 }
 
 .config-actions {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
-    max-width: 980px;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  max-width: 980px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .config-actions .btn {
-    width: auto;
+  width: auto;
 }
 
 /* 字体大小控制 */
 .font-size-control {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .font-size-control input[type="range"] {
-    flex: 1;
-    min-height: auto;
-    height: 6px;
-    padding: 0;
-    cursor: pointer;
+  flex: 1;
+  min-height: auto;
+  height: 6px;
+  padding: 0;
+  cursor: pointer;
 }
 
 .font-size-control input[type="number"] {
-    width: 60px;
-    text-align: center;
-    flex-shrink: 0;
+  width: 60px;
+  text-align: center;
+  flex-shrink: 0;
 }
 
 /* 轮询策略状态显示 */
 .rotation-status {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    background: rgba(8, 145, 178, 0.08);
-    border-radius: 0.5rem;
-    margin-top: 0.5rem;
-    font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(8, 145, 178, 0.08);
+  border-radius: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
 }
 
 .rotation-label {
-    color: var(--text-light);
-    font-weight: 500;
+  color: var(--text-light);
+  font-weight: 500;
 }
 
 #currentRotationInfo {
-    color: var(--primary);
-    font-weight: 600;
+  color: var(--primary);
+  font-weight: 600;
 }
 
 /* Toast通知 */
 .toast {
-    position: fixed;
-    top: 16px;
-    right: 16px;
-    background: var(--card);
-    border-radius: 0.75rem;
-    padding: 0.75rem 1rem;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-    z-index: 9999;
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    min-width: 240px;
-    max-width: 360px;
-    animation: slideIn 0.3s ease;
-    border-left: 3px solid var(--primary);
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  background: var(--card);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 240px;
+  max-width: 360px;
+  animation: slideIn 0.3s ease;
+  border-left: 3px solid var(--primary);
 }
 
 .toast.success {
-    border-left-color: var(--success);
+  border-left-color: var(--success);
 }
 
 .toast.error {
-    border-left-color: var(--danger);
+  border-left-color: var(--danger);
 }
 
 .toast.warning {
-    border-left-color: var(--warning);
+  border-left-color: var(--warning);
 }
 
 .toast.info {
-    border-left-color: var(--info);
+  border-left-color: var(--info);
 }
 
 .toast-icon {
-    font-size: 1.25rem;
-    flex-shrink: 0;
+  font-size: 1.25rem;
+  flex-shrink: 0;
 }
 
 .toast-content {
-    flex: 1;
+  flex: 1;
 }
 
 .toast-title {
-    font-weight: 600;
-    font-size: 0.875rem;
-    color: var(--text);
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--text);
 }
 
 .toast-message {
-    font-size: 0.8rem;
-    color: var(--text-light);
+  font-size: 0.8rem;
+  color: var(--text-light);
 }
 
 @keyframes slideIn {
-    from {
-        transform: translateX(400px);
-        opacity: 0;
-    }
+  from {
+    transform: translateX(400px);
+    opacity: 0;
+  }
 
-    to {
-        transform: translateX(0);
-        opacity: 1;
-    }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 @keyframes slideOut {
-    from {
-        transform: translateX(0);
-        opacity: 1;
-    }
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
 
-    to {
-        transform: translateX(400px);
-        opacity: 0;
-    }
+  to {
+    transform: translateX(400px);
+    opacity: 0;
+  }
 }
 
 /* Modal弹窗 */
 .modal {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    z-index: 9998;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem;
-    animation: modalBgIn 0.25s ease-out;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 9998;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  animation: modalBgIn 0.25s ease-out;
 }
 
 @keyframes modalBgIn {
-    from {
-        opacity: 0;
-        backdrop-filter: blur(0px);
-        -webkit-backdrop-filter: blur(0px);
-    }
+  from {
+    opacity: 0;
+    backdrop-filter: blur(0px);
+    -webkit-backdrop-filter: blur(0px);
+  }
 
-    to {
-        opacity: 1;
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
-    }
+  to {
+    opacity: 1;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
 }
 
 .modal-content {
-    background: rgba(255, 255, 255, 0.8);
-    backdrop-filter: blur(24px) saturate(180%);
-    -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border-radius: 1rem;
-    padding: 1.25rem;
-    max-width: 400px;
-    width: 100%;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
-    animation: scaleIn 0.2s;
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    color: var(--text);
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+  animation: scaleIn 0.2s;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  color: var(--text);
 }
 
 @media (prefers-color-scheme: dark) {
-    .modal-content {
-        background: rgba(30, 41, 59, 0.8);
-        border: 1px solid rgba(255, 255, 255, 0.15);
-    }
+  .modal-content {
+    background: rgba(30, 41, 59, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+  }
 }
 
 .modal-content.modal-lg {
-    max-width: 700px;
+  max-width: 700px;
 }
 
 .modal-content.modal-xl {
-    max-width: 900px;
-    display: flex;
-    flex-direction: column;
-    max-height: 80vh;
-    overflow: hidden;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+  overflow: hidden;
 }
 
 .modal-content.modal-xl .quota-container {
-    flex: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .modal-content.modal-xl .modal-actions {
-    flex-shrink: 0;
-    border-top: 1px solid var(--border);
-    padding-top: 1rem;
-    margin-top: 0.5rem;
-    background: transparent;
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+  margin-top: 0.5rem;
+  background: transparent;
 }
 
 .modal-title {
-    font-size: 1rem;
-    font-weight: 700;
-    margin-bottom: 0.75rem;
-    color: var(--text);
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--text);
 }
 
 .modal-message {
-    color: var(--text-light);
-    margin-bottom: 1rem;
-    line-height: 1.5;
-    font-size: 0.85rem;
+  color: var(--text-light);
+  margin-bottom: 1rem;
+  line-height: 1.5;
+  font-size: 0.85rem;
 }
 
 .modal-actions {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
 }
 
 .modal-actions button {
-    flex: none;
-    width: auto;
+  flex: none;
+  width: auto;
 }
 
 .form-modal .modal-content {
-    max-width: 480px;
+  max-width: 480px;
 }
 
 .form-modal.oauth-modal .modal-content {
-    max-width: 720px;
+  max-width: 720px;
 }
 
 .form-modal input {
-    margin-bottom: 0.75rem;
+  margin-bottom: 0.75rem;
 }
 
 .form-modal .oauth-generator-row {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .form-modal .oauth-generated-panel {
-    margin-bottom: 0.75rem;
-    padding: 0.75rem;
-    border-radius: 0.75rem;
-    border: 1px solid var(--border);
-    background: rgba(15, 23, 42, 0.03);
+  margin-bottom: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.03);
 }
 
 .form-modal .oauth-generated-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .form-modal .oauth-generated-summary {
-    font-size: 0.85rem;
-    color: var(--text-light);
+  font-size: 0.85rem;
+  color: var(--text-light);
 }
 
 .form-modal .oauth-generated-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    max-height: 240px;
-    overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 240px;
+  overflow-y: auto;
 }
 
 .form-modal .oauth-generated-item {
-    border: 1px solid var(--border);
-    border-radius: 0.75rem;
-    padding: 0.75rem;
-    background: rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.7);
 }
 
 .form-modal .oauth-generated-item-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .form-modal .oauth-generated-item-header span {
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
 }
 
 .form-modal .oauth-generated-item textarea {
-    margin-bottom: 0;
-    min-height: 72px;
-    font-size: 0.8rem;
-    line-height: 1.45;
+  margin-bottom: 0;
+  min-height: 72px;
+  font-size: 0.8rem;
+  line-height: 1.45;
 }
 
 .form-modal .oauth-generated-copy-btn {
-    flex: none;
-    padding: 0.45rem 0.75rem;
-    font-size: 0.75rem;
-    white-space: nowrap;
+  flex: none;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.75rem;
+  white-space: nowrap;
 }
 
 .form-modal .oauth-generated-empty {
-    font-size: 0.85rem;
-    line-height: 1.6;
-    color: var(--text-light);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--text-light);
 }
 
 .form-modal .form-row {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 .form-modal .oauth-steps {
-    background: rgba(59, 130, 246, 0.1);
-    padding: 0.875rem;
-    border-radius: 0.5rem;
-    margin-bottom: 1rem;
-    border: 1.5px solid var(--info);
-    color: var(--text);
+  background: rgba(59, 130, 246, 0.1);
+  padding: 0.875rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  border: 1.5px solid var(--info);
+  color: var(--text);
 }
 
 .form-modal .oauth-steps p {
-    margin-bottom: 0.5rem;
-    font-size: 0.8rem;
-    color: var(--text);
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text);
 }
 
 .form-modal .oauth-steps p:last-child {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 @media (prefers-color-scheme: dark) {
-    .form-modal .oauth-generated-panel {
-        background: rgba(255, 255, 255, 0.04);
-    }
+  .form-modal .oauth-generated-panel {
+    background: rgba(255, 255, 255, 0.04);
+  }
 
-    .form-modal .oauth-generated-item {
-        background: rgba(15, 23, 42, 0.45);
-    }
+  .form-modal .oauth-generated-item {
+    background: rgba(15, 23, 42, 0.45);
+  }
 }
 
 @keyframes fadeIn {
-    from {
-        opacity: 0;
-    }
+  from {
+    opacity: 0;
+  }
 
-    to {
-        opacity: 1;
-    }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes scaleIn {
-    from {
-        transform: scale(0.95);
-        opacity: 0;
-    }
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
 
-    to {
-        transform: scale(1);
-        opacity: 1;
-    }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 /* Loading遮罩 */
 .loading-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.6);
-    z-index: 9999;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    gap: 1rem;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .spinner {
-    width: 40px;
-    height: 40px;
-    border: 3px solid rgba(255, 255, 255, 0.2);
-    border-top-color: white;
-    border-radius: 50%;
-    animation: spin 0.7s linear infinite;
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
 }
 
 .loading-text {
-    color: white;
-    font-size: 0.875rem;
-    font-weight: 500;
+  color: white;
+  font-size: 0.875rem;
+  font-weight: 500;
 }
 
 /* 帮助提示 */
 .help-tip {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: var(--info);
-    color: white;
-    font-size: 0.65rem;
-    font-weight: 600;
-    cursor: help;
-    margin-left: 4px;
-    position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--info);
+  color: white;
+  font-size: 0.65rem;
+  font-weight: 600;
+  cursor: help;
+  margin-left: 4px;
+  position: relative;
 }
 
 /* 恢复默认按钮 */
 .restore-default {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: auto;
-    height: 18px;
-    padding: 0 6px;
-    border-radius: 9px;
-    background: transparent;
-    border: 1.5px solid var(--border);
-    color: var(--text-light);
-    font-size: 0.7rem;
-    font-weight: 600;
-    cursor: pointer;
-    margin-left: 4px;
-    transition: all 0.2s ease;
-    vertical-align: middle;
-    white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 9px;
+  background: transparent;
+  border: 1.5px solid var(--border);
+  color: var(--text-light);
+  font-size: 0.7rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-left: 4px;
+  transition: all 0.2s ease;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .restore-default:hover {
-    background: var(--primary);
-    border-color: var(--primary);
-    color: white;
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
 }
 
 .restore-default:active {
-    transform: scale(0.95);
+  transform: scale(0.95);
 }
 
 /* 解锁按钮 */
 .unlock-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: transparent;
-    border: 1.5px solid var(--border);
-    color: var(--text-light);
-    font-size: 0.75rem;
-    font-weight: 600;
-    cursor: pointer;
-    margin-left: 4px;
-    transition: all 0.2s ease;
-    vertical-align: middle;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: transparent;
+  border: 1.5px solid var(--border);
+  color: var(--text-light);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-left: 4px;
+  transition: all 0.2s ease;
+  vertical-align: middle;
 }
 
 .unlock-btn:hover {
-    background: var(--warning);
-    border-color: var(--warning);
-    color: white;
+  background: var(--warning);
+  border-color: var(--warning);
+  color: white;
 }
 
 .unlock-btn:active {
-    transform: scale(0.9);
+  transform: scale(0.9);
 }
 
 /* Textarea wrapper for lock button */
 .textarea-wrapper {
-    position: relative;
+  position: relative;
 }
 
 /* Floating lock button inside textarea */
 .textarea-lock-btn {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 1.5rem;
-    cursor: pointer;
-    opacity: 0.9;
-    transition: all 0.2s;
-    z-index: 5;
-    background: var(--card);
-    padding: 0;
-    border-radius: 50%;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    border: 1px solid var(--border);
-    width: 48px;
-    height: 48px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.5rem;
+  cursor: pointer;
+  opacity: 0.9;
+  transition: all 0.2s;
+  z-index: 5;
+  background: var(--card);
+  padding: 0;
+  border-radius: 50%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--border);
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .textarea-lock-btn:hover {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1.1);
-    border-color: var(--warning);
-    color: var(--warning);
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1.1);
+  border-color: var(--warning);
+  color: var(--warning);
 }
 
 /* Hide lock button when textarea is unlocked (not readonly) */
-.textarea-wrapper textarea:not([readonly])~.textarea-lock-btn {
-    display: none !important;
+.textarea-wrapper textarea:not([readonly]) ~ .textarea-lock-btn {
+  display: none !important;
 }
 
 .help-tip::before {
-    content: attr(data-tooltip);
-    position: absolute;
-    bottom: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.9);
-    color: white;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.375rem;
-    font-size: 0.75rem;
-    font-weight: 400;
-    white-space: pre-line;
-    min-width: 200px;
-    max-width: 300px;
-    text-align: left;
-    line-height: 1.4;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s;
-    z-index: 1000;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.9);
+  color: white;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 400;
+  white-space: pre-line;
+  min-width: 200px;
+  max-width: 300px;
+  text-align: left;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 .help-tip::after {
-    content: '';
-    position: absolute;
-    bottom: calc(100% + 2px);
-    left: 50%;
-    transform: translateX(-50%);
-    border: 6px solid transparent;
-    border-top-color: rgba(0, 0, 0, 0.9);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s;
-    z-index: 1000;
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: rgba(0, 0, 0, 0.9);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 1000;
 }
 
 .help-tip:hover::before,
 .help-tip:hover::after {
-    opacity: 1;
+  opacity: 1;
 }
 
 @media (prefers-color-scheme: dark) {
-    .help-tip::before {
-        background: rgba(30, 41, 59, 0.95);
-        color: #f1f5f9;
-        border: 1px solid rgba(255, 255, 255, 0.2);
-    }
+  .help-tip::before {
+    background: rgba(30, 41, 59, 0.95);
+    color: #f1f5f9;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+  }
 
-    .help-tip::after {
-        border-top-color: rgba(30, 41, 59, 0.95);
-    }
+  .help-tip::after {
+    border-top-color: rgba(30, 41, 59, 0.95);
+  }
 }
 
 /* 开关样式 */
 .switch-row {
-    display: flex !important;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    background: rgba(8, 145, 178, 0.08);
-    padding: 0.5rem;
-    border-radius: 0.5rem;
-    border: 1px solid rgba(8, 145, 178, 0.15);
-    align-items: center;
+  display: flex !important;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: rgba(8, 145, 178, 0.08);
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(8, 145, 178, 0.15);
+  align-items: center;
 }
 
 .switch-group {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    background: var(--card);
-    padding: 0.375rem 0.625rem;
-    border-radius: 0.375rem;
-    flex: 1 1 auto;
-    min-width: 140px;
-    border: 1px solid var(--border);
-    transition: all 0.2s;
-    min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: var(--card);
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.375rem;
+  flex: 1 1 auto;
+  min-width: 140px;
+  border: 1px solid var(--border);
+  transition: all 0.2s;
+  min-height: 36px;
 }
 
 .switch-group:hover {
-    border-color: var(--primary);
-    box-shadow: 0 2px 8px rgba(8, 145, 178, 0.1);
+  border-color: var(--primary);
+  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.1);
 }
 
 .switch-group label:first-child {
-    flex: 1;
-    margin-bottom: 0;
-    font-weight: 500;
-    color: var(--text);
-    white-space: nowrap;
+  flex: 1;
+  margin-bottom: 0;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
 }
 
 .switch {
-    position: relative;
-    display: inline-block;
-    width: 44px;
-    height: 24px;
-    flex-shrink: 0;
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
 }
 
 .switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-    margin: 0;
-    padding: 0;
-    min-height: 0;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  margin: 0;
+  padding: 0;
+  min-height: 0;
 }
 
 .slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: #ccc;
-    transition: 0.3s;
-    border-radius: 24px;
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.3s;
+  border-radius: 24px;
 }
 
 .slider:before {
-    position: absolute;
-    content: "";
-    height: 18px;
-    width: 18px;
-    left: 3px;
-    bottom: 3px;
-    background-color: white;
-    transition: 0.3s;
-    border-radius: 50%;
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.3s;
+  border-radius: 50%;
 }
 
-input:checked+.slider {
-    background-color: var(--primary);
+input:checked + .slider {
+  background-color: var(--primary);
 }
 
-input:checked+.slider:before {
-    transform: translateX(20px);
+input:checked + .slider:before {
+  transform: translateX(20px);
 }
 
 .slider:hover {
-    box-shadow: 0 0 0 3px rgba(8, 145, 178, 0.1);
+  box-shadow: 0 0 0 3px rgba(8, 145, 178, 0.1);
 }
 
 /* 额度弹窗头部 */
 .quota-modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.75rem;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .quota-update-time {
-    font-size: 0.75rem;
-    color: var(--text-light);
+  font-size: 0.75rem;
+  color: var(--text-light);
 }
 
 /* 额度弹窗 - 标签页样式 */
 .quota-tabs {
-    display: flex;
-    gap: 0.625rem;
-    margin-bottom: 1rem;
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
-    padding: 0.375rem;
-    margin: -0.375rem;
-    margin-bottom: 0.625rem;
+  display: flex;
+  gap: 0.625rem;
+  margin-bottom: 1rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+  padding: 0.375rem;
+  margin: -0.375rem;
+  margin-bottom: 0.625rem;
 }
 
 .quota-tabs::-webkit-scrollbar {
-    height: 4px;
+  height: 4px;
 }
 
 .quota-tabs::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 2px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 2px;
 }
 
 .quota-tab {
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: var(--text-light) !important;
-    padding: 0.5rem 1rem;
-    background: var(--bg) !important;
-    border: 2px solid var(--border) !important;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    white-space: nowrap;
-    min-height: auto;
-    box-shadow: none !important;
-    width: auto;
-    line-height: 1.2;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-light) !important;
+  padding: 0.5rem 1rem;
+  background: var(--bg) !important;
+  border: 2px solid var(--border) !important;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+  min-height: auto;
+  box-shadow: none !important;
+  width: auto;
+  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .quota-tab:hover {
-    color: var(--primary) !important;
-    border-color: var(--primary) !important;
-    background: rgba(8, 145, 178, 0.05) !important;
-    transform: none;
+  color: var(--primary) !important;
+  border-color: var(--primary) !important;
+  background: rgba(8, 145, 178, 0.05) !important;
+  transform: none;
 }
 
 .quota-tab.active {
-    color: white !important;
-    background: var(--primary) !important;
-    border-color: var(--primary) !important;
+  color: white !important;
+  background: var(--primary) !important;
+  border-color: var(--primary) !important;
 }
 
 .quota-container {
-    max-height: 55vh;
-    overflow: auto;
-    position: relative;
-    padding: 0.25rem;
+  max-height: 55vh;
+  overflow: auto;
+  position: relative;
+  padding: 0.25rem;
 }
 
 .quota-loading,
 .quota-error,
 .quota-empty {
-    text-align: center;
-    padding: 1.5rem;
-    color: var(--text-light);
-    font-size: 0.875rem;
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--text-light);
+  font-size: 0.875rem;
 }
 
 .quota-error {
-    color: var(--danger);
+  color: var(--danger);
 }
 
 .quota-group-title {
-    font-size: 0.9rem;
-    font-weight: 700;
-    color: var(--text);
-    margin: 1rem 0 0.5rem 0;
-    padding-bottom: 0.375rem;
-    border-bottom: 1.5px solid var(--border);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    justify-content: space-between;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 1rem 0 0.5rem 0;
+  padding-bottom: 0.375rem;
+  border-bottom: 1.5px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: space-between;
 }
 
 .quota-group-title:first-child {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 .quota-group-left {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
 .quota-group-icon {
-    width: 18px;
-    height: 18px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .quota-group-label {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .quota-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 0.75rem;
-    padding: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.75rem;
+  padding: 0.5rem;
 }
 
 .quota-item {
-    background: rgba(255, 255, 255, 0.85);
-    padding: 0.625rem;
-    border-radius: 0.5rem;
-    border: 1.5px solid var(--border);
-    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease, background 0.15s ease;
-    cursor: default;
-    color: var(--text);
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.625rem;
+  border-radius: 0.5rem;
+  border: 1.5px solid var(--border);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    border-color 0.15s ease,
+    background 0.15s ease;
+  cursor: default;
+  color: var(--text);
 }
 
 .quota-item:hover {
-    transform: scale(1.02);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
-    border-color: var(--primary);
-    background: rgba(255, 255, 255, 0.98);
-    z-index: 1;
-    position: relative;
+  transform: scale(1.02);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+  border-color: var(--primary);
+  background: rgba(255, 255, 255, 0.98);
+  z-index: 1;
+  position: relative;
 }
 
 @media (prefers-color-scheme: dark) {
-    .quota-item {
-        background: rgba(30, 41, 59, 0.78);
-    }
+  .quota-item {
+    background: rgba(30, 41, 59, 0.78);
+  }
 
-    .quota-item:hover {
-        background: rgba(30, 41, 59, 0.94);
-    }
+  .quota-item:hover {
+    background: rgba(30, 41, 59, 0.94);
+  }
 }
 
 .quota-model-name {
-    font-size: 0.75rem;
-    color: var(--text);
-    margin-bottom: 0.375rem;
-    font-weight: 500;
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    min-width: 0;
+  font-size: 0.75rem;
+  color: var(--text);
+  margin-bottom: 0.375rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
 }
 
 .quota-model-icon {
-    width: 16px;
-    height: 16px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .quota-model-text {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .quota-bar-container {
-    position: relative;
-    height: 0.5rem;
-    background: var(--border);
-    border-radius: 0.25rem;
-    overflow: hidden;
-    margin-bottom: 0.375rem;
+  position: relative;
+  height: 0.5rem;
+  background: var(--border);
+  border-radius: 0.25rem;
+  overflow: hidden;
+  margin-bottom: 0.375rem;
 }
 
 .quota-bar {
-    height: 100%;
-    border-radius: 0.25rem;
-    transition: width 0.3s ease;
+  height: 100%;
+  border-radius: 0.25rem;
+  transition: width 0.3s ease;
 }
 
 .quota-info-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 0.7rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.7rem;
 }
 
 .quota-percentage {
-    font-weight: 600;
-    color: var(--text);
+  font-weight: 600;
+  color: var(--text);
 }
 
 .quota-reset {
-    color: var(--text-light);
+  color: var(--text-light);
 }
 
 /* Token卡片内嵌额度 */
 .token-quota-inline {
-    background: rgba(8, 145, 178, 0.05);
-    border: 1px solid var(--border);
-    border-radius: 0.5rem;
-    margin-bottom: 0.75rem;
-    overflow: hidden;
+  background: rgba(8, 145, 178, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  margin-bottom: 0.75rem;
+  overflow: hidden;
 }
 
 .quota-inline-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.375rem 0.5rem;
-    cursor: pointer;
-    transition: background 0.2s;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.375rem 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s;
 }
 
 .quota-inline-header:hover {
-    background: rgba(8, 145, 178, 0.1);
+  background: rgba(8, 145, 178, 0.1);
 }
 
 .quota-inline-summary {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex: 1;
-    min-width: 0;
-    font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+  font-size: 0.75rem;
 }
 
 .quota-summary-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-    width: 100%;
-    min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  width: 100%;
+  min-width: 0;
 }
 
 .quota-summary-row {
-    display: grid;
-    grid-template-columns: 18px 1fr 60px 52px;
-    grid-template-areas:
-        "icon label bar pct"
-        ". reset reset reset";
-    align-items: center;
-    gap: 0.35rem;
-    row-gap: 0.1rem;
-    min-width: 0;
+  display: grid;
+  grid-template-columns: 18px 1fr 60px 52px;
+  grid-template-areas:
+    "icon label bar pct"
+    ". reset reset reset";
+  align-items: center;
+  gap: 0.35rem;
+  row-gap: 0.1rem;
+  min-width: 0;
 }
 
 .quota-summary-icon {
-    grid-area: icon;
-    width: 18px;
-    height: 18px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  grid-area: icon;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .quota-icon-img {
-    width: 16px;
-    height: 16px;
-    display: block;
+  width: 16px;
+  height: 16px;
+  display: block;
 }
 
 .quota-summary-label {
-    grid-area: label;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--text);
-    font-weight: 500;
+  grid-area: label;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+  font-weight: 500;
 }
 
 .quota-summary-reset {
-    grid-area: reset;
-    font-size: 0.65rem;
-    color: var(--text-light);
-    text-align: left;
-    white-space: normal;
-    overflow-wrap: anywhere;
-    font-variant-numeric: tabular-nums;
-    min-width: 0;
+  grid-area: reset;
+  font-size: 0.65rem;
+  color: var(--text-light);
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
 }
 
 .quota-summary-bar {
-    grid-area: bar;
-    width: 60px;
-    height: 8px;
-    background: var(--border);
-    border-radius: 4px;
-    overflow: hidden;
+  grid-area: bar;
+  width: 60px;
+  height: 8px;
+  background: var(--border);
+  border-radius: 4px;
+  overflow: hidden;
 }
 
 .quota-summary-bar span {
-    display: block;
-    height: 100%;
-    border-radius: 4px;
+  display: block;
+  height: 100%;
+  border-radius: 4px;
 }
 
 .quota-summary-pct {
-    grid-area: pct;
-    flex-shrink: 0;
-    font-weight: 600;
-    font-size: 0.7rem;
-    color: var(--primary);
-    min-width: 32px;
-    text-align: right;
+  grid-area: pct;
+  flex-shrink: 0;
+  font-weight: 600;
+  font-size: 0.7rem;
+  color: var(--primary);
+  min-width: 32px;
+  text-align: right;
 }
 
 .quota-inline-toggle {
-    font-size: 0.65rem;
-    color: var(--text-light);
-    flex-shrink: 0;
-    margin-left: 0.5rem;
-    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  font-size: 0.65rem;
+  color: var(--text-light);
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .quota-inline-toggle.expanded {
-    transform: rotate(180deg);
+  transform: rotate(180deg);
 }
 
 .quota-inline-detail {
-    border-top: 1px solid var(--border);
-    padding: 0.5rem;
-    background: var(--bg);
-    animation: slideDown 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    transform-origin: top;
+  border-top: 1px solid var(--border);
+  padding: 0.5rem;
+  background: var(--bg);
+  animation: slideDown 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: top;
 }
 
 @keyframes slideDown {
-    from {
-        opacity: 0;
-        transform: scaleY(0.8);
-        max-height: 0;
-    }
+  from {
+    opacity: 0;
+    transform: scaleY(0.8);
+    max-height: 0;
+  }
 
-    to {
-        opacity: 1;
-        transform: scaleY(1);
-        max-height: 500px;
-    }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+    max-height: 500px;
+  }
 }
 
 .quota-inline-detail.collapsing {
-    animation: slideUp 0.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  animation: slideUp 0.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 @keyframes slideUp {
-    from {
-        opacity: 1;
-        transform: scaleY(1);
-    }
+  from {
+    opacity: 1;
+    transform: scaleY(1);
+  }
 
-    to {
-        opacity: 0;
-        transform: scaleY(0.8);
-    }
+  to {
+    opacity: 0;
+    transform: scaleY(0.8);
+  }
 }
 
 .quota-detail-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    margin-bottom: 0.5rem;
-    max-height: 200px;
-    overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .quota-detail-row {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.25rem 0;
-    font-size: 0.7rem;
-    border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0;
+  font-size: 0.7rem;
+  border-bottom: 1px solid var(--border);
 }
 
 .quota-detail-row:last-child {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .quota-detail-icon {
-    flex-shrink: 0;
-    font-size: 0.65rem;
+  flex-shrink: 0;
+  font-size: 0.65rem;
 }
 
 .quota-detail-icon .quota-icon-img {
-    width: 14px;
-    height: 14px;
+  width: 14px;
+  height: 14px;
 }
 
 .quota-detail-name {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
 }
 
 .quota-detail-bar {
-    flex: 0 0 50px;
-    height: 6px;
-    background: var(--border);
-    border-radius: 3px;
-    overflow: hidden;
+  flex: 0 0 50px;
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
 }
 
 .quota-detail-bar span {
-    display: block;
-    height: 100%;
-    border-radius: 3px;
+  display: block;
+  height: 100%;
+  border-radius: 3px;
 }
 
 .quota-detail-pct {
-    flex-shrink: 0;
-    font-weight: 600;
-    font-size: 0.65rem;
-    color: var(--primary);
-    min-width: 28px;
-    text-align: right;
+  flex-shrink: 0;
+  font-weight: 600;
+  font-size: 0.65rem;
+  color: var(--primary);
+  min-width: 28px;
+  text-align: right;
 }
 
 .quota-refresh-btn {
-    width: 100%;
-    margin-top: 0.5rem;
+  width: 100%;
+  margin-top: 0.5rem;
 }
 
 .quota-loading-small {
-    font-size: 0.7rem;
-    color: var(--text-light);
-    text-align: center;
-    padding: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--text-light);
+  text-align: center;
+  padding: 0.5rem;
 }
 
 .quota-empty-small,
 .quota-error-small {
-    font-size: 0.7rem;
-    color: var(--text-light);
-    text-align: center;
-    padding: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--text-light);
+  text-align: center;
+  padding: 0.5rem;
 }
 
 .quota-error-small {
-    color: var(--danger);
+  color: var(--danger);
 }
 
 .quota-summary-error {
-    color: var(--danger);
-    font-size: 0.7rem;
+  color: var(--danger);
+  font-size: 0.7rem;
 }
 
 .quota-group-meta {
-    font-size: 0.75em;
-    font-weight: 400;
-    color: var(--text-light);
-    margin-left: 0.5rem;
+  font-size: 0.75em;
+  font-weight: 400;
+  color: var(--text-light);
+  margin-left: 0.5rem;
 }
 
 .hidden {
-    display: none !important;
+  display: none !important;
 }
 
 /* ==================== 日志页面样式 ==================== */
 
 #logsPage {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    min-height: 0;
-    overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 #logsPage.page-enter {
-    animation: pageSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  animation: pageSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* 日志顶部栏 */
 .logs-top-bar {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    background: rgba(255, 255, 255, 0.6);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    padding: 0.75rem 1rem;
-    border-radius: 0.75rem;
-    margin-bottom: 1rem;
-    border: 1.5px solid var(--border);
-    flex-shrink: 0;
-    z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1rem;
+  border: 1.5px solid var(--border);
+  flex-shrink: 0;
+  z-index: 10;
 }
 
 @media (prefers-color-scheme: dark) {
-    .logs-top-bar {
-        background: rgba(30, 41, 59, 0.95);
-    }
+  .logs-top-bar {
+    background: rgba(30, 41, 59, 0.95);
+  }
 }
 
 /* 日志顶部行：统计 */
 .logs-top-row {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 /* 日志统计 */
 .log-stats {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    padding-bottom: 0.25rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 0.25rem;
 }
 
 .log-stat-item {
-    display: flex;
-    align-items: baseline;
-    gap: 0.25rem;
-    padding: 0.25rem 0.5rem;
-    border-radius: 0.375rem;
-    transition: all 0.2s;
-    border: 1.5px solid transparent;
-    white-space: nowrap;
-    flex-shrink: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+  border: 1.5px solid transparent;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .log-stat-item.clickable {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .log-stat-item.clickable:hover {
-    background: rgba(8, 145, 178, 0.1);
-    transform: translateY(-1px);
+  background: rgba(8, 145, 178, 0.1);
+  transform: translateY(-1px);
 }
 
 .log-stat-item.clickable:active {
-    transform: translateY(0) scale(0.98);
+  transform: translateY(0) scale(0.98);
 }
 
 .log-stat-item.clickable.active {
-    background: rgba(8, 145, 178, 0.15);
-    border-color: var(--primary);
-    box-shadow: 0 2px 8px rgba(8, 145, 178, 0.2);
+  background: rgba(8, 145, 178, 0.15);
+  border-color: var(--primary);
+  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.2);
 }
 
 .log-stat-item.info.active {
-    border-color: var(--success);
-    background: rgba(16, 185, 129, 0.15);
+  border-color: var(--success);
+  background: rgba(16, 185, 129, 0.15);
 }
 
 .log-stat-item.debug.active {
-    border-color: #3b82f6;
-    background: rgba(59, 130, 246, 0.15);
+  border-color: #3b82f6;
+  background: rgba(59, 130, 246, 0.15);
 }
 
 .log-stat-item.warn.active {
-    border-color: var(--warning);
-    background: rgba(245, 158, 11, 0.15);
+  border-color: var(--warning);
+  background: rgba(245, 158, 11, 0.15);
 }
 
 .log-stat-item.error.active {
-    border-color: var(--danger);
-    background: rgba(239, 68, 68, 0.15);
+  border-color: var(--danger);
+  background: rgba(239, 68, 68, 0.15);
 }
 
 .log-stat-item.request.active {
-    border-color: var(--info);
-    background: rgba(6, 182, 212, 0.15);
+  border-color: var(--info);
+  background: rgba(6, 182, 212, 0.15);
 }
 
 .log-stat-num {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--primary);
-    line-height: 1;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--primary);
+  line-height: 1;
 }
 
 .log-stat-item.info .log-stat-num {
-    color: var(--success);
+  color: var(--success);
 }
 
 .log-stat-item.debug .log-stat-num {
-    color: #3b82f6;
+  color: #3b82f6;
 }
 
 .log-stat-item.warn .log-stat-num {
-    color: var(--warning);
+  color: var(--warning);
 }
 
 .log-stat-item.error .log-stat-num {
-    color: var(--danger);
+  color: var(--danger);
 }
 
 .log-stat-item.request .log-stat-num {
-    color: var(--info);
+  color: var(--info);
 }
 
 .log-stat-label {
-    font-size: 0.85rem;
-    color: var(--text-light);
-    line-height: 1;
+  font-size: 0.85rem;
+  color: var(--text-light);
+  line-height: 1;
 }
 
 /* 日志第二行：搜索 + 操作按钮 */
 .logs-second-row {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 /* 日志搜索框 */
 .log-search {
-    flex: 1;
-    min-width: 150px;
+  flex: 1;
+  min-width: 150px;
 }
 
 .log-search input {
-    min-height: 32px;
-    font-size: 0.8rem;
+  min-height: 32px;
+  font-size: 0.8rem;
 }
 
 /* 日志操作按钮组 - 类似 Token 页面的网格布局 */
 .log-action-btns {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    justify-content: flex-start;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 /* 筛选按钮样式 */
 .log-filter-btn {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    background: var(--bg);
-    border: 1.5px solid var(--border);
-    border-radius: 0.375rem;
-    color: var(--text-light);
-    cursor: pointer;
-    transition: all 0.2s;
-    min-height: 32px;
-    width: auto;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--bg);
+  border: 1.5px solid var(--border);
+  border-radius: 0.375rem;
+  color: var(--text-light);
+  cursor: pointer;
+  transition: all 0.2s;
+  min-height: 32px;
+  width: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .log-filter-btn:hover {
-    border-color: var(--primary);
-    color: var(--primary);
-    transform: translateY(-1px);
+  border-color: var(--primary);
+  color: var(--primary);
+  transform: translateY(-1px);
 }
 
 .log-filter-btn.active {
-    background: var(--primary);
-    border-color: var(--primary);
-    color: white;
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
 }
 
 /* 筛选按钮颜色 */
 .log-filter-btn.info.active {
-    background: var(--success);
-    border-color: var(--success);
+  background: var(--success);
+  border-color: var(--success);
 }
 
 .log-filter-btn.warn.active {
-    background: var(--warning);
-    border-color: var(--warning);
+  background: var(--warning);
+  border-color: var(--warning);
 }
 
 .log-filter-btn.error.active {
-    background: var(--danger);
-    border-color: var(--danger);
+  background: var(--danger);
+  border-color: var(--danger);
 }
 
 .log-filter-btn.request.active {
-    background: var(--info);
-    border-color: var(--info);
+  background: var(--info);
+  border-color: var(--info);
 }
 
 /* 日志容器 */
 .log-container {
-    flex: 1;
-    min-height: 0;
-    background: rgba(255, 255, 255, 0.5);
-    border: 1.5px solid var(--border);
-    border-radius: 0.75rem;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background: rgba(255, 255, 255, 0.5);
+  border: 1.5px solid var(--border);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (prefers-color-scheme: dark) {
-    .log-container {
-        background: rgba(30, 41, 59, 0.5);
-    }
+  .log-container {
+    background: rgba(30, 41, 59, 0.5);
+  }
 }
 
 /* 日志列表 */
 .log-list {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 0.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 /* 日志条目 */
 .log-item {
-    background: rgba(255, 255, 255, 0.9);
-    border: 1.5px solid var(--border);
-    border-radius: 0.5rem;
-    padding: 0.625rem 0.75rem;
-    transition: all 0.2s;
-    animation: logFadeIn 0.3s ease;
-    flex-shrink: 0;
-    max-height: 300px;
-    overflow-y: auto;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1.5px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  transition: all 0.2s;
+  animation: logFadeIn 0.3s ease;
+  flex-shrink: 0;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 @keyframes logFadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(-5px);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
 
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (prefers-color-scheme: dark) {
-    .log-item {
-        background: rgba(30, 41, 59, 0.9);
-    }
+  .log-item {
+    background: rgba(30, 41, 59, 0.9);
+  }
 }
 
 .log-item:hover {
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .log-item.info {
-    border-left: 3px solid var(--success);
+  border-left: 3px solid var(--success);
 }
 
 .log-item.info:hover {
-    border-color: var(--success);
+  border-color: var(--success);
 }
 
 .log-item.warn {
-    border-left: 3px solid var(--warning);
+  border-left: 3px solid var(--warning);
 }
 
 .log-item.warn:hover {
-    border-color: var(--warning);
+  border-color: var(--warning);
 }
 
 .log-item.error {
-    border-left: 3px solid var(--danger);
+  border-left: 3px solid var(--danger);
 }
 
 .log-item.error:hover {
-    border-color: var(--danger);
+  border-color: var(--danger);
 }
 
 .log-item.request {
-    border-left: 3px solid var(--info);
+  border-left: 3px solid var(--info);
 }
 
 .log-item.request:hover {
-    border-color: var(--info);
+  border-color: var(--info);
 }
 
 .log-item-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.375rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
 }
 
 .log-level-icon {
-    font-size: 0.875rem;
+  font-size: 0.875rem;
 }
 
 .log-level-tag {
-    font-size: 0.65rem;
-    font-weight: 600;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    text-transform: uppercase;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  text-transform: uppercase;
 }
 
 .log-level-tag.info {
-    background: rgba(16, 185, 129, 0.15);
-    color: var(--success);
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--success);
 }
 
 .log-level-tag.debug {
-    background: rgba(59, 130, 246, 0.15);
-    color: #3b82f6;
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
 }
 
 .log-level-tag.warn {
-    background: rgba(245, 158, 11, 0.15);
-    color: var(--warning);
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning);
 }
 
 .log-level-tag.error {
-    background: rgba(239, 68, 68, 0.15);
-    color: var(--danger);
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--danger);
 }
 
 .log-level-tag.request {
-    background: rgba(6, 182, 212, 0.15);
-    color: var(--info);
+  background: rgba(6, 182, 212, 0.15);
+  color: var(--info);
 }
 
 .log-time {
-    font-size: 0.7rem;
-    color: var(--text-light);
-    margin-left: auto;
+  font-size: 0.7rem;
+  color: var(--text-light);
+  margin-left: auto;
 }
 
 /* 日志复制按钮 */
 .log-copy-btn {
-    width: 24px;
-    height: 24px;
-    min-height: 24px;
-    min-width: 24px;
-    padding: 0;
-    margin-left: 0.5rem;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 0.25rem;
-    cursor: pointer;
-    font-size: 0.75rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 0;
-    transition: all 0.2s ease;
-    flex-shrink: 0;
-    box-shadow: none;
-    color: var(--text-light);
+  width: 24px;
+  height: 24px;
+  min-height: 24px;
+  min-width: 24px;
+  padding: 0;
+  margin-left: 0.5rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+  box-shadow: none;
+  color: var(--text-light);
 }
 
 .log-item:hover .log-copy-btn {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 
 .log-copy-btn:hover {
-    opacity: 1 !important;
-    background: var(--bg);
-    border-color: var(--primary);
-    color: var(--primary);
-    transform: scale(1.1);
+  opacity: 1 !important;
+  background: var(--bg);
+  border-color: var(--primary);
+  color: var(--primary);
+  transform: scale(1.1);
 }
 
 .log-copy-btn:active {
-    transform: scale(0.95);
+  transform: scale(0.95);
 }
 
 .log-copy-btn.copied {
-    opacity: 1 !important;
-    background: var(--success);
-    border-color: var(--success);
-    color: white;
+  opacity: 1 !important;
+  background: var(--success);
+  border-color: var(--success);
+  color: white;
 }
 
 /* 移动端日志复制按钮始终显示 */
 @media (max-width: 768px) {
-    .log-copy-btn {
-        opacity: 0.5;
-    }
+  .log-copy-btn {
+    opacity: 0.5;
+  }
 }
 
 .log-message {
-    font-size: 0.75rem;
-    color: var(--text);
-    line-height: 1.5;
-    word-break: break-word;
-    /* 继承全局字体设置，不再硬编码等宽字体 */
-    max-height: 200px;
-    overflow-y: auto;
+  font-size: 0.75rem;
+  color: var(--text);
+  line-height: 1.5;
+  word-break: break-word;
+  /* 继承全局字体设置，不再硬编码等宽字体 */
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .log-message mark {
-    background: rgba(245, 158, 11, 0.3);
-    color: inherit;
-    padding: 0 0.125rem;
-    border-radius: 0.125rem;
+  background: rgba(245, 158, 11, 0.3);
+  color: inherit;
+  padding: 0 0.125rem;
+  border-radius: 0.125rem;
 }
 
 /* 日志空状态 */
 .log-empty {
-    text-align: center;
-    padding: 3rem 1rem;
-    color: var(--text-light);
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-light);
 }
 
 .log-empty-icon {
-    font-size: 3rem;
-    margin-bottom: 0.75rem;
-    opacity: 0.5;
+  font-size: 3rem;
+  margin-bottom: 0.75rem;
+  opacity: 0.5;
 }
 
 .log-empty-text {
-    font-size: 1rem;
-    font-weight: 500;
+  font-size: 1rem;
+  font-weight: 500;
 }
 
 /* 加载更多按钮 */
 .load-more-btn {
-    margin: 1rem auto;
-    width: auto;
-    padding: 0.5rem 1.5rem;
+  margin: 1rem auto;
+  width: auto;
+  padding: 0.5rem 1.5rem;
 }
 
 /* 自动刷新按钮激活状态 */
 #autoRefreshBtn.active {
-    background: var(--success);
-    animation: pulse 2s ease-in-out infinite;
+  background: var(--success);
+  animation: pulse 2s ease-in-out infinite;
 }
 
 /* 响应式 - 日志页面 */
 @media (max-width: 768px) {
-    .logs-top-bar {
-        padding: 0.5rem 0.75rem;
-    }
+  .logs-top-bar {
+    padding: 0.5rem 0.75rem;
+  }
 
-    .logs-top-row {
-        justify-content: flex-start;
-        overflow-x: auto;
-    }
+  .logs-top-row {
+    justify-content: flex-start;
+    overflow-x: auto;
+  }
 
-    .log-stats {
-        justify-content: flex-start;
-        gap: 0.5rem;
-    }
+  .log-stats {
+    justify-content: flex-start;
+    gap: 0.5rem;
+  }
 
-    .log-stat-num {
-        font-size: 0.9rem;
-    }
+  .log-stat-num {
+    font-size: 0.9rem;
+  }
 
-    .log-stat-label {
-        font-size: 0.7rem;
-    }
+  .log-stat-label {
+    font-size: 0.7rem;
+  }
 
-    .log-stat-item {
-        padding: 0.2rem 0.375rem;
-    }
+  .log-stat-item {
+    padding: 0.2rem 0.375rem;
+  }
 
-    .logs-second-row {
-        flex-wrap: wrap;
-    }
+  .logs-second-row {
+    flex-wrap: wrap;
+  }
 
-    .log-search {
-        flex: 1 1 100%;
-        order: 1;
-    }
+  .log-search {
+    flex: 1 1 100%;
+    order: 1;
+  }
 
-    .log-action-btns {
-        flex: 1 1 100%;
-        order: 2;
-        display: grid !important;
-        grid-template-columns: repeat(4, 1fr) !important;
-        gap: 0.375rem !important;
-    }
+  .log-action-btns {
+    flex: 1 1 100%;
+    order: 2;
+    display: grid !important;
+    grid-template-columns: repeat(4, 1fr) !important;
+    gap: 0.375rem !important;
+  }
 
-    .log-action-btns .btn {
-        width: 100% !important;
-        padding: 0.375rem 0.5rem;
-        font-size: 0.7rem;
-        min-height: 32px;
-    }
+  .log-action-btns .btn {
+    width: 100% !important;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.7rem;
+    min-height: 32px;
+  }
 
-    .log-item {
-        padding: 0.5rem;
-    }
+  .log-item {
+    padding: 0.5rem;
+  }
 
-    .log-message {
-        font-size: 0.7rem;
-    }
+  .log-message {
+    font-size: 0.7rem;
+  }
 
-    .log-time {
-        font-size: 0.65rem;
-    }
+  .log-time {
+    font-size: 0.65rem;
+  }
 }
 
 @media (max-width: 480px) {
-    .tab {
-        flex-direction: column;
-        gap: 0.125rem;
-        min-height: 44px;
-        padding: 0.375rem 0.25rem;
-    }
+  .tab {
+    flex-direction: column;
+    gap: 0.125rem;
+    min-height: 44px;
+    padding: 0.375rem 0.25rem;
+  }
 
-    .tab .tab-icon {
-        font-size: 1rem;
-    }
+  .tab .tab-icon {
+    font-size: 1rem;
+  }
 
-    .tab .tab-text {
-        font-size: 0.6rem;
-    }
+  .tab .tab-text {
+    font-size: 0.6rem;
+  }
 
-    .log-stat-num {
-        font-size: 0.85rem;
-    }
+  .log-stat-num {
+    font-size: 0.85rem;
+  }
 
-    .log-stat-label {
-        font-size: 0.65rem;
-    }
+  .log-stat-label {
+    font-size: 0.65rem;
+  }
 
-    .log-action-btns {
-        grid-template-columns: repeat(4, 1fr) !important;
-    }
+  .log-action-btns {
+    grid-template-columns: repeat(4, 1fr) !important;
+  }
 
-    .log-action-btns .btn {
-        padding: 0.25rem 0.375rem;
-        font-size: 0.65rem;
-        min-height: 30px;
-    }
+  .log-action-btns .btn {
+    padding: 0.25rem 0.375rem;
+    font-size: 0.65rem;
+    min-height: 30px;
+  }
 }
 
 /* 敏感信息行 - 隐藏时不显示 */
 .sensitive-row {
-    transition: opacity 0.2s, max-height 0.2s;
+  transition:
+    opacity 0.2s,
+    max-height 0.2s;
 }
 
 /* 响应式 */
 @media (max-width: 768px) {
-    .container {
-        padding: 0;
-        height: 100vh;
-        height: 100dvh;
-        align-items: stretch;
-    }
+  .container {
+    padding: 0;
+    height: 100vh;
+    height: 100dvh;
+    align-items: stretch;
+  }
 
-    .login-form {
-        margin: auto 0.5rem;
-        padding: 1.5rem;
-    }
+  .login-form {
+    margin: auto 0.5rem;
+    padding: 1.5rem;
+  }
 
-    .login-form h2 {
-        font-size: 1.25rem;
-    }
+  .login-form h2 {
+    font-size: 1.25rem;
+  }
 
-    .main-content {
-        height: 100vh;
-        height: 100dvh;
-        border-radius: 0;
-        margin: 0;
-    }
+  .main-content {
+    height: 100vh;
+    height: 100dvh;
+    border-radius: 0;
+    margin: 0;
+  }
 
-    .header {
-        padding: 0.5rem 0.75rem;
-        flex-wrap: nowrap;
-        gap: 0.5rem;
-    }
+  .header {
+    padding: 0.5rem 0.75rem;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+  }
 
-    .header-right {
-        flex-shrink: 0;
-    }
+  .header-right {
+    flex-shrink: 0;
+  }
 
-    .header-right .server-info {
-        display: none;
-    }
+  .header-right .server-info {
+    display: none;
+  }
 
-    .header-right button {
-        padding: 0.375rem 0.5rem;
-        font-size: 0.7rem;
-        min-height: 32px;
-    }
+  .header-right button {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.7rem;
+    min-height: 32px;
+  }
 
-    .tabs {
-        flex: 1;
-        min-width: 0;
-    }
+  .tabs {
+    flex: 1;
+    min-width: 0;
+  }
 
-    .tab {
-        flex: 1;
-        padding: 0.375rem 0.5rem;
-        min-height: 32px;
-        font-size: 0.75rem;
-    }
+  .tab {
+    flex: 1;
+    padding: 0.375rem 0.5rem;
+    min-height: 32px;
+    font-size: 0.75rem;
+  }
 
-    .tab .tab-icon {
-        font-size: 0.9rem;
-    }
+  .tab .tab-icon {
+    font-size: 0.9rem;
+  }
 
-    .tab .tab-text {
-        font-size: 0.75rem;
-    }
+  .tab .tab-text {
+    font-size: 0.75rem;
+  }
 
-    .content {
-        padding: 0.75rem;
-    }
+  .content {
+    padding: 0.75rem;
+  }
 
-    .top-bar {
-        flex-direction: column;
-        gap: 0.5rem;
-        align-items: stretch;
-        padding: 0.5rem 0.75rem;
-    }
+  .top-bar {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: stretch;
+    padding: 0.5rem 0.75rem;
+  }
 
-    .stats-inline {
-        justify-content: space-around;
-        flex-wrap: nowrap;
-    }
+  .stats-inline {
+    justify-content: space-around;
+    flex-wrap: nowrap;
+  }
 
-    /* 移动端显示展开/收起按钮 */
-    .action-toggle-btn {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-shrink: 0;
-    }
+  /* 移动端显示展开/收起按钮 */
+  .action-toggle-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
 
-    /* 移动端操作按钮区域可收起 */
-    .action-btns {
-        display: grid !important;
-        grid-template-columns: repeat(3, 1fr) !important;
-        gap: 0.375rem !important;
-        justify-content: stretch !important;
-        max-height: none;
-        overflow: visible;
-        transition: max-height 0.25s ease-out,
-            opacity 0.25s ease-out,
-            margin 0.25s ease-out,
-            padding 0.25s ease-out;
-    }
+  /* 移动端操作按钮区域可收起 */
+  .action-btns {
+    display: grid !important;
+    grid-template-columns: repeat(3, 1fr) !important;
+    gap: 0.375rem !important;
+    justify-content: stretch !important;
+    max-height: none;
+    overflow: visible;
+    transition:
+      max-height 0.25s ease-out,
+      opacity 0.25s ease-out,
+      margin 0.25s ease-out,
+      padding 0.25s ease-out;
+  }
 
-    .action-btns.collapsed {
-        max-height: 0;
-        opacity: 0;
-        margin-top: -0.5rem;
-        pointer-events: none;
-        overflow: hidden;
-    }
+  .action-btns.collapsed {
+    max-height: 0;
+    opacity: 0;
+    margin-top: -0.5rem;
+    pointer-events: none;
+    overflow: hidden;
+  }
 
-    .action-btns>.btn,
-    .action-btns>.btn-sm {
-        width: 100% !important;
-    }
+  .action-btns > .btn,
+  .action-btns > .btn-sm {
+    width: 100% !important;
+  }
 
-    .action-btns .btn-sm {
-        width: 100% !important;
-        padding: 0.375rem 0.5rem;
-        font-size: 0.7rem;
-        min-height: 32px;
-    }
+  .action-btns .btn-sm {
+    width: 100% !important;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.7rem;
+    min-height: 32px;
+  }
 
-    .token-grid {
-        grid-template-columns: 1fr;
-    }
+  .token-grid {
+    grid-template-columns: 1fr;
+  }
 
-    .settings-layout {
-        grid-template-columns: 1fr;
-    }
+  .settings-layout {
+    grid-template-columns: 1fr;
+  }
 
-    .settings-nav {
-        position: static;
-        max-height: none;
-        overflow: visible;
-    }
+  .settings-nav {
+    position: static;
+    max-height: none;
+    overflow: visible;
+  }
 
-    .settings-section-select {
-        display: block;
-    }
+  .settings-section-select {
+    display: block;
+  }
 
-    .settings-nav-list {
-        display: none;
-    }
+  .settings-nav-list {
+    display: none;
+  }
 
-    .config-grid {
-        grid-template-columns: 1fr;
-    }
+  .config-grid {
+    grid-template-columns: 1fr;
+  }
 
-    .form-row-inline {
-        grid-template-columns: 1fr;
-    }
+  .form-row-inline {
+    grid-template-columns: 1fr;
+  }
 
-    .switch-row {
-        flex-direction: column !important;
-        gap: 0.375rem;
-        padding: 0.375rem;
-    }
+  .switch-row {
+    flex-direction: column !important;
+    gap: 0.375rem;
+    padding: 0.375rem;
+  }
 
-    .switch-group {
-        width: 100%;
-        min-height: 32px;
-        padding: 0.3rem 0.5rem;
-    }
+  .switch-group {
+    width: 100%;
+    min-height: 32px;
+    padding: 0.3rem 0.5rem;
+  }
 
-    .toast {
-        right: 8px;
-        left: 8px;
-        min-width: auto;
-        max-width: none;
-    }
+  .toast {
+    right: 8px;
+    left: 8px;
+    min-width: auto;
+    max-width: none;
+  }
 
-    .modal {
-        padding: 0.25rem;
-    }
+  .modal {
+    padding: 0.25rem;
+  }
 
-    .modal-content {
-        padding: 0.75rem;
-    }
+  .modal-content {
+    padding: 0.75rem;
+  }
 
-    .modal-content.modal-xl {
-        max-width: 100%;
-        max-height: 90vh;
-        margin: 0.25rem;
-    }
+  .modal-content.modal-xl {
+    max-width: 100%;
+    max-height: 90vh;
+    margin: 0.25rem;
+  }
 
-    .quota-modal-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.25rem;
-    }
+  .quota-modal-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
 
-    .quota-tabs {
-        flex-wrap: nowrap;
-        gap: 0.375rem;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        padding-bottom: 0.25rem;
-    }
+  .quota-tabs {
+    flex-wrap: nowrap;
+    gap: 0.375rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.25rem;
+  }
 
-    .quota-tab {
-        font-size: 0.75rem;
-        padding: 0.3rem 0.6rem;
-    }
+  .quota-tab {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.6rem;
+  }
 
-    .quota-grid {
-        grid-template-columns: 1fr;
-        gap: 0.5rem;
-        padding: 0.25rem;
-    }
+  .quota-grid {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    padding: 0.25rem;
+  }
 
-    .quota-item {
-        padding: 0.5rem;
-    }
+  .quota-item {
+    padding: 0.5rem;
+  }
 
-    .quota-item:hover {
-        transform: none;
-    }
+  .quota-item:hover {
+    transform: none;
+  }
 
-    .quota-group-title {
-        font-size: 0.85rem;
-        margin: 0.75rem 0 0.375rem 0;
-    }
+  .quota-group-title {
+    font-size: 0.85rem;
+    margin: 0.75rem 0 0.375rem 0;
+  }
 
-    /* 移动端内嵌额度优化 */
-    .quota-summary-label {
-        font-size: 0.7rem;
-    }
+  /* 移动端内嵌额度优化 */
+  .quota-summary-label {
+    font-size: 0.7rem;
+  }
 
-    .quota-summary-row {
-        grid-template-columns: 18px 1fr 54px 48px;
-        grid-template-areas:
-            "icon label bar pct"
-            ". reset reset reset";
-        gap: 0.3rem;
-    }
+  .quota-summary-row {
+    grid-template-columns: 18px 1fr 54px 48px;
+    grid-template-areas:
+      "icon label bar pct"
+      ". reset reset reset";
+    gap: 0.3rem;
+  }
 
-    .quota-summary-bar {
-        width: 54px;
-    }
+  .quota-summary-bar {
+    width: 54px;
+  }
 
-    /* 移动端Token卡片操作按钮 */
-    .token-actions {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        /* 允许换行，防止过窄 */
-    }
+  /* 移动端Token卡片操作按钮 */
+  .token-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    /* 允许换行，防止过窄 */
+  }
 
-    .token-actions .btn-xs {
-        flex: 1;
-        /* 自适应撑满 */
-        min-width: 60px;
-        /* 最小宽度 */
-        padding: 0.375rem 0.5rem;
-        font-size: 0.75rem;
-        /* 稍微大一点 */
-        min-height: 32px;
-        /* 更易点击 */
-    }
+  .token-actions .btn-xs {
+    flex: 1;
+    /* 自适应撑满 */
+    min-width: 60px;
+    /* 最小宽度 */
+    padding: 0.375rem 0.5rem;
+    font-size: 0.75rem;
+    /* 稍微大一点 */
+    min-height: 32px;
+    /* 更易点击 */
+  }
 }
 
 @media (max-width: 480px) {
-    .stat-num {
-        font-size: 1rem;
-    }
+  .stat-num {
+    font-size: 1rem;
+  }
 
-    .stat-text {
-        font-size: 0.75rem;
-    }
+  .stat-text {
+    font-size: 0.75rem;
+  }
 
-    .btn-sm {
-        padding: 0.25rem 0.375rem;
-        font-size: 0.65rem;
-        min-height: 30px;
-    }
+  .btn-sm {
+    padding: 0.25rem 0.375rem;
+    font-size: 0.65rem;
+    min-height: 30px;
+  }
 
-    .token-card {
-        padding: 0.625rem;
-    }
+  .token-card {
+    padding: 0.625rem;
+  }
 
-    .info-row {
-        font-size: 0.7rem;
-    }
+  .info-row {
+    font-size: 0.7rem;
+  }
 
-    .info-label {
-        width: 18px;
-    }
+  .info-label {
+    width: 18px;
+  }
 
-    .info-value {
-        font-size: 0.7rem;
-    }
+  .info-value {
+    font-size: 0.7rem;
+  }
 
-    /* 超小屏幕按钮布局 */
-    .action-btns {
-        grid-template-columns: repeat(3, 1fr);
-    }
+  /* 超小屏幕按钮布局 */
+  .action-btns {
+    grid-template-columns: repeat(3, 1fr);
+  }
 
-    .quota-summary-label {
-        font-size: 0.65rem;
-    }
+  .quota-summary-label {
+    font-size: 0.65rem;
+  }
 
-    .quota-summary-pct {
-        font-size: 0.65rem;
-    }
+  .quota-summary-pct {
+    font-size: 0.65rem;
+  }
 
-    .quota-summary-bar {
-        width: 44px;
-    }
+  .quota-summary-bar {
+    width: 44px;
+  }
 
-    .quota-summary-reset {
-        font-size: 0.6rem;
-    }
+  .quota-summary-reset {
+    font-size: 0.6rem;
+  }
 
-    .quota-summary-row {
-        grid-template-columns: 18px 1fr 44px 44px;
-        grid-template-areas:
-            "icon label bar pct"
-            ". reset reset reset";
-        gap: 0.25rem;
-    }
+  .quota-summary-row {
+    grid-template-columns: 18px 1fr 44px 44px;
+    grid-template-areas:
+      "icon label bar pct"
+      ". reset reset reset";
+    gap: 0.25rem;
+  }
 
-    .quota-detail-name {
-        font-size: 0.6rem;
-    }
+  .quota-detail-name {
+    font-size: 0.6rem;
+  }
 
-    .quota-detail-pct {
-        font-size: 0.6rem;
-    }
+  .quota-detail-pct {
+    font-size: 0.6rem;
+  }
 
-    /* Token卡片头部优化 */
-    .token-header {
-        flex-wrap: wrap;
-        gap: 0.25rem;
-    }
+  /* Token卡片头部优化 */
+  .token-header {
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
 
-    .status {
-        font-size: 0.65rem;
-        padding: 0.2rem 0.4rem;
-    }
+  .status {
+    font-size: 0.65rem;
+    padding: 0.2rem 0.4rem;
+  }
 
-    .token-id {
-        font-size: 0.6rem;
-    }
+  .token-id {
+    font-size: 0.6rem;
+  }
 }
 
 /* ==================== 导入拖拽上传样式 ==================== */
 
 /* 拖拽区域 */
 .import-dropzone {
-    border: 2px dashed var(--border);
-    border-radius: 0.75rem;
-    padding: 2rem 1rem;
-    text-align: center;
-    cursor: pointer;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    background: rgba(8, 145, 178, 0.03);
-    margin-bottom: 1rem;
+  border: 2px dashed var(--border);
+  border-radius: 0.75rem;
+  padding: 2rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  background: rgba(8, 145, 178, 0.03);
+  margin-bottom: 1rem;
 }
 
 .import-dropzone:hover {
-    border-color: var(--primary);
-    background: rgba(8, 145, 178, 0.08);
-    transform: translateY(-2px);
+  border-color: var(--primary);
+  background: rgba(8, 145, 178, 0.08);
+  transform: translateY(-2px);
 }
 
 .import-dropzone.dragover {
-    border-color: var(--primary);
-    background: rgba(8, 145, 178, 0.15);
-    border-style: solid;
-    transform: scale(1.02);
-    box-shadow: 0 8px 24px rgba(8, 145, 178, 0.2);
+  border-color: var(--primary);
+  background: rgba(8, 145, 178, 0.15);
+  border-style: solid;
+  transform: scale(1.02);
+  box-shadow: 0 8px 24px rgba(8, 145, 178, 0.2);
 }
 
 .dropzone-icon {
-    font-size: 3rem;
-    margin-bottom: 0.75rem;
-    opacity: 0.6;
-    transition: transform 0.25s ease;
+  font-size: 3rem;
+  margin-bottom: 0.75rem;
+  opacity: 0.6;
+  transition: transform 0.25s ease;
 }
 
 .import-dropzone:hover .dropzone-icon,
 .import-dropzone.dragover .dropzone-icon {
-    transform: scale(1.1);
-    opacity: 1;
+  transform: scale(1.1);
+  opacity: 1;
 }
 
 .dropzone-text {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: 0.375rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.375rem;
 }
 
 .dropzone-hint {
-    font-size: 0.8rem;
-    color: var(--text-light);
+  font-size: 0.8rem;
+  color: var(--text-light);
 }
 
 /* 已选文件信息 */
 .import-file-info {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    background: rgba(16, 185, 129, 0.1);
-    border: 1.5px solid var(--success);
-    border-radius: 0.5rem;
-    margin-bottom: 1rem;
-    animation: fileInfoIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: rgba(16, 185, 129, 0.1);
+  border: 1.5px solid var(--success);
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  animation: fileInfoIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @keyframes fileInfoIn {
-    from {
-        opacity: 0;
-        transform: translateY(-10px) scale(0.95);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.95);
+  }
 
-    to {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .file-info-icon {
-    font-size: 1.5rem;
-    flex-shrink: 0;
+  font-size: 1.5rem;
+  flex-shrink: 0;
 }
 
 .file-info-details {
-    flex: 1;
-    min-width: 0;
+  flex: 1;
+  min-width: 0;
 }
 
 .file-info-name {
-    font-weight: 600;
-    font-size: 0.875rem;
-    color: var(--text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .file-info-meta {
-    font-size: 0.75rem;
-    color: var(--text-light);
-    margin-top: 0.125rem;
+  font-size: 0.75rem;
+  color: var(--text-light);
+  margin-top: 0.125rem;
 }
 
 /* 暗色模式适配 */
 @media (prefers-color-scheme: dark) {
-    .import-dropzone {
-        background: rgba(8, 145, 178, 0.05);
-    }
+  .import-dropzone {
+    background: rgba(8, 145, 178, 0.05);
+  }
 
-    .import-dropzone:hover {
-        background: rgba(8, 145, 178, 0.1);
-    }
+  .import-dropzone:hover {
+    background: rgba(8, 145, 178, 0.1);
+  }
 
-    .import-dropzone.dragover {
-        background: rgba(8, 145, 178, 0.2);
-    }
+  .import-dropzone.dragover {
+    background: rgba(8, 145, 178, 0.2);
+  }
 
-    .import-file-info {
-        background: rgba(16, 185, 129, 0.15);
-    }
+  .import-file-info {
+    background: rgba(16, 185, 129, 0.15);
+  }
 }
 
 /* 导入方式切换标签 */
 .import-tabs {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .import-tab {
-    flex: 1;
-    padding: 0.5rem 1rem;
-    background: var(--bg);
-    border: 1.5px solid var(--border);
-    border-radius: 0.5rem;
-    color: var(--text-light);
-    font-size: 0.85rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    min-height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.375rem;
+  flex: 1;
+  padding: 0.5rem 1rem;
+  background: var(--bg);
+  border: 1.5px solid var(--border);
+  border-radius: 0.5rem;
+  color: var(--text-light);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
 }
 
 .import-tab:hover {
-    border-color: var(--primary);
-    color: var(--primary);
-    transform: translateY(-1px);
+  border-color: var(--primary);
+  color: var(--primary);
+  transform: translateY(-1px);
 }
 
 .import-tab.active {
-    background: var(--primary);
-    border-color: var(--primary);
-    color: white;
-    box-shadow: 0 2px 8px rgba(8, 145, 178, 0.3);
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+  box-shadow: 0 2px 8px rgba(8, 145, 178, 0.3);
 }
 
 /* 导入内容区域 */
 .import-tab-content {
-    animation: tabContentIn 0.25s ease;
+  animation: tabContentIn 0.25s ease;
 }
 
 @keyframes tabContentIn {
-    from {
-        opacity: 0;
-        transform: translateY(-5px);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
 
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* 手动输入JSON区域 */
 #importJsonInput {
-    font-family: 'Ubuntu Mono', 'Consolas', 'Monaco', monospace;
-    font-size: 0.8rem;
-    line-height: 1.5;
-    min-height: 150px;
-    max-height: 300px;
-    resize: vertical;
+  font-family: "Ubuntu Mono", "Consolas", "Monaco", monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  min-height: 150px;
+  max-height: 300px;
+  resize: vertical;
 }
 
 .import-json-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .import-json-status {
-    font-size: 0.8rem;
-    font-weight: 500;
+  font-size: 0.8rem;
+  font-weight: 500;
 }
 
 .import-json-status.success {
-    color: var(--success);
+  color: var(--success);
 }
 
 .import-json-status.error {
-    color: var(--danger);
+  color: var(--danger);
 }
 
 /* 移动端适配 */
 @media (max-width: 768px) {
-    .import-dropzone {
-        padding: 1.5rem 0.75rem;
-    }
+  .import-dropzone {
+    padding: 1.5rem 0.75rem;
+  }
 
-    .dropzone-icon {
-        font-size: 2.5rem;
-    }
+  .dropzone-icon {
+    font-size: 2.5rem;
+  }
 
-    .dropzone-text {
-        font-size: 0.9rem;
-    }
+  .dropzone-text {
+    font-size: 0.9rem;
+  }
 
-    .dropzone-hint {
-        font-size: 0.75rem;
-    }
+  .dropzone-hint {
+    font-size: 0.75rem;
+  }
 
-    .import-file-info {
-        padding: 0.5rem 0.75rem;
-    }
+  .import-file-info {
+    padding: 0.5rem 0.75rem;
+  }
 
-    .file-info-icon {
-        font-size: 1.25rem;
-    }
+  .file-info-icon {
+    font-size: 1.25rem;
+  }
 
-    .file-info-name {
-        font-size: 0.8rem;
-    }
+  .file-info-name {
+    font-size: 0.8rem;
+  }
 
-    .file-info-meta {
-        font-size: 0.7rem;
-    }
+  .file-info-meta {
+    font-size: 0.7rem;
+  }
 
-    .import-tabs {
-        gap: 0.375rem;
-    }
+  .import-tabs {
+    gap: 0.375rem;
+  }
 
-    .import-tab {
-        padding: 0.375rem 0.5rem;
-        font-size: 0.75rem;
-        min-height: 36px;
-    }
+  .import-tab {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.75rem;
+    min-height: 36px;
+  }
 
-    #importJsonInput {
-        font-size: 0.75rem;
-        min-height: 120px;
-    }
+  #importJsonInput {
+    font-size: 0.75rem;
+    min-height: 120px;
+  }
 
-    .import-json-actions {
-        flex-wrap: wrap;
-        gap: 0.5rem;
-    }
+  .import-json-actions {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
 
-    .import-json-status {
-        font-size: 0.75rem;
-    }
+  .import-json-status {
+    font-size: 0.75rem;
+  }
 }
 
 /* ==================== IP封禁管理样式 ==================== */
 
 .security-info {
-    background: rgba(8, 145, 178, 0.08);
-    padding: 0.75rem;
-    border-radius: 0.5rem;
-    margin-bottom: 1rem;
-    border: 1px solid rgba(8, 145, 178, 0.15);
+  background: rgba(8, 145, 178, 0.08);
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(8, 145, 178, 0.15);
 }
 
 .security-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
 .security-info p {
-    margin-bottom: 0.5rem;
-    font-size: 0.8rem;
-    color: var(--text);
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text);
 }
 
 .security-info ul {
-    margin: 0;
-    padding-left: 1.5rem;
-    font-size: 0.75rem;
-    color: var(--text-light);
+  margin: 0;
+  padding-left: 1.5rem;
+  font-size: 0.75rem;
+  color: var(--text-light);
 }
 
 .security-info li {
-    margin-bottom: 0.25rem;
+  margin-bottom: 0.25rem;
 }
 
 .blocked-ips-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
 }
 
 .blocked-ips-header h5 {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--text);
-    margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
 }
 
 .blocked-ips-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    max-height: 400px;
-    overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .blocked-ip-item {
-    background: rgba(255, 255, 255, 0.9);
-    border: 1.5px solid var(--border);
-    border-radius: 0.5rem;
-    padding: 0.75rem;
-    transition: all 0.2s;
-    animation: ipItemIn 0.3s ease;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1.5px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  transition: all 0.2s;
+  animation: ipItemIn 0.3s ease;
 }
 
 @keyframes ipItemIn {
-    from {
-        opacity: 0;
-        transform: translateY(-5px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (prefers-color-scheme: dark) {
-    .blocked-ip-item {
-        background: rgba(30, 41, 59, 0.9);
-    }
+  .blocked-ip-item {
+    background: rgba(30, 41, 59, 0.9);
+  }
 }
 
 .blocked-ip-item:hover {
-    border-color: var(--danger);
-    box-shadow: 0 2px 8px rgba(239, 68, 68, 0.15);
+  border-color: var(--danger);
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.15);
 }
 
 .blocked-ip-item.permanent {
-    border-left: 3px solid var(--danger);
+  border-left: 3px solid var(--danger);
 }
 
 .blocked-ip-item.temporary {
-    border-left: 3px solid var(--warning);
+  border-left: 3px solid var(--warning);
 }
 
 .blocked-ip-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
 }
 
 .blocked-ip-address {
-    font-family: 'Ubuntu Mono', 'Consolas', monospace;
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--text);
+  font-family: "Ubuntu Mono", "Consolas", monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
 }
 
 .blocked-ip-type {
-    font-size: 0.7rem;
-    padding: 0.2rem 0.5rem;
-    border-radius: 9999px;
-    font-weight: 600;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 9999px;
+  font-weight: 600;
 }
 
 .blocked-ip-type.permanent {
-    background: rgba(239, 68, 68, 0.15);
-    color: var(--danger);
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--danger);
 }
 
 .blocked-ip-type.temporary {
-    background: rgba(245, 158, 11, 0.15);
-    color: var(--warning);
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning);
 }
 
 .blocked-ip-info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    font-size: 0.75rem;
-    color: var(--text-light);
-    margin-bottom: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-light);
+  margin-bottom: 0.5rem;
 }
 
 .blocked-ip-actions {
-    display: flex;
-    gap: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
 }
 
 .empty-state-small {
-    text-align: center;
-    padding: 2rem 1rem;
-    color: var(--text-light);
-    font-size: 0.85rem;
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--text-light);
+  font-size: 0.85rem;
 }
 
 .whitelist-section {
-    margin-top: 1.5rem;
-    padding-top: 1rem;
-    border-top: 1.5px solid var(--border);
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1.5px solid var(--border);
 }
 
 .whitelist-section h5 {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.75rem;
 }
 
 .whitelist-input-group {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .whitelist-input-group input {
-    flex: 1;
-    min-height: 36px;
+  flex: 1;
+  min-height: 36px;
 }
 
 .whitelist-ips-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .whitelist-ip-tag {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.625rem;
-    background: rgba(16, 185, 129, 0.1);
-    border: 1px solid var(--success);
-    border-radius: 0.375rem;
-    font-size: 0.75rem;
-    font-family: 'Ubuntu Mono', 'Consolas', monospace;
-    color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid var(--success);
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-family: "Ubuntu Mono", "Consolas", monospace;
+  color: var(--text);
 }
 
 .whitelist-ip-tag button {
-    width: 18px;
-    height: 18px;
-    min-height: 18px;
-    min-width: 18px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    color: var(--danger);
-    cursor: pointer;
-    font-size: 0.7rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    transition: all 0.2s;
+  width: 18px;
+  height: 18px;
+  min-height: 18px;
+  min-width: 18px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--danger);
+  cursor: pointer;
+  font-size: 0.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s;
 }
 
 .whitelist-ip-tag button:hover {
-    background: var(--danger);
-    color: white;
-    transform: scale(1.1);
+  background: var(--danger);
+  color: white;
+  transform: scale(1.1);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -962,6 +962,19 @@ html.tab-logs .content {
   gap: 0.5rem;
 }
 
+/* Token Tier 标签 */
+.token-tier-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  background: var(--bg-light);
+  color: var(--text);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+
 .btn-icon {
   width: 24px;
   height: 24px;

--- a/public/style.css
+++ b/public/style.css
@@ -1457,8 +1457,90 @@ html.tab-logs .content {
     max-width: 480px;
 }
 
+.form-modal.oauth-modal .modal-content {
+    max-width: 720px;
+}
+
 .form-modal input {
     margin-bottom: 0.75rem;
+}
+
+.form-modal .oauth-generator-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.form-modal .oauth-generated-panel {
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid var(--border);
+    background: rgba(15, 23, 42, 0.03);
+}
+
+.form-modal .oauth-generated-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.form-modal .oauth-generated-summary {
+    font-size: 0.85rem;
+    color: var(--text-light);
+}
+
+.form-modal .oauth-generated-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.form-modal .oauth-generated-item {
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    background: rgba(255, 255, 255, 0.7);
+}
+
+.form-modal .oauth-generated-item-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.form-modal .oauth-generated-item-header span {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.form-modal .oauth-generated-item textarea {
+    margin-bottom: 0;
+    min-height: 72px;
+    font-size: 0.8rem;
+    line-height: 1.45;
+}
+
+.form-modal .oauth-generated-copy-btn {
+    flex: none;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+
+.form-modal .oauth-generated-empty {
+    font-size: 0.85rem;
+    line-height: 1.6;
+    color: var(--text-light);
 }
 
 .form-modal .form-row {
@@ -1485,6 +1567,16 @@ html.tab-logs .content {
 
 .form-modal .oauth-steps p:last-child {
     margin-bottom: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    .form-modal .oauth-generated-panel {
+        background: rgba(255, 255, 255, 0.04);
+    }
+
+    .form-modal .oauth-generated-item {
+        background: rgba(15, 23, 42, 0.45);
+    }
 }
 
 @keyframes fadeIn {

--- a/public/style.css
+++ b/public/style.css
@@ -730,6 +730,25 @@ html.tab-logs .content {
     }
 }
 
+.token-disable-reason {
+    padding: 0.35rem 0.6rem;
+    margin: 0 0.2rem 0.3rem;
+    background: rgba(220, 53, 69, 0.08);
+    border-radius: 6px;
+    font-size: 0.78rem;
+    color: var(--danger, #dc3545);
+    line-height: 1.4;
+    word-break: break-all;
+    border-left: 3px solid var(--danger, #dc3545);
+}
+
+@media (prefers-color-scheme: dark) {
+    .token-disable-reason {
+        background: rgba(220, 53, 69, 0.12);
+        color: #f08080;
+    }
+}
+
 .token-card.refresh-failed {
     border-color: var(--danger);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -771,9 +771,113 @@ html.tab-logs .content {
   font-size: 0.8rem;
 }
 
+/* 403 错误 URL 操作区域 */
+.error-403-actions {
+  margin: 0.3rem 0.2rem 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.error-403-url-item {
+  padding: 0.5rem 0.6rem;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 8px;
+  border-left: 3px solid var(--primary, #4f46e5);
+}
+
+.error-403-url-header {
+  margin-bottom: 0.25rem;
+}
+
+.error-403-badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.error-403-badge.badge-validation {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warning, #f59e0b);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+}
+
+.error-403-badge.badge-appeal {
+  background: rgba(220, 53, 69, 0.1);
+  color: var(--danger, #dc3545);
+  border: 1px solid rgba(220, 53, 69, 0.25);
+}
+
+.error-403-url-desc {
+  font-size: 0.78rem;
+  color: var(--text-light, #64748b);
+  margin-bottom: 0.35rem;
+  line-height: 1.3;
+}
+
+.error-403-url-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.error-403-url-input {
+  flex: 1;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.75rem;
+  font-family: "Consolas", "Monaco", monospace;
+  background: var(--bg, #f8fafc);
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 5px;
+  color: var(--primary, #4f46e5);
+  cursor: text;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.error-403-url-input:focus {
+  outline: none;
+  border-color: var(--primary, #4f46e5);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.15);
+}
+
+.error-403-copy-btn {
+  flex-shrink: 0;
+  min-width: 2rem;
+  padding: 0.3rem 0.4rem;
+  font-size: 0.8rem;
+}
+
 @media (prefers-color-scheme: dark) {
   .token-disable-reason {
     background: rgba(220, 53, 69, 0.12);
+    color: #f08080;
+  }
+
+  .error-403-url-item {
+    background: rgba(30, 41, 59, 0.6);
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .error-403-url-input {
+    background: rgba(15, 23, 42, 0.5);
+    border-color: rgba(255, 255, 255, 0.1);
+    color: #818cf8;
+  }
+
+  .error-403-badge.badge-validation {
+    background: rgba(245, 158, 11, 0.2);
+    color: #fbbf24;
+  }
+
+  .error-403-badge.badge-appeal {
+    background: rgba(220, 53, 69, 0.15);
     color: #f08080;
   }
 }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,40 +1,64 @@
-import { randomUUID } from 'crypto';
-import tokenManager from '../auth/token_manager.js';
-import config from '../config/config.js';
-import fingerprintRequester from '../requester.js';
-import { saveBase64Image } from '../utils/imageStorage.js';
-import logger from '../utils/logger.js';
-import memoryManager from '../utils/memoryManager.js';
-import { httpRequest, httpStreamRequest } from '../utils/httpClient.js';
-import { generateTrajectorybody } from '../utils/trajectory.js';
-import { buildRecordCodeAssistMetricsBody } from '../utils/recordCodeAssistMetrics.js';
-import { createTelemetryBatch, serializeTelemetryBatch } from "../utils/createTelemetry.js"
-import { createLog1, createLog2 } from "../utils/additionalLogs.js"
-import { buildClientRegister, buildFrontEnd, buildClientFeatrueHeaders, buildClientRegisterHeaders, buildFrontEndHeaders } from "../utils/unleash.js"
-import { MODEL_LIST_CACHE_TTL, QA_PAIRS } from '../constants/index.js';
-import { createApiError } from '../utils/errors.js';
-import { generateCheckpointBody } from '../utils/checkPoint.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import axios from "axios";
+import { randomUUID } from "crypto";
+import path from "path";
+import { fileURLToPath } from "url";
+import tokenManager from "../auth/token_manager.js";
+import config from "../config/config.js";
+import { MODEL_LIST_CACHE_TTL, QA_PAIRS } from "../constants/index.js";
+import fingerprintRequester from "../requester.js";
+import { createLog1, createLog2 } from "../utils/additionalLogs.js";
+import { generateCheckpointBody } from "../utils/checkPoint.js";
 import {
-  convertToToolCall,
-  registerStreamMemoryCleanup
-} from './stream_parser.js';
-import { setSignature, shouldCacheSignature, isImageModel } from '../utils/thoughtSignatureCache.js';
+  createTelemetryBatch,
+  serializeTelemetryBatch,
+} from "../utils/createTelemetry.js";
+import { createApiError } from "../utils/errors.js";
+import { httpRequest } from "../utils/httpClient.js";
+import { saveBase64Image } from "../utils/imageStorage.js";
+import logger from "../utils/logger.js";
+import memoryManager from "../utils/memoryManager.js";
+import { buildRecordCodeAssistMetricsBody } from "../utils/recordCodeAssistMetrics.js";
 import {
-  isDebugDumpEnabled,
+  isImageModel,
+  setSignature,
+  shouldCacheSignature,
+} from "../utils/thoughtSignatureCache.js";
+import { generateTrajectorybody } from "../utils/trajectory.js";
+import {
+  buildClientFeatrueHeaders,
+  buildClientRegister,
+  buildClientRegisterHeaders,
+  buildFrontEnd,
+  buildFrontEndHeaders,
+} from "../utils/unleash.js";
+import {
+  collectStreamChunk,
   createDumpId,
   createStreamCollector,
-  collectStreamChunk,
+  dumpFinalRawResponse,
   dumpFinalRequest,
   dumpStreamResponse,
-  dumpFinalRawResponse
-} from './debugDump.js';
-import { getUpstreamStatus, readUpstreamErrorBody, isCallerDoesNotHavePermission } from './upstreamError.js';
-import { createStreamLineProcessor } from './streamLineProcessor.js';
-import { runAxiosSseStream, runNativeSseStream, postJsonAndParse } from './geminiTransport.js';
-import { parseGeminiCandidateParts, toOpenAIUsage } from './geminiResponseParser.js';
-import axios from 'axios';
+  isDebugDumpEnabled,
+} from "./debugDump.js";
+import {
+  parseGeminiCandidateParts,
+  toOpenAIUsage,
+} from "./geminiResponseParser.js";
+import {
+  postJsonAndParse,
+  runAxiosSseStream,
+  runNativeSseStream,
+} from "./geminiTransport.js";
+import {
+  convertToToolCall,
+  registerStreamMemoryCleanup,
+} from "./stream_parser.js";
+import { createStreamLineProcessor } from "./streamLineProcessor.js";
+import {
+  getUpstreamStatus,
+  isCallerDoesNotHavePermission,
+  readUpstreamErrorBody,
+} from "./upstreamError.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -56,14 +80,26 @@ function startTokenTimer(token) {
     tokenTimers.get(key).lastUsed = now;
     return;
   }
-  sendClientRegister(token).catch(err => logger.warn('定时调用ClientRegister失败:', err.message));
-  sendClientFeature(token).catch(err => logger.warn('定时调用ClientFeature失败:', err.message));
-  sendFrontEnd(token).catch(err => logger.warn('定时调用FrontEnd失败:', err.message));
+  sendClientRegister(token).catch((err) =>
+    logger.warn("定时调用ClientRegister失败:", err.message),
+  );
+  sendClientFeature(token).catch((err) =>
+    logger.warn("定时调用ClientFeature失败:", err.message),
+  );
+  sendFrontEnd(token).catch((err) =>
+    logger.warn("定时调用FrontEnd失败:", err.message),
+  );
 
   const intervalId = setInterval(() => {
-    sendClientRegister(token).catch(err => logger.warn('定时调用ClientRegister失败:', err.message));
-    sendClientFeature(token).catch(err => logger.warn('定时调用ClientFeature失败:', err.message));
-    sendFrontEnd(token).catch(err => logger.warn('定时调用FrontEnd失败:', err.message));
+    sendClientRegister(token).catch((err) =>
+      logger.warn("定时调用ClientRegister失败:", err.message),
+    );
+    sendClientFeature(token).catch((err) =>
+      logger.warn("定时调用ClientFeature失败:", err.message),
+    );
+    sendFrontEnd(token).catch((err) =>
+      logger.warn("定时调用FrontEnd失败:", err.message),
+    );
   }, BACKEND_CALL_INTERVAL);
 
   tokenTimers.set(key, { lastUsed: now, intervalId });
@@ -88,25 +124,27 @@ let useAxios = false;
 // 初始化请求客户端
 if (config.useNativeAxios === true) {
   useAxios = true;
-  logger.info('使用原生 axios 请求');
+  logger.info("使用原生 axios 请求");
 } else {
   try {
     // 使用 src/bin/config.json 作为 TLS 指纹配置文件
     // 检测是否在 pkg 环境中
-    const isPkg = typeof process.pkg !== 'undefined';
+    const isPkg = typeof process.pkg !== "undefined";
 
     // 根据环境选择配置文件路径
     const configPath = isPkg
-      ? path.join(path.dirname(process.execPath), 'bin', 'tls_config.json')  // pkg 打包环境
-      : path.join(__dirname, '..', 'bin', 'tls_config.json');  // 开发环境
+      ? path.join(path.dirname(process.execPath), "bin", "tls_config.json") // pkg 打包环境
+      : path.join(__dirname, "..", "bin", "tls_config.json"); // 开发环境
     requester = fingerprintRequester.create({
       configPath,
       timeout: config.timeout ? Math.ceil(config.timeout / 1000) : 30,
-      proxy: config.proxy || null,
     });
-    logger.info('使用 FingerprintRequester 请求');
+    logger.info("使用 FingerprintRequester 请求");
   } catch (error) {
-    logger.warn('FingerprintRequester 初始化失败，自动降级使用 axios:', error.message);
+    logger.warn(
+      "FingerprintRequester 初始化失败，自动降级使用 axios:",
+      error.message,
+    );
     useAxios = true;
   }
 }
@@ -124,39 +162,38 @@ let modelListCacheTime = 0;
 // 默认模型列表（当 API 请求失败时使用）
 // 使用 Object.freeze 防止意外修改，并帮助 V8 优化
 const DEFAULT_MODELS = Object.freeze([
-  'claude-opus-4-6',
-  'claude-opus-4-6-thinking',
-  'claude-sonnet-4-6',
-  'claude-sonnet-4-6-thinking',
-  'gemini-3.1-pro-high',
-  'gemini-2.5-flash-lite',
-  'gemini-3.1-flash-image',
-  'gemini-3.1-flash-image-4K',
-  'gemini-3.1-flash-image-2K',
-  'gemini-2.5-flash-thinking',
-  'gemini-2.5-pro',
-  'gemini-2.5-flash',
-  'gemini-3.1-pro-low',
-  'chat_20706',
-  'rev19-uic3-1p',
-  'gpt-oss-120b-medium',
-  'chat_23310'
+  "claude-opus-4-6",
+  "claude-opus-4-6-thinking",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-6-thinking",
+  "gemini-3.1-pro-high",
+  "gemini-2.5-flash-lite",
+  "gemini-3.1-flash-image",
+  "gemini-3.1-flash-image-4K",
+  "gemini-3.1-flash-image-2K",
+  "gemini-2.5-flash-thinking",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "gemini-3.1-pro-low",
+  "chat_20706",
+  "rev19-uic3-1p",
+  "gpt-oss-120b-medium",
+  "chat_23310",
 ]);
 
 // 生成默认模型列表响应
 function getDefaultModelList() {
   const created = Math.floor(Date.now() / 1000);
   return {
-    object: 'list',
-    data: DEFAULT_MODELS.map(id => ({
+    object: "list",
+    data: DEFAULT_MODELS.map((id) => ({
       id,
-      object: 'model',
+      object: "model",
       created,
-      owned_by: 'google'
-    }))
+      owned_by: "google",
+    })),
   };
 }
-
 
 // 注册对象池与模型缓存的内存清理回调
 function registerMemoryCleanup() {
@@ -167,7 +204,7 @@ function registerMemoryCleanup() {
   memoryManager.registerCleanup(() => {
     const ttl = getModelCacheTTL();
     const now = Date.now();
-    if (modelListCache && (now - modelListCacheTime) > ttl) {
+    if (modelListCache && now - modelListCacheTime > ttl) {
       modelListCache = null;
       modelListCacheTime = 0;
     }
@@ -181,32 +218,38 @@ registerMemoryCleanup();
 
 function buildHeaders(token) {
   return {
-    'Host': config.api.host,
-    'User-Agent': config.api.userAgent,
-    'Authorization': `Bearer ${token.access_token}`,
-    'Content-Type': 'application/json',
-    'Accept-Encoding': 'gzip'
+    Host: config.api.host,
+    "User-Agent": config.api.userAgent,
+    Authorization: `Bearer ${token.access_token}`,
+    "Content-Type": "application/json",
+    "Accept-Encoding": "gzip",
   };
 }
 
-function buildRequesterConfig(headers, body = null, method = "POST") {
+function buildRequesterConfig(
+  headers,
+  body = null,
+  method = "POST",
+  proxy = null,
+) {
   const reqConfig = {
     method: method,
     headers,
     timeout_ms: config.timeout,
-    proxy: config.proxy
   };
+  if (proxy) {
+    reqConfig.proxy = proxy;
+  }
   if (body !== null) {
     // 判断是否为二进制数据
     if (Buffer.isBuffer(body) || body instanceof Uint8Array) {
-      reqConfig.body = body;  // 直接传递
+      reqConfig.body = body; // 直接传递
     } else {
-      reqConfig.body = JSON.stringify(body);  // JSON 对象才序列化
+      reqConfig.body = JSON.stringify(body); // JSON 对象才序列化
     }
   }
   return reqConfig;
 }
-
 
 // 统一错误处理
 async function handleApiError(error, token, dumpId = null) {
@@ -214,33 +257,46 @@ async function handleApiError(error, token, dumpId = null) {
   const errorBody = await readUpstreamErrorBody(error);
 
   if (dumpId) {
-    await dumpFinalRawResponse(dumpId, String(errorBody ?? ''));
+    await dumpFinalRawResponse(dumpId, String(errorBody ?? ""));
   }
 
   if (status === 403) {
     if (isCallerDoesNotHavePermission(errorBody)) {
-      throw createApiError(`超出模型最大上下文。错误详情: ${errorBody}`, status, errorBody);
+      throw createApiError(
+        `超出模型最大上下文。错误详情: ${errorBody}`,
+        status,
+        errorBody,
+      );
     }
     tokenManager.disableCurrentToken(token);
-    throw createApiError(`该账号没有使用权限，已自动禁用。错误详情: ${errorBody}`, status, errorBody);
+    throw createApiError(
+      `该账号没有使用权限，已自动禁用。错误详情: ${errorBody}`,
+      status,
+      errorBody,
+    );
   }
 
-  throw createApiError(`API请求失败 (${status}): ${errorBody}`, status, errorBody);
+  throw createApiError(
+    `API请求失败 (${status}): ${errorBody}`,
+    status,
+    errorBody,
+  );
 }
-
 
 // ==================== 导出函数 ====================
 
 export async function generateAssistantResponse(requestBody, token, callback) {
   startTokenTimer(token);
-  const trajectoryId = requestBody.requestId.split('/')[2];
+  const trajectoryId = requestBody.requestId.split("/")[2];
   const conversationId = randomUUID();
   const messageId = randomUUID();
   const modelName = requestBody.model;
   const headers = buildHeaders(token);
-  const dumpId = isDebugDumpEnabled() ? createDumpId('stream') : null;
+  const dumpId = isDebugDumpEnabled() ? createDumpId("stream") : null;
   const streamCollector = dumpId ? createStreamCollector() : null;
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(requestBody)));
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(requestBody)),
+  );
   let num = Math.floor(Math.random() * QA_PAIRS.length);
   if (dumpId) {
     await dumpFinalRequest(dumpId, requestBody);
@@ -251,12 +307,12 @@ export async function generateAssistantResponse(requestBody, token, callback) {
     toolCalls: [],
     reasoningSignature: null,
     sessionId: requestBody.request?.sessionId,
-    model: requestBody.model
+    model: requestBody.model,
   };
   const processor = createStreamLineProcessor({
     state,
     onEvent: callback,
-    onRawChunk: (chunk) => collectStreamChunk(streamCollector, chunk)
+    onRawChunk: (chunk) => collectStreamChunk(streamCollector, chunk),
   });
 
   try {
@@ -266,14 +322,23 @@ export async function generateAssistantResponse(requestBody, token, callback) {
         headers,
         data: requestBody,
         timeout: config.timeout,
-        processor
+        proxy: config.proxy || null,
+        processor,
       });
     } else {
-      const streamResponse = requester.antigravity_fetchStream(config.api.url, buildRequesterConfig(headers, requestBody));
+      const streamResponse = requester.antigravity_fetchStream(
+        config.api.url,
+        buildRequesterConfig(
+          headers,
+          requestBody,
+          "POST",
+          config.proxy || null,
+        ),
+      );
       await runNativeSseStream({
         streamResponse,
         processor,
-        onErrorChunk: (chunk) => collectStreamChunk(streamCollector, chunk)
+        onErrorChunk: (chunk) => collectStreamChunk(streamCollector, chunk),
       });
     }
 
@@ -281,12 +346,27 @@ export async function generateAssistantResponse(requestBody, token, callback) {
     if (dumpId) {
       await dumpStreamResponse(dumpId, streamCollector);
     }
-    sendRecordCodeAssistMetrics(token, trajectoryId).catch(err => logger.warn('发送RecordCodeAssistMetrics失败:', err.message));
-    sendRecordTrajectoryAnalytics(token, num, trajectoryId,messageId,conversationId, modelName).catch(err => logger.warn('发送轨迹分析失败:', err.message));
-    sendLog(token,num,trajectoryId,conversationId,messageId).catch(err => logger.warn('发送log失败:', err.message));
-    sendCheckPoint(token).catch(err => logger.warn('发送checkPoint失败:', err.message));;
+    sendRecordCodeAssistMetrics(token, trajectoryId).catch((err) =>
+      logger.warn("发送RecordCodeAssistMetrics失败:", err.message),
+    );
+    sendRecordTrajectoryAnalytics(
+      token,
+      num,
+      trajectoryId,
+      messageId,
+      conversationId,
+      modelName,
+    ).catch((err) => logger.warn("发送轨迹分析失败:", err.message));
+    sendLog(token, num, trajectoryId, conversationId, messageId).catch((err) =>
+      logger.warn("发送log失败:", err.message),
+    );
+    sendCheckPoint(token).catch((err) =>
+      logger.warn("发送checkPoint失败:", err.message),
+    );
   } catch (error) {
-    try { processor.close(); } catch { }
+    try {
+      processor.close();
+    } catch {}
     await handleApiError(error, token, dumpId);
   }
 }
@@ -296,14 +376,17 @@ async function fetchRawModels(headers, token) {
   try {
     if (useAxios) {
       const response = await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: config.api.modelsUrl,
         headers,
-        data: {}
+        data: {},
       });
       return response.data;
     }
-    const response = await requester.antigravity_fetch(config.api.modelsUrl, buildRequesterConfig(headers, {}));
+    const response = await requester.antigravity_fetch(
+      config.api.modelsUrl,
+      buildRequesterConfig(headers, {}),
+    );
     if (response.status !== 200) {
       const errorBody = await response.text();
       throw { status: response.status, message: errorBody };
@@ -318,14 +401,14 @@ export async function getAvailableModels() {
   // 检查缓存是否有效（动态 TTL）
   const now = Date.now();
   const ttl = getModelCacheTTL();
-  if (modelListCache && (now - modelListCacheTime) < ttl) {
+  if (modelListCache && now - modelListCacheTime < ttl) {
     return modelListCache;
   }
 
   const token = await tokenManager.getToken();
   if (!token) {
     // 没有 token 时返回默认模型列表
-    logger.warn('没有可用的 token，返回默认模型列表');
+    logger.warn("没有可用的 token，返回默认模型列表");
     return getDefaultModelList();
   }
 
@@ -337,36 +420,38 @@ export async function getAvailableModels() {
   }
 
   const created = Math.floor(Date.now() / 1000);
-  const modelList = Object.keys(data.models || {}).map(id => ({
+  const modelList = Object.keys(data.models || {}).map((id) => ({
     id,
-    object: 'model',
+    object: "model",
     created,
-    owned_by: 'google'
+    owned_by: "google",
   }));
 
   // 添加默认模型（如果 API 返回的列表中没有）
-  const existingIds = new Set(modelList.map(m => m.id));
+  const existingIds = new Set(modelList.map((m) => m.id));
   for (const defaultModel of DEFAULT_MODELS) {
     if (!existingIds.has(defaultModel)) {
       modelList.push({
         id: defaultModel,
-        object: 'model',
+        object: "model",
         created,
-        owned_by: 'google'
+        owned_by: "google",
       });
     }
   }
 
   const result = {
-    object: 'list',
-    data: modelList
+    object: "list",
+    data: modelList,
   };
 
   // 更新缓存
   modelListCache = result;
   modelListCacheTime = now;
   const currentTTL = getModelCacheTTL();
-  logger.info(`模型列表已缓存 (有效期: ${currentTTL / 1000}秒, 模型数量: ${modelList.length})`);
+  logger.info(
+    `模型列表已缓存 (有效期: ${currentTTL / 1000}秒, 模型数量: ${modelList.length})`,
+  );
 
   return result;
 }
@@ -375,7 +460,7 @@ export async function getAvailableModels() {
 export function clearModelListCache() {
   modelListCache = null;
   modelListCacheTime = 0;
-  logger.info('模型列表缓存已清除');
+  logger.info("模型列表缓存已清除");
 }
 
 export async function getModelsWithQuotas(token) {
@@ -388,7 +473,7 @@ export async function getModelsWithQuotas(token) {
     if (modelData.quotaInfo) {
       quotas[modelId] = {
         r: modelData.quotaInfo.remainingFraction,
-        t: modelData.quotaInfo.resetTime
+        t: modelData.quotaInfo.resetTime,
       };
     }
   });
@@ -398,14 +483,16 @@ export async function getModelsWithQuotas(token) {
 
 export async function generateAssistantResponseNoStream(requestBody, token) {
   startTokenTimer(token);
-  const trajectoryId = requestBody.requestId.split('/')[2];
+  const trajectoryId = requestBody.requestId.split("/")[2];
   const conversationId = randomUUID();
   const messageId = randomUUID();
   const modelName = requestBody.model;
   const headers = buildHeaders(token);
-  const dumpId = isDebugDumpEnabled() ? createDumpId('no_stream') : null;
+  const dumpId = isDebugDumpEnabled() ? createDumpId("no_stream") : null;
   let num = Math.floor(Math.random() * QA_PAIRS.length);
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(requestBody)));
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(requestBody)),
+  );
 
   if (dumpId) await dumpFinalRequest(dumpId, requestBody);
   let data;
@@ -417,14 +504,31 @@ export async function generateAssistantResponseNoStream(requestBody, token) {
       headers,
       body: requestBody,
       timeout: config.timeout,
-      requesterConfig: buildRequesterConfig(headers, requestBody),
+      proxy: config.proxy || null,
+      requesterConfig: buildRequesterConfig(
+        headers,
+        requestBody,
+        "POST",
+        config.proxy || null,
+      ),
       dumpId,
       dumpFinalRawResponse,
-      rawFormat: 'json'
+      rawFormat: "json",
     });
-    sendRecordCodeAssistMetrics(token, trajectoryId).catch(err => logger.warn('发送RecordCodeAssistMetrics失败:', err.message));
-    sendRecordTrajectoryAnalytics(token, num, trajectoryId,messageId,conversationId, modelName).catch(err => logger.warn('发送轨迹分析失败:', err.message));
-    sendLog(token,num,trajectoryId,conversationId,messageId).catch(err => logger.warn('发送log失败:', err.message));
+    sendRecordCodeAssistMetrics(token, trajectoryId).catch((err) =>
+      logger.warn("发送RecordCodeAssistMetrics失败:", err.message),
+    );
+    sendRecordTrajectoryAnalytics(
+      token,
+      num,
+      trajectoryId,
+      messageId,
+      conversationId,
+      modelName,
+    ).catch((err) => logger.warn("发送轨迹分析失败:", err.message));
+    sendLog(token, num, trajectoryId, conversationId, messageId).catch((err) =>
+      logger.warn("发送log失败:", err.message),
+    );
   } catch (error) {
     await handleApiError(error, token, dumpId);
   }
@@ -435,7 +539,7 @@ export async function generateAssistantResponseNoStream(requestBody, token) {
     sessionId: requestBody.request?.sessionId,
     model: requestBody.model,
     convertToToolCall,
-    saveBase64Image
+    saveBase64Image,
   });
 
   const usageData = toOpenAIUsage(data.response?.usageMetadata);
@@ -447,7 +551,11 @@ export async function generateAssistantResponseNoStream(requestBody, token) {
   const isImage = isImageModel(model);
 
   // 判断是否应该缓存签名
-  if (sessionId && model && shouldCacheSignature({ hasTools, isImageModel: isImage })) {
+  if (
+    sessionId &&
+    model &&
+    shouldCacheSignature({ hasTools, isImageModel: isImage })
+  ) {
     // 获取最终使用的签名（优先使用工具签名，回退到思维签名）
     let finalSignature = parsed.reasoningSignature;
 
@@ -463,29 +571,46 @@ export async function generateAssistantResponseNoStream(requestBody, token) {
     }
 
     if (finalSignature) {
-      const cachedContent = parsed.reasoningContent || ' ';
-      setSignature(sessionId, model, finalSignature, cachedContent, { hasTools, isImageModel: isImage });
+      const cachedContent = parsed.reasoningContent || " ";
+      setSignature(sessionId, model, finalSignature, cachedContent, {
+        hasTools,
+        isImageModel: isImage,
+      });
     }
   }
 
   // 生图模型：转换为 markdown 格式
   if (parsed.imageUrls.length > 0) {
-    let markdown = parsed.content ? parsed.content + '\n\n' : '';
-    markdown += parsed.imageUrls.map(url => `![image](${url})`).join('\n\n');
-    return { content: markdown, reasoningContent: parsed.reasoningContent, reasoningSignature: parsed.reasoningSignature, toolCalls: parsed.toolCalls, usage: usageData };
+    let markdown = parsed.content ? parsed.content + "\n\n" : "";
+    markdown += parsed.imageUrls.map((url) => `![image](${url})`).join("\n\n");
+    return {
+      content: markdown,
+      reasoningContent: parsed.reasoningContent,
+      reasoningSignature: parsed.reasoningSignature,
+      toolCalls: parsed.toolCalls,
+      usage: usageData,
+    };
   }
 
-  return { content: parsed.content, reasoningContent: parsed.reasoningContent, reasoningSignature: parsed.reasoningSignature, toolCalls: parsed.toolCalls, usage: usageData };
+  return {
+    content: parsed.content,
+    reasoningContent: parsed.reasoningContent,
+    reasoningSignature: parsed.reasoningSignature,
+    toolCalls: parsed.toolCalls,
+    usage: usageData,
+  };
 }
 
 export async function generateImageForSD(requestBody, token) {
   startTokenTimer(token);
-  const trajectoryId = requestBody.requestId.split('/')[2];
+  const trajectoryId = requestBody.requestId.split("/")[2];
   const conversationId = randomUUID();
   const messageId = randomUUID();
   const modelName = requestBody.model;
   const headers = buildHeaders(token);
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(requestBody),'utf-8'));
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(requestBody), "utf-8"),
+  );
   let data;
   let num = Math.floor(Math.random() * QA_PAIRS.length);
 
@@ -493,14 +618,19 @@ export async function generateImageForSD(requestBody, token) {
 
   try {
     if (useAxios) {
-      data = (await httpRequest({
-        method: 'POST',
-        url: config.api.noStreamUrl,
-        headers,
-        data: requestBody
-      })).data;
+      data = (
+        await httpRequest({
+          method: "POST",
+          url: config.api.noStreamUrl,
+          headers,
+          data: requestBody,
+        })
+      ).data;
     } else {
-      const response = await requester.antigravity_fetch(config.api.noStreamUrl, buildRequesterConfig(headers, requestBody));
+      const response = await requester.antigravity_fetch(
+        config.api.noStreamUrl,
+        buildRequesterConfig(headers, requestBody),
+      );
       if (response.status !== 200) {
         const errorBody = await response.text();
         throw { status: response.status, message: errorBody };
@@ -510,30 +640,62 @@ export async function generateImageForSD(requestBody, token) {
   } catch (error) {
     await handleApiError(error, token);
   }
-  sendRecordCodeAssistMetrics(token, trajectoryId).catch(err => logger.warn('发送RecordCodeAssistMetrics失败:', err.message));
-  sendRecordTrajectoryAnalytics(token, num, trajectoryId,messageId,conversationId, modelName).catch(err => logger.warn('发送轨迹分析失败:', err.message));
-  sendLog(token,num,trajectoryId,conversationId,messageId).catch(err => logger.warn('发送log失败:', err.message));
+  sendRecordCodeAssistMetrics(token, trajectoryId).catch((err) =>
+    logger.warn("发送RecordCodeAssistMetrics失败:", err.message),
+  );
+  sendRecordTrajectoryAnalytics(
+    token,
+    num,
+    trajectoryId,
+    messageId,
+    conversationId,
+    modelName,
+  ).catch((err) => logger.warn("发送轨迹分析失败:", err.message));
+  sendLog(token, num, trajectoryId, conversationId, messageId).catch((err) =>
+    logger.warn("发送log失败:", err.message),
+  );
 
   const parts = data.response?.candidates?.[0]?.content?.parts || [];
-  const images = parts.filter(p => p.inlineData).map(p => p.inlineData.data);
+  const images = parts
+    .filter((p) => p.inlineData)
+    .map((p) => p.inlineData.data);
 
   return images;
 }
 
-export async function sendRecordTrajectoryAnalytics(token, num, trajectoryId,executionId,cascadeId, modelName = "claude-opus-4-6-thinking") {
-  const trajectorybody = generateTrajectorybody(num, trajectoryId,executionId,cascadeId, modelName, token);
+export async function sendRecordTrajectoryAnalytics(
+  token,
+  num,
+  trajectoryId,
+  executionId,
+  cascadeId,
+  modelName = "claude-opus-4-6-thinking",
+) {
+  const trajectorybody = generateTrajectorybody(
+    num,
+    trajectoryId,
+    executionId,
+    cascadeId,
+    modelName,
+    token,
+  );
   const headers = buildHeaders(token);
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(trajectorybody)));
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(trajectorybody)),
+  );
   try {
     if (useAxios) {
       await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: config.api.recordTrajectory,
         headers,
-        data: trajectorybody
+        data: trajectorybody,
       });
     } else {
-      const response = await requester.antigravity_fetch(config.api.recordTrajectory, buildRequesterConfig(headers, trajectorybody));
+      const response = await requester.antigravity_fetch(
+        config.api.recordTrajectory,
+        buildRequesterConfig(headers, trajectorybody),
+      );
       if (response.status !== 200) {
         const errorBody = await response.text();
         throw new Error(`轨迹分析请求失败 (${response.status}): ${errorBody}`);
@@ -543,22 +705,28 @@ export async function sendRecordTrajectoryAnalytics(token, num, trajectoryId,exe
     throw error;
   }
 }
-export async function sendLog(token, num, trajectoryId, conversationId,messageId) {
+export async function sendLog(
+  token,
+  num,
+  trajectoryId,
+  conversationId,
+  messageId,
+) {
   const sessionId = trajectoryId;
   //const conversationId = randomUUID();
-  
+
   const logs = [
     createLog2(conversationId, token, sessionId),
-    createTelemetryBatch(num, sessionId,conversationId,messageId,token.sub),
-    createLog1(conversationId, token, sessionId)
+    createTelemetryBatch(num, sessionId, conversationId, messageId, token.sub),
+    createLog1(conversationId, token, sessionId),
   ];
-  
+
   const headers = buildHeaders(token);
   headers["Host"] = "play.googleapis.com";
   headers["User-Agent"] = "Go-http-client/1.1";
   headers["Content-Type"] = "application/octet-stream";
   headers["Accept-Encoding"] = "gzip";
-  
+
   try {
     for (const log of logs) {
       const serializeData = serializeTelemetryBatch(log);
@@ -567,12 +735,12 @@ export async function sendLog(token, num, trajectoryId, conversationId,messageId
       }
       const serializeLogBody = serializeData.data;
       headers["Content-Length"] = String(serializeLogBody.length);
-      
+
       await axios({
-        method: 'POST',
+        method: "POST",
         url: "https://play.googleapis.com/log",
         headers,
-        data: serializeLogBody
+        data: serializeLogBody,
       });
     }
   } catch (error) {
@@ -583,20 +751,27 @@ export async function sendLog(token, num, trajectoryId, conversationId,messageId
 export async function sendRecordCodeAssistMetrics(token, trajectoryId) {
   const requestBody = buildRecordCodeAssistMetricsBody(token, trajectoryId);
   const headers = buildHeaders(token);
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(requestBody),'utf-8'));
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(requestBody), "utf-8"),
+  );
   try {
     if (useAxios) {
       await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: config.api.recordCodeAssistMetrics,
         headers,
-        data: requestBody
+        data: requestBody,
       });
     } else {
-      const response = await requester.antigravity_fetch(config.api.recordCodeAssistMetrics, buildRequesterConfig(headers, requestBody));
+      const response = await requester.antigravity_fetch(
+        config.api.recordCodeAssistMetrics,
+        buildRequesterConfig(headers, requestBody),
+      );
       if (response.status !== 200) {
         const errorBody = await response.text();
-        throw new Error(`RecordCodeAssistMetrics请求失败 (${response.status}): ${errorBody}`);
+        throw new Error(
+          `RecordCodeAssistMetrics请求失败 (${response.status}): ${errorBody}`,
+        );
       }
     }
   } catch (error) {
@@ -607,20 +782,27 @@ export async function sendRecordCodeAssistMetrics(token, trajectoryId) {
 export async function sendClientRegister(token) {
   const requestBody = buildClientRegister(token);
   const headers = buildClientRegisterHeaders(token);
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(requestBody),'utf-8'));
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(requestBody), "utf-8"),
+  );
   try {
     if (useAxios) {
       await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: config.api.unleash.register,
         headers,
-        data: requestBody
+        data: requestBody,
       });
     } else {
-      const response = await requester.antigravity_fetch(config.api.unleash.register, buildRequesterConfig(headers, requestBody));
+      const response = await requester.antigravity_fetch(
+        config.api.unleash.register,
+        buildRequesterConfig(headers, requestBody),
+      );
       if (response.status !== 200 && response.status !== 202) {
         const errorBody = await response.text();
-        throw new Error(`ClientRegister请求失败 (${response.status}): ${errorBody}`);
+        throw new Error(
+          `ClientRegister请求失败 (${response.status}): ${errorBody}`,
+        );
       }
     }
   } catch (error) {
@@ -634,15 +816,20 @@ export async function sendClientFeature(token) {
   try {
     if (useAxios) {
       await httpRequest({
-        method: 'GET',
+        method: "GET",
         url: config.api.unleash.features,
-        headers
+        headers,
       });
     } else {
-      const response = await requester.antigravity_fetch(config.api.unleash.features, buildRequesterConfig(headers, null, "GET"));
+      const response = await requester.antigravity_fetch(
+        config.api.unleash.features,
+        buildRequesterConfig(headers, null, "GET"),
+      );
       if (response.status !== 200 && response.status !== 202) {
         const errorBody = await response.text();
-        throw new Error(`ClientFeature请求失败 (${response.status}): ${errorBody}`);
+        throw new Error(
+          `ClientFeature请求失败 (${response.status}): ${errorBody}`,
+        );
       }
     }
   } catch (error) {
@@ -653,17 +840,22 @@ export async function sendClientFeature(token) {
 export async function sendFrontEnd(token) {
   const requestBody = buildFrontEnd(token);
   const headers = buildFrontEndHeaders(token);
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(requestBody),'utf-8'));
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(requestBody), "utf-8"),
+  );
   try {
     if (useAxios) {
       await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: config.api.unleash.frontend,
         headers,
-        data: requestBody
+        data: requestBody,
       });
     } else {
-      const response = await requester.antigravity_fetch(config.api.unleash.frontend, buildRequesterConfig(headers, requestBody));
+      const response = await requester.antigravity_fetch(
+        config.api.unleash.frontend,
+        buildRequesterConfig(headers, requestBody),
+      );
       if (response.status !== 200 && response.status !== 202) {
         const errorBody = await response.text();
         throw new Error(`FrontEnd请求失败 (${response.status}): ${errorBody}`);
@@ -677,25 +869,32 @@ export async function sendFrontEnd(token) {
 export async function sendCheckPoint(token) {
   const requestBody = generateCheckpointBody(token);
   const headers = buildHeaders(token);
-  headers["Content-Length"] = String(Buffer.byteLength(JSON.stringify(requestBody),'utf-8'));
-  if (checkPointList.has(token.sessionId)){
+  headers["Content-Length"] = String(
+    Buffer.byteLength(JSON.stringify(requestBody), "utf-8"),
+  );
+  if (checkPointList.has(token.sessionId)) {
     return;
-  }else{
+  } else {
     checkPointList.add(token.sessionId);
   }
   try {
     if (useAxios) {
       await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: config.api.url,
         headers,
-        data: requestBody
+        data: requestBody,
       });
     } else {
-      const response = await requester.antigravity_fetch(config.api.url, buildRequesterConfig(headers, requestBody));
+      const response = await requester.antigravity_fetch(
+        config.api.url,
+        buildRequesterConfig(headers, requestBody),
+      );
       if (response.status !== 200 && response.status !== 202) {
         const errorBody = await response.text();
-        throw new Error(`CheckPoint请求失败 (${response.status}): ${errorBody}`);
+        throw new Error(
+          `CheckPoint请求失败 (${response.status}): ${errorBody}`,
+        );
       }
     }
   } catch (error) {

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -232,13 +232,15 @@ function buildRequesterConfig(
   method = "POST",
   proxy = null,
 ) {
+  const effectiveProxy =
+    proxy || (config.proxy?.allRequests ? config.proxy : null);
   const reqConfig = {
     method: method,
     headers,
     timeout_ms: config.timeout,
   };
-  if (proxy) {
-    reqConfig.proxy = proxy;
+  if (effectiveProxy) {
+    reqConfig.proxy = effectiveProxy;
   }
   if (body !== null) {
     // 判断是否为二进制数据

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -270,7 +270,7 @@ async function handleApiError(error, token, dumpId = null) {
         errorBody,
       );
     }
-    tokenManager.disableCurrentToken(token);
+    tokenManager.disableCurrentToken(token, `API请求返回403: ${errorBody}`);
     throw createApiError(
       `该账号没有使用权限，已自动禁用。错误详情: ${errorBody}`,
       status,

--- a/src/api/geminiTransport.js
+++ b/src/api/geminiTransport.js
@@ -1,29 +1,41 @@
-import { httpRequest, httpStreamRequest } from '../utils/httpClient.js';
+import { httpRequest, httpStreamRequest } from "../utils/httpClient.js";
 
-export async function runAxiosSseStream({ url, headers, data, timeout, processor } = {}) {
+export async function runAxiosSseStream({
+  url,
+  headers,
+  data,
+  timeout,
+  proxy = null,
+  processor,
+} = {}) {
   const response = await httpStreamRequest({
-    method: 'POST',
+    method: "POST",
     url,
     headers,
     data,
-    timeout
+    timeout,
+    proxy,
   });
 
-  response.data.on('data', (chunk) => {
+  response.data.on("data", (chunk) => {
     processor.processChunk(chunk);
   });
 
   await new Promise((resolve, reject) => {
-    response.data.on('end', () => {
+    response.data.on("end", () => {
       processor.close();
       resolve();
     });
-    response.data.on('error', reject);
+    response.data.on("error", reject);
   });
 }
 
-export async function runNativeSseStream({ streamResponse, processor, onErrorChunk } = {}) {
-  let errorBody = '';
+export async function runNativeSseStream({
+  streamResponse,
+  processor,
+  onErrorChunk,
+} = {}) {
+  let errorBody = "";
   let statusCode = null;
 
   await new Promise((resolve, reject) => {
@@ -58,43 +70,51 @@ export async function postJsonAndParse({
   headers,
   body,
   timeout,
+  proxy = null,
   requesterConfig,
   dumpId,
   dumpFinalRawResponse,
-  rawFormat = 'json'
+  rawFormat = "json",
 } = {}) {
   if (useAxios) {
     if (dumpId) {
       const resp = await httpRequest({
-        method: 'POST',
+        method: "POST",
         url,
         headers,
         data: body,
         timeout,
-        responseType: 'text'
+        proxy,
+        responseType: "text",
       });
-      const rawText = typeof resp.data === 'string' ? resp.data : JSON.stringify(resp.data, null, 2);
+      const rawText =
+        typeof resp.data === "string"
+          ? resp.data
+          : JSON.stringify(resp.data, null, 2);
       await dumpFinalRawResponse(dumpId, rawText, rawFormat);
       return JSON.parse(rawText);
     }
 
-    return (await httpRequest({
-      method: 'POST',
-      url,
-      headers,
-      data: body,
-      timeout
-    })).data;
+    return (
+      await httpRequest({
+        method: "POST",
+        url,
+        headers,
+        data: body,
+        timeout,
+        proxy,
+      })
+    ).data;
   }
 
   if (!requester) {
-    throw new Error('native requester is required when useAxios=false');
+    throw new Error("native requester is required when useAxios=false");
   }
 
   const response = await requester.antigravity_fetch(url, requesterConfig);
   if (response.status !== 200) {
     const errorBody = await response.text();
-    if (dumpId) await dumpFinalRawResponse(dumpId, errorBody, 'txt');
+    if (dumpId) await dumpFinalRawResponse(dumpId, errorBody, "txt");
     throw { status: response.status, message: errorBody };
   }
 

--- a/src/api/geminicli_client.js
+++ b/src/api/geminicli_client.js
@@ -1,24 +1,28 @@
-import geminicliTokenManager from '../auth/geminicli_token_manager.js';
-import config from '../config/config.js';
-import logger from '../utils/logger.js';
-import { createApiError } from '../utils/errors.js';
+import geminicliTokenManager from "../auth/geminicli_token_manager.js";
+import config from "../config/config.js";
+import { createApiError } from "../utils/errors.js";
+import { saveBase64Image } from "../utils/imageStorage.js";
 import {
-  convertToToolCall
-} from './stream_parser.js';
-import { saveBase64Image } from '../utils/imageStorage.js';
-import {
-  isDebugDumpEnabled,
+  collectStreamChunk,
   createDumpId,
   createStreamCollector,
-  collectStreamChunk,
+  dumpFinalRawResponse,
   dumpFinalRequest,
   dumpStreamResponse,
-  dumpFinalRawResponse
-} from './debugDump.js';
-import { getUpstreamStatus, readUpstreamErrorBody, isCallerDoesNotHavePermission } from './upstreamError.js';
-import { createStreamLineProcessor } from './streamLineProcessor.js';
-import { runAxiosSseStream, postJsonAndParse } from './geminiTransport.js';
-import { parseGeminiCandidateParts, toOpenAIUsage } from './geminiResponseParser.js';
+  isDebugDumpEnabled,
+} from "./debugDump.js";
+import {
+  parseGeminiCandidateParts,
+  toOpenAIUsage,
+} from "./geminiResponseParser.js";
+import { postJsonAndParse, runAxiosSseStream } from "./geminiTransport.js";
+import { convertToToolCall } from "./stream_parser.js";
+import { createStreamLineProcessor } from "./streamLineProcessor.js";
+import {
+  getUpstreamStatus,
+  isCallerDoesNotHavePermission,
+  readUpstreamErrorBody,
+} from "./upstreamError.js";
 
 // ==================== 调试：复用 client.js 的调试日志实现 ====================
 
@@ -42,11 +46,12 @@ import { parseGeminiCandidateParts, toOpenAIUsage } from './geminiResponseParser
 function buildHeaders(token) {
   const geminicliConfig = config.geminicli?.api || {};
   return {
-    'Host': geminicliConfig.host || 'cloudcode-pa.googleapis.com',
-    'User-Agent': geminicliConfig.userAgent || 'GeminiCLI/0.1.5 (Windows; AMD64)',
-    'Authorization': `Bearer ${token.access_token}`,
-    'Content-Type': 'application/json',
-    'Accept-Encoding': 'gzip'
+    Host: geminicliConfig.host || "cloudcode-pa.googleapis.com",
+    "User-Agent":
+      geminicliConfig.userAgent || "GeminiCLI/0.1.5 (Windows; AMD64)",
+    Authorization: `Bearer ${token.access_token}`,
+    "Content-Type": "application/json",
+    "Accept-Encoding": "gzip",
   };
 }
 
@@ -59,8 +64,10 @@ function buildApiUrl(stream = true) {
   const geminicliConfig = config.geminicli?.api || {};
   // 使用 v1internal 端点，模型名称在请求体中指定
   return stream
-    ? (geminicliConfig.url || 'https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse')
-    : (geminicliConfig.noStreamUrl || 'https://cloudcode-pa.googleapis.com/v1internal:generateContent');
+    ? geminicliConfig.url ||
+        "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"
+    : geminicliConfig.noStreamUrl ||
+        "https://cloudcode-pa.googleapis.com/v1internal:generateContent";
 }
 
 /**
@@ -77,7 +84,7 @@ function buildRequestBody(requestBody, model, projectId) {
   return {
     model: model,
     project: projectId,
-    request: requestBody
+    request: requestBody,
   };
 }
 
@@ -89,20 +96,36 @@ function buildRequestBody(requestBody, model, projectId) {
 async function handleApiError(error, token) {
   const status = getUpstreamStatus(error);
   const errorBody = await readUpstreamErrorBody(error);
-  
+
   if (status === 403) {
     if (isCallerDoesNotHavePermission(errorBody)) {
-      throw createApiError(`超出模型最大上下文。错误详情: ${errorBody}`, status, errorBody);
+      throw createApiError(
+        `超出模型最大上下文。错误详情: ${errorBody}`,
+        status,
+        errorBody,
+      );
     }
     geminicliTokenManager.disableCurrentToken(token);
-    throw createApiError(`该账号没有使用权限，已自动禁用。错误详情: ${errorBody}`, status, errorBody);
+    throw createApiError(
+      `该账号没有使用权限，已自动禁用。错误详情: ${errorBody}`,
+      status,
+      errorBody,
+    );
   }
-  
+
   if (status === 429) {
-    throw createApiError(`请求频率过高，请稍后重试。错误详情: ${errorBody}`, status, errorBody);
+    throw createApiError(
+      `请求频率过高，请稍后重试。错误详情: ${errorBody}`,
+      status,
+      errorBody,
+    );
   }
-  
-  throw createApiError(`API请求失败 (${status}): ${errorBody}`, status, errorBody);
+
+  throw createApiError(
+    `API请求失败 (${status}): ${errorBody}`,
+    status,
+    errorBody,
+  );
 }
 
 // ==================== 导出函数 ====================
@@ -114,50 +137,61 @@ async function handleApiError(error, token) {
  * @param {string} model - 模型名称
  * @param {Function} callback - 回调函数
  */
-export async function generateStreamResponse(requestBody, token, model, callback) {
+export async function generateStreamResponse(
+  requestBody,
+  token,
+  model,
+  callback,
+) {
   if (!token.projectId) {
-    throw createApiError('Token 缺少 projectId，请在管理页面获取 ProjectId', 400);
+    throw createApiError(
+      "Token 缺少 projectId，请在管理页面获取 ProjectId",
+      400,
+    );
   }
-  
+
   const headers = buildHeaders(token);
   const url = buildApiUrl(true);
   const fullRequestBody = buildRequestBody(requestBody, model, token.projectId);
-  
+
   // 调试日志
-  const dumpId = isDebugDumpEnabled() ? createDumpId('cli_stream') : null;
+  const dumpId = isDebugDumpEnabled() ? createDumpId("cli_stream") : null;
   const streamCollector = dumpId ? createStreamCollector() : null;
   if (dumpId) {
     await dumpFinalRequest(dumpId, fullRequestBody);
   }
-  
+
   // 状态对象用于流式解析
   const state = {
     toolCalls: [],
     reasoningSignature: null,
     sessionId: null, // Gemini CLI 不使用 sessionId
-    model: model
+    model: model,
   };
   const processor = createStreamLineProcessor({
     state,
     onEvent: callback,
-    onRawChunk: (chunk) => collectStreamChunk(streamCollector, chunk)
+    onRawChunk: (chunk) => collectStreamChunk(streamCollector, chunk),
   });
-  
+
   try {
     await runAxiosSseStream({
       url,
       headers,
       data: fullRequestBody,
       timeout: config.timeout,
-      processor
+      proxy: config.proxy || null,
+      processor,
     });
-    
+
     // 流式响应结束后写入日志
     if (dumpId) {
       await dumpStreamResponse(dumpId, streamCollector);
     }
   } catch (error) {
-    try { processor.close(); } catch { }
+    try {
+      processor.close();
+    } catch {}
     await handleApiError(error, token);
   }
 }
@@ -171,19 +205,22 @@ export async function generateStreamResponse(requestBody, token, model, callback
  */
 export async function generateNoStreamResponse(requestBody, token, model) {
   if (!token.projectId) {
-    throw createApiError('Token 缺少 projectId，请在管理页面获取 ProjectId', 400);
+    throw createApiError(
+      "Token 缺少 projectId，请在管理页面获取 ProjectId",
+      400,
+    );
   }
-  
+
   const headers = buildHeaders(token);
   const url = buildApiUrl(false);
   const fullRequestBody = buildRequestBody(requestBody, model, token.projectId);
-  
+
   // 调试日志
-  const dumpId = isDebugDumpEnabled() ? createDumpId('cli_no_stream') : null;
+  const dumpId = isDebugDumpEnabled() ? createDumpId("cli_no_stream") : null;
   if (dumpId) {
     await dumpFinalRequest(dumpId, fullRequestBody);
   }
-  
+
   let data;
   try {
     data = await postJsonAndParse({
@@ -192,40 +229,41 @@ export async function generateNoStreamResponse(requestBody, token, model) {
       headers,
       body: fullRequestBody,
       timeout: config.timeout,
+      proxy: config.proxy || null,
       dumpId,
-      dumpFinalRawResponse
+      dumpFinalRawResponse,
     });
   } catch (error) {
     await handleApiError(error, token);
   }
-  
+
   // 处理 GeminiCLI 的 response 包装格式
   // GeminiCLI API 返回格式: { "response": { "candidates": [...] } }
   if (data.response) {
     data = data.response;
   }
-  
+
   // 解析响应内容
-  const parts = (data.candidates?.[0]?.content?.parts) || [];
+  const parts = data.candidates?.[0]?.content?.parts || [];
   const parsed = parseGeminiCandidateParts({
     parts,
     sessionId: null,
     model,
     convertToToolCall,
-    saveBase64Image
+    saveBase64Image,
   });
 
   const usageData = toOpenAIUsage(data.usageMetadata);
 
   if (parsed.imageUrls.length > 0) {
-    let markdown = parsed.content ? parsed.content + '\n\n' : '';
-    markdown += parsed.imageUrls.map(url => `![image](${url})`).join('\n\n');
+    let markdown = parsed.content ? parsed.content + "\n\n" : "";
+    markdown += parsed.imageUrls.map((url) => `![image](${url})`).join("\n\n");
     return {
       content: markdown,
       reasoningContent: parsed.reasoningContent,
       reasoningSignature: parsed.reasoningSignature,
       toolCalls: parsed.toolCalls,
-      usage: usageData
+      usage: usageData,
     };
   }
 
@@ -234,7 +272,7 @@ export async function generateNoStreamResponse(requestBody, token, model) {
     reasoningContent: parsed.reasoningContent,
     reasoningSignature: parsed.reasoningSignature,
     toolCalls: parsed.toolCalls,
-    usage: usageData
+    usage: usageData,
   };
 }
 

--- a/src/api/geminicli_client.js
+++ b/src/api/geminicli_client.js
@@ -126,7 +126,7 @@ async function handleApiError(error, token) {
         errorBody,
       );
     }
-    geminicliTokenManager.disableCurrentToken(token);
+    geminicliTokenManager.disableCurrentToken(token, `API请求返回403: ${errorBody}`);
     throw createApiError(
       `该账号没有使用权限，已自动禁用。错误详情: ${errorBody}`,
       status,
@@ -308,9 +308,10 @@ export async function getToken() {
 /**
  * 禁用当前 Token
  * @param {Object} token - Token 对象
+ * @param {string} [reason] - 禁用原因
  */
-export function disableCurrentToken(token) {
-  geminicliTokenManager.disableCurrentToken(token);
+export function disableCurrentToken(token, reason) {
+  geminicliTokenManager.disableCurrentToken(token, reason);
 }
 
 /**

--- a/src/api/geminicli_client.js
+++ b/src/api/geminicli_client.js
@@ -1,6 +1,7 @@
 import geminicliTokenManager from "../auth/geminicli_token_manager.js";
 import config from "../config/config.js";
 import { createApiError } from "../utils/errors.js";
+import { httpRequest } from "../utils/httpClient.js";
 import { saveBase64Image } from "../utils/imageStorage.js";
 import {
   collectStreamChunk,
@@ -68,6 +69,26 @@ function buildApiUrl(stream = true) {
         "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"
     : geminicliConfig.noStreamUrl ||
         "https://cloudcode-pa.googleapis.com/v1internal:generateContent";
+}
+
+/**
+ * 获取 Gemini CLI 基础 URL（支持从完整 URL 解析）
+ * @returns {string}
+ */
+function getGeminiCliBaseUrl() {
+  const geminicliConfig = config.geminicli?.api || {};
+  if (geminicliConfig.baseUrl) return geminicliConfig.baseUrl;
+
+  const sampleUrl = geminicliConfig.url || geminicliConfig.noStreamUrl;
+  if (sampleUrl) {
+    try {
+      return new URL(sampleUrl).origin;
+    } catch {
+      // ignore
+    }
+  }
+
+  return "https://cloudcode-pa.googleapis.com";
 }
 
 /**
@@ -300,4 +321,71 @@ export function recordRequest(token) {
   if (token && token.refresh_token) {
     geminicliTokenManager.incrementRequestCount(token.refresh_token);
   }
+}
+
+/**
+ * 获取 Gemini CLI 额度信息
+ * @param {Object} token - Token 对象（必须包含 projectId）
+ * @returns {Promise<Object>} quotas: { [modelId]: { r, t } }
+ */
+export async function getGeminiCliQuotas(token) {
+  if (!token?.projectId) {
+    throw createApiError("Token 缺少 projectId，请先获取 Project ID", 400);
+  }
+
+  const geminicliConfig = config.geminicli?.api || {};
+  const baseUrl = getGeminiCliBaseUrl();
+  const url = `${baseUrl}/v1internal:retrieveUserQuota`;
+
+  const headers = {
+    Host: geminicliConfig.host || "cloudcode-pa.googleapis.com",
+    "User-Agent":
+      geminicliConfig.userAgent || "GeminiCLI/0.1.5 (Windows; AMD64)",
+    Authorization: `Bearer ${token.access_token}`,
+    "Content-Type": "application/json",
+    "Accept-Encoding": "gzip",
+  };
+
+  const response = await httpRequest({
+    method: "POST",
+    url,
+    headers,
+    data: { project: token.projectId },
+    timeout: config.timeout,
+  });
+
+  const buckets = response?.data?.buckets || [];
+  const quotas = {};
+
+  for (const bucket of buckets) {
+    const modelId = bucket?.modelId || bucket?.model || bucket?.id;
+    const fractionRaw = Number(bucket?.remainingFraction);
+    if (!modelId || !Number.isFinite(fractionRaw)) continue;
+
+    const remainingFraction = Math.min(1, Math.max(0, fractionRaw));
+    const resetTime =
+      typeof bucket?.resetTime === "string" ? bucket.resetTime : null;
+
+    if (!quotas[modelId]) {
+      quotas[modelId] = { r: remainingFraction, t: resetTime };
+      continue;
+    }
+
+    // 同一模型取更低的剩余额度
+    if (remainingFraction < quotas[modelId].r) {
+      quotas[modelId].r = remainingFraction;
+    }
+
+    // 取更早的重置时间
+    if (resetTime) {
+      const currentReset = quotas[modelId].t;
+      if (!currentReset) {
+        quotas[modelId].t = resetTime;
+      } else if (Date.parse(resetTime) < Date.parse(currentReset)) {
+        quotas[modelId].t = resetTime;
+      }
+    }
+  }
+
+  return quotas;
 }

--- a/src/api/geminicli_client.js
+++ b/src/api/geminicli_client.js
@@ -1,5 +1,7 @@
 import geminicliTokenManager from "../auth/geminicli_token_manager.js";
 import config from "../config/config.js";
+import quotaManager from "../auth/quota_manager.js";
+import tokenCooldownManager from "../auth/token_cooldown_manager.js";
 import { createApiError } from "../utils/errors.js";
 import { httpRequest } from "../utils/httpClient.js";
 import { saveBase64Image } from "../utils/imageStorage.js";
@@ -111,10 +113,15 @@ function buildRequestBody(requestBody, model, projectId) {
 
 /**
  * 统一错误处理
+ * 
+ * 429 处理策略（参考 MD 文档第 11.3 节）：
+ * - 429 不禁用凭证，只对当前凭证+当前模型设置冷却
+ * - 从错误响应中解析冷却结束时间
  * @param {Error} error - 错误对象
  * @param {Object} token - Token 对象
+ * @param {string} [model] - 模型名称（用于模型级冷却）
  */
-async function handleApiError(error, token) {
+async function handleApiError(error, token, model) {
   const status = getUpstreamStatus(error);
   const errorBody = await readUpstreamErrorBody(error);
 
@@ -135,6 +142,42 @@ async function handleApiError(error, token) {
   }
 
   if (status === 429) {
+    // 尝试解析冷却时间并设置模型级冷却
+    if (model && token?.refresh_token) {
+      try {
+        const salt = await geminicliTokenManager.getSalt();
+        const { generateTokenId } = await import("../utils/idGenerator.js");
+        const tokenId = generateTokenId(token.refresh_token, salt);
+
+        // 尝试从错误体中提取 resetTime
+        let resetTimestamp = null;
+        try {
+          const parsed = typeof errorBody === "string" ? JSON.parse(errorBody) : errorBody;
+          const resetTimeStr =
+            parsed?.error?.details?.[0]?.metadata?.resetTime ||
+            parsed?.resetTime ||
+            parsed?.error?.resetTime;
+          if (resetTimeStr) {
+            const ms = Date.parse(resetTimeStr);
+            if (Number.isFinite(ms) && ms > Date.now()) {
+              resetTimestamp = ms;
+            }
+          }
+        } catch {
+          // 解析失败，使用默认冷却时间
+        }
+
+        // 如果无法从响应解析到 resetTime，默认冷却 5 分钟
+        if (!resetTimestamp) {
+          resetTimestamp = Date.now() + 5 * 60 * 1000;
+        }
+
+        tokenCooldownManager.setCooldown(tokenId, model, resetTimestamp);
+      } catch {
+        // 设置冷却失败不影响错误抛出
+      }
+    }
+
     throw createApiError(
       `请求频率过高，请稍后重试。错误详情: ${errorBody}`,
       status,
@@ -213,7 +256,7 @@ export async function generateStreamResponse(
     try {
       processor.close();
     } catch {}
-    await handleApiError(error, token);
+    await handleApiError(error, token, model);
   }
 }
 
@@ -255,7 +298,7 @@ export async function generateNoStreamResponse(requestBody, token, model) {
       dumpFinalRawResponse,
     });
   } catch (error) {
-    await handleApiError(error, token);
+    await handleApiError(error, token, model);
   }
 
   // 处理 GeminiCLI 的 response 包装格式
@@ -326,6 +369,7 @@ export function recordRequest(token) {
 
 /**
  * 获取 Gemini CLI 额度信息
+ * 优先使用 retrieveUserQuota，失败时回退到 fetchAvailableModels
  * @param {Object} token - Token 对象（必须包含 projectId）
  * @returns {Promise<Object>} quotas: { [modelId]: { r, t } }
  */
@@ -334,59 +378,114 @@ export async function getGeminiCliQuotas(token) {
     throw createApiError("Token 缺少 projectId，请先获取 Project ID", 400);
   }
 
-  const geminicliConfig = config.geminicli?.api || {};
   const baseUrl = getGeminiCliBaseUrl();
-  const url = `${baseUrl}/v1internal:retrieveUserQuota`;
+  const geminicliConfig = config.geminicli?.api || {};
 
-  const headers = {
-    Host: geminicliConfig.host || "cloudcode-pa.googleapis.com",
-    "User-Agent":
-      geminicliConfig.userAgent || "GeminiCLI/0.1.5 (Windows; AMD64)",
-    Authorization: `Bearer ${token.access_token}`,
-    "Content-Type": "application/json",
-    "Accept-Encoding": "gzip",
-  };
+  // ===== 第一优先：retrieveUserQuota =====
+  try {
+    const url = `${baseUrl}/v1internal:retrieveUserQuota`;
+    const headers = {
+      Host: geminicliConfig.host || "cloudcode-pa.googleapis.com",
+      "User-Agent":
+        geminicliConfig.userAgent || "GeminiCLI/0.1.5 (Windows; AMD64)",
+      Authorization: `Bearer ${token.access_token}`,
+      "Content-Type": "application/json",
+      "Accept-Encoding": "gzip",
+    };
 
-  const response = await httpRequest({
-    method: "POST",
-    url,
-    headers,
-    data: { project: token.projectId },
-    timeout: config.timeout,
-  });
+    const response = await httpRequest({
+      method: "POST",
+      url,
+      headers,
+      data: { project: token.projectId },
+      timeout: config.timeout,
+    });
 
-  const buckets = response?.data?.buckets || [];
-  const quotas = {};
+    const buckets = response?.data?.buckets || [];
+    const quotas = {};
 
-  for (const bucket of buckets) {
-    const modelId = bucket?.modelId || bucket?.model || bucket?.id;
-    const fractionRaw = Number(bucket?.remainingFraction);
-    if (!modelId || !Number.isFinite(fractionRaw)) continue;
+    for (const bucket of buckets) {
+      const modelId = bucket?.modelId || bucket?.model || bucket?.id;
+      const fractionRaw = Number(bucket?.remainingFraction);
+      if (!modelId || !Number.isFinite(fractionRaw)) continue;
 
-    const remainingFraction = Math.min(1, Math.max(0, fractionRaw));
-    const resetTime =
-      typeof bucket?.resetTime === "string" ? bucket.resetTime : null;
+      const remainingFraction = Math.min(1, Math.max(0, fractionRaw));
+      const resetTime =
+        typeof bucket?.resetTime === "string" ? bucket.resetTime : null;
 
-    if (!quotas[modelId]) {
-      quotas[modelId] = { r: remainingFraction, t: resetTime };
-      continue;
-    }
+      if (!quotas[modelId]) {
+        quotas[modelId] = { r: remainingFraction, t: resetTime };
+        continue;
+      }
 
-    // 同一模型取更低的剩余额度
-    if (remainingFraction < quotas[modelId].r) {
-      quotas[modelId].r = remainingFraction;
-    }
+      // 同一模型取更低的剩余额度
+      if (remainingFraction < quotas[modelId].r) {
+        quotas[modelId].r = remainingFraction;
+      }
 
-    // 取更早的重置时间
-    if (resetTime) {
-      const currentReset = quotas[modelId].t;
-      if (!currentReset) {
-        quotas[modelId].t = resetTime;
-      } else if (Date.parse(resetTime) < Date.parse(currentReset)) {
-        quotas[modelId].t = resetTime;
+      // 取更早的重置时间
+      if (resetTime) {
+        const currentReset = quotas[modelId].t;
+        if (!currentReset) {
+          quotas[modelId].t = resetTime;
+        } else if (Date.parse(resetTime) < Date.parse(currentReset)) {
+          quotas[modelId].t = resetTime;
+        }
       }
     }
-  }
 
-  return quotas;
+    return quotas;
+  } catch (primaryError) {
+    // retrieveUserQuota 失败，尝试 fetchAvailableModels 回退
+    const primaryStatus =
+      primaryError.response?.status || primaryError.status || primaryError.statusCode || 500;
+
+    // 如果是认证/权限错误，不需要回退
+    if (primaryStatus === 401 || primaryStatus === 403) {
+      throw primaryError;
+    }
+
+    try {
+      const fallbackUrl = `${baseUrl}/v1internal:fetchAvailableModels`;
+      const fallbackHeaders = {
+        Host: geminicliConfig.host || "cloudcode-pa.googleapis.com",
+        "User-Agent":
+          geminicliConfig.userAgent || "GeminiCLI/0.1.5 (Windows; AMD64)",
+        Authorization: `Bearer ${token.access_token}`,
+        "Content-Type": "application/json",
+        "Accept-Encoding": "gzip",
+      };
+
+      const fallbackResponse = await httpRequest({
+        method: "POST",
+        url: fallbackUrl,
+        headers: fallbackHeaders,
+        data: {},
+        timeout: config.timeout,
+      });
+
+      const data = fallbackResponse?.data;
+      const quotas = {};
+
+      // fetchAvailableModels 返回格式: { models: { modelId: { quotaInfo: { remainingFraction, resetTime } } } }
+      Object.entries(data?.models || {}).forEach(([modelId, modelData]) => {
+        const quotaInfo = modelData?.quotaInfo;
+        if (!quotaInfo) return;
+
+        const fractionRaw = Number(quotaInfo.remainingFraction);
+        if (!Number.isFinite(fractionRaw)) return;
+
+        const remainingFraction = Math.min(1, Math.max(0, fractionRaw));
+        const resetTime =
+          typeof quotaInfo.resetTime === "string" ? quotaInfo.resetTime : null;
+
+        quotas[modelId] = { r: remainingFraction, t: resetTime };
+      });
+
+      return quotas;
+    } catch (fallbackError) {
+      // 两个接口都失败了，抛出原始错误
+      throw primaryError;
+    }
+  }
 }

--- a/src/auth/geminicli_token_manager.js
+++ b/src/auth/geminicli_token_manager.js
@@ -884,9 +884,32 @@ class GeminiCliTokenManager {
       throw new TokenError("Token不存在", null, 404);
     }
 
+    return this.fetchProjectIdForTokenData(tokenData, tokenId);
+  }
+
+  /**
+   * 根据 token 数据获取并更新 projectId
+   * @param {Object} tokenData - 完整 token 对象
+   * @param {string|null} tokenId - 安全的 token ID，可选
+   * @returns {Promise<Object>} 包含 projectId 和 tier 的结果
+   */
+  async fetchProjectIdForTokenData(tokenData, tokenId = null) {
+    if (!tokenData) {
+      throw new TokenError("Token不存在", null, 404);
+    }
+
+    const effectiveTokenId =
+      tokenId ||
+      (await this.store.getSalt().then((salt) =>
+        generateTokenId(tokenData.refresh_token, salt),
+      ));
+
     // 确保 token 未过期
     if (this.isExpired(tokenData)) {
-      await this.refreshToken(tokenData);
+      const refreshedToken = await this.refreshToken(tokenData);
+      if (refreshedToken) {
+        tokenData = refreshedToken;
+      }
     }
 
     const result = await this.fetchProjectId(tokenData);
@@ -906,7 +929,7 @@ class GeminiCliTokenManager {
     const allTokens = await this.store.readAll();
     const salt = await this.store.getSalt();
     const index = allTokens.findIndex(
-      (t) => generateTokenId(t.refresh_token, salt) === tokenId,
+      (t) => generateTokenId(t.refresh_token, salt) === effectiveTokenId,
     );
     if (index !== -1) {
       allTokens[index].projectId = projectId;
@@ -927,7 +950,50 @@ class GeminiCliTokenManager {
       }
     }
 
-    return { projectId, tier };
+    return { projectId, tier, tokenId: effectiveTokenId };
+  }
+
+  /**
+   * 批量获取已启用 Gemini CLI Token 的 Project ID
+   * @returns {Promise<Object>} 批量处理结果
+   */
+  async batchFetchProjectIds() {
+    const allTokens = await this.store.readAll();
+    const salt = await this.store.getSalt();
+    const enabledTokens = allTokens.filter((token) => token.enable !== false);
+
+    const results = [];
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const token of enabledTokens) {
+      const currentTokenId = generateTokenId(token.refresh_token, salt);
+      try {
+        const result = await this.fetchProjectIdForTokenData(token, currentTokenId);
+        successCount += 1;
+        results.push({
+          tokenId: currentTokenId,
+          success: true,
+          projectId: result.projectId,
+          tier: result.tier || null,
+        });
+      } catch (error) {
+        failCount += 1;
+        results.push({
+          tokenId: currentTokenId,
+          success: false,
+          message: error.message,
+          status: error.statusCode || error.status || 500,
+        });
+      }
+    }
+
+    return {
+      total: enabledTokens.length,
+      successCount,
+      failCount,
+      results,
+    };
   }
 
   /**

--- a/src/auth/geminicli_token_manager.js
+++ b/src/auth/geminicli_token_manager.js
@@ -751,6 +751,69 @@ class GeminiCliTokenManager {
   }
 
   /**
+   * 发送测试消息验证凭证在 API 层面的可用性
+   * 通过非流式 generateContent 发送一个极简请求，检查是否会返回 403 等致命错误
+   * @param {Object} token - Token 对象（必须已刷新且包含 projectId）
+   * @returns {Promise<{ok: boolean, status?: number, message?: string}>}
+   * @private
+   */
+  async _sendTestMessage(token) {
+    const geminicliConfig = config.geminicli?.api || {};
+    const noStreamUrl = geminicliConfig.noStreamUrl
+      || 'https://cloudcode-pa.googleapis.com/v1internal:generateContent';
+
+    const testRequestBody = {
+      model: 'gemini-2.5-flash',
+      project: token.projectId,
+      request: {
+        contents: [
+          { role: 'user', parts: [{ text: 'hi' }] }
+        ],
+        generationConfig: {
+          maxOutputTokens: 1,
+          candidateCount: 1
+        }
+      }
+    };
+
+    try {
+      await httpRequest({
+        method: 'POST',
+        url: noStreamUrl,
+        headers: {
+          'Host': geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
+          'User-Agent': geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
+          'Authorization': `Bearer ${token.access_token}`,
+          'Content-Type': 'application/json',
+          'Accept-Encoding': 'gzip'
+        },
+        data: testRequestBody,
+        timeout: 30000
+      });
+      return { ok: true };
+    } catch (error) {
+      const status = error.response?.status || error.status || error.statusCode || 500;
+      let errorBody = '';
+      try {
+        const data = error.response?.data;
+        errorBody = typeof data === 'string' ? data : (data ? JSON.stringify(data) : error.message);
+      } catch {
+        errorBody = error.message || '未知错误';
+      }
+
+      if (status === 403) {
+        const isContextLimit = String(errorBody).includes('The caller does not');
+        if (!isContextLimit) {
+          return { ok: false, status, message: errorBody };
+        }
+      }
+
+      // 其他非致命状态码不阻止启用
+      return { ok: true };
+    }
+  }
+
+  /**
    * 从禁用池启用 token（先测试可用性）
    * @param {string} tokenId - 安全的 token ID
    * @returns {Promise<Object>} 操作结果
@@ -801,7 +864,21 @@ class GeminiCliTokenManager {
         log.warn(`[GeminiCLI][启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`);
       }
 
-      log.info(`[GeminiCLI][启用检测] token ${tokenId} 测试通过，正在启用...`);
+      // 步骤3: 发送测试消息，验证 API 调用是否会触发 403
+      if (tokenData.projectId) {
+        log.info(`[GeminiCLI][启用检测] 正在发送测试消息验证 API 可用性...`);
+        const testResult = await this._sendTestMessage(tokenData);
+        if (!testResult.ok) {
+          log.warn(`[GeminiCLI][启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`);
+          return {
+            success: false,
+            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`
+          };
+        }
+        log.info(`[GeminiCLI][启用检测] token ${tokenId} 测试消息通过`);
+      }
+
+      log.info(`[GeminiCLI][启用检测] token ${tokenId} 全部检测通过，正在启用...`);
 
       // 测试通过，执行启用
       const allTokens = await this.store.readAll();

--- a/src/auth/geminicli_token_manager.js
+++ b/src/auth/geminicli_token_manager.js
@@ -20,6 +20,36 @@ const GEMINICLI_API_CONFIG = {
   BASE_URL: "https://cloudcode-pa.googleapis.com",
 };
 
+// Tier 映射表：将原始 tier ID 映射为统一 tier 名称
+const TIER_MAP = {
+  "g1-ultra-tier": "ultra",
+  "ws-ai-ultra-business-tier": "ultra",
+  "g1-pro-tier": "pro",
+  "helium-tier": "pro",
+  "standard-tier": "pro",
+  "free-tier": "free",
+};
+
+/**
+ * 将原始 tier ID 映射为统一的 tier 名称
+ * @param {string|null} rawTier - 原始 tier ID
+ * @returns {string} 统一的 tier 名称
+ */
+function mapTier(rawTier) {
+  if (!rawTier) return "pro";
+  const lower = rawTier.toLowerCase();
+  return TIER_MAP[lower] || "pro";
+}
+
+// 永久性刷新失败的错误文本特征（匹配到任一即视为永久失效）
+const PERMANENT_REFRESH_ERROR_TEXTS = [
+  "invalid_grant",
+  "refresh_token_expired",
+  "invalid_refresh_token",
+  "unauthorized_client",
+  "access_denied",
+];
+
 // 轮询策略枚举（复用 token_manager.js 的定义）
 const RotationStrategy = {
   ROUND_ROBIN: "round_robin", // 均衡负载：每次请求切换
@@ -167,6 +197,10 @@ class GeminiCliTokenManager {
 
   /**
    * 安全刷新单个 token（不抛出异常）
+   * 
+   * 错误分类策略（参考 MD 文档第 8.3 节）：
+   * - 永久失效：400/401/403 或错误文本含 invalid_grant 等
+   * - 临时失败：429/500/502/503/504/网络异常
    * @param {Object} token - Token 对象
    * @returns {Promise<{action: 'success'|'disable'|'skip', reason?: string}>} 刷新结果
    * @private
@@ -182,7 +216,14 @@ class GeminiCliTokenManager {
       const rawMessage = error.message || "未知错误";
       const reason = `启动检测刷新失败(${statusCode}): ${rawMessage}`;
       this._recordTokenError(token, reason, "startup_refresh");
-      if (statusCode === 403 || statusCode === 400) {
+
+      // 永久失效判断：HTTP 400/401/403 或错误文本包含特定关键词
+      const isPermanent =
+        statusCode === 400 ||
+        statusCode === 401 ||
+        statusCode === 403 ||
+        PERMANENT_REFRESH_ERROR_TEXTS.some((t) => rawMessage.toLowerCase().includes(t));
+      if (isPermanent) {
         return { action: "disable", reason };
       }
       return { action: "skip", reason };
@@ -351,18 +392,22 @@ class GeminiCliTokenManager {
   }
 
   /**
-   * 通过 loadCodeAssist API 获取 projectId
+   * 通过 loadCodeAssist API 获取 projectId 和 tier 信息
+   * 
+   * 优先级链（参考 MD 文档第 6 节）：
+   * 1. loadCodeAssist → 提取 cloudaicompanionProject + tier
+   * 2. onboardUser → 创建项目并获取 projectId
+   * 3. Google Cloud 项目列表 → 回退方案
    * @param {Object} token - Token 对象
-   * @returns {Promise<string|null>} projectId 或 null
+   * @returns {Promise<{projectId: string|null, tier: string|null}>} projectId 和 tier
    */
   async fetchProjectId(token) {
     const salt = await this.store.getSalt();
     const tokenId = generateTokenId(token.refresh_token, salt);
-    log.info(`[GeminiCLI] 正在获取 projectId: ${tokenId}`);
+    log.info(`[GeminiCLI] 正在获取 projectId 和 tier: ${tokenId}`);
 
     const geminicliConfig = config.geminicli?.api || {};
     const baseUrl = geminicliConfig.baseUrl || GEMINICLI_API_CONFIG.BASE_URL;
-    const url = `${baseUrl}/v1internal:loadCodeAssist`;
 
     const headers = {
       Host: geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
@@ -373,39 +418,58 @@ class GeminiCliTokenManager {
       "Accept-Encoding": "gzip",
     };
 
-    const requestBody = {
-      metadata: {
-        ideType: "ANTIGRAVITY",
-        platform: "PLATFORM_UNSPECIFIED",
-        pluginType: "GEMINI",
-      },
-    };
-
+    // ===== 第一优先：loadCodeAssist =====
     try {
-      const response = await httpRequest({
+      const loadResponse = await httpRequest({
         method: "POST",
-        url,
+        url: `${baseUrl}/v1internal:loadCodeAssist`,
         headers,
-        data: requestBody,
+        data: {
+          metadata: {
+            ideType: "ANTIGRAVITY",
+            platform: "PLATFORM_UNSPECIFIED",
+            pluginType: "GEMINI",
+          },
+        },
         timeout: 30000,
       });
 
-      const data = response.data;
+      const data = loadResponse.data;
 
-      // 检查是否有 currentTier（表示用户已激活）
-      if (data.currentTier) {
+      // 提取 tier 信息（paidTier 优先，currentTier 其次）
+      const rawTier =
+        data.paidTier?.id || data.currentTier?.id || null;
+      const tier = mapTier(rawTier);
+      if (rawTier) {
+        log.info(`[GeminiCLI] 检测到 tier: ${rawTier} -> ${tier}`);
+      }
+
+      // 情况 A：已经激活，有 currentTier 和 projectId
+      if (data.currentTier || data.cloudaicompanionProject) {
         const projectId = data.cloudaicompanionProject;
         if (projectId) {
           log.info(`[GeminiCLI] 成功获取 projectId: ${projectId}`);
-          return projectId;
+          return { projectId, tier };
         }
         log.warn("[GeminiCLI] loadCodeAssist 响应中无 projectId");
-        return null;
+        // 有 currentTier 但无 projectId，继续尝试 onboardUser
       }
 
-      // 用户未激活，尝试 onboardUser
+      // 情况 B：尚未激活或无 projectId，尝试 onboardUser
       log.info("[GeminiCLI] 用户未激活，尝试 onboardUser...");
-      return await this._tryOnboardUser(token, data);
+      const onboardResult = await this._tryOnboardUser(token, headers, baseUrl, data);
+      if (onboardResult) {
+        return { projectId: onboardResult, tier };
+      }
+
+      // onboardUser 也失败了，尝试 Google Cloud 项目列表
+      log.info("[GeminiCLI] onboardUser 未返回 projectId，尝试 Google Cloud 项目列表...");
+      const gcpProjectId = await this._tryGoogleCloudProjectList(token);
+      if (gcpProjectId) {
+        return { projectId: gcpProjectId, tier };
+      }
+
+      return { projectId: null, tier };
     } catch (error) {
       const status = error.response?.status || error.status || 500;
       log.error(`[GeminiCLI] 获取 projectId 失败 (${status}):`, error.message);
@@ -413,34 +477,33 @@ class GeminiCliTokenManager {
       if (status === 403 || status === 401) {
         throw new TokenError("Token 无权限获取 projectId", tokenId, status);
       }
-      throw new TokenError(
-        `获取 projectId 失败: ${error.message}`,
-        tokenId,
-        status,
-      );
+
+      // 非致命错误时仍尝试 Google Cloud 项目列表回退
+      log.info("[GeminiCLI] loadCodeAssist 失败，尝试 Google Cloud 项目列表回退...");
+      try {
+        const gcpProjectId = await this._tryGoogleCloudProjectList(token);
+        if (gcpProjectId) {
+          return { projectId: gcpProjectId, tier: null };
+        }
+      } catch (fallbackError) {
+        log.error(`[GeminiCLI] Google Cloud 项目列表回退也失败:`, fallbackError.message);
+      }
+
+      throw new TokenError(`获取 projectId 失败: ${error.message}`, tokenId, status);
     }
   }
 
   /**
    * 尝试通过 onboardUser 获取 projectId（长时间运行操作）
    * @param {Object} token - Token 对象
-   * @param {Object} loadCodeAssistData - loadCodeAssist 的响应数据
+   * @param {Object} headers - 请求头
+   * @param {string} baseUrl - API 基础 URL
+   * @param {Object} loadCodeAssistData - loadCodeAssist 的响应数据（用于提取 allowedTiers）
    * @returns {Promise<string|null>} projectId 或 null
    * @private
    */
-  async _tryOnboardUser(token, loadCodeAssistData) {
-    const geminicliConfig = config.geminicli?.api || {};
-    const baseUrl = geminicliConfig.baseUrl || GEMINICLI_API_CONFIG.BASE_URL;
+  async _tryOnboardUser(token, headers, baseUrl, loadCodeAssistData) {
     const url = `${baseUrl}/v1internal:onboardUser`;
-
-    const headers = {
-      Host: geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
-      "User-Agent":
-        geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
-      Authorization: `Bearer ${token.access_token}`,
-      "Content-Type": "application/json",
-      "Accept-Encoding": "gzip",
-    };
 
     // 从 loadCodeAssist 响应中获取默认 tier
     let tierId = "LEGACY";
@@ -511,6 +574,72 @@ class GeminiCliTokenManager {
   }
 
   /**
+   * 第三优先回退：通过 Google Cloud Resource Manager 获取项目列表
+   * 当 loadCodeAssist 和 onboardUser 都失败时使用
+   * @param {Object} token - Token 对象
+   * @returns {Promise<string|null>} projectId 或 null
+   * @private
+   */
+  async _tryGoogleCloudProjectList(token) {
+    try {
+      const response = await httpRequest({
+        method: "GET",
+        url: "https://cloudresourcemanager.googleapis.com/v1/projects",
+        headers: {
+          Authorization: `Bearer ${token.access_token}`,
+          "User-Agent": GEMINICLI_API_CONFIG.USER_AGENT,
+          "Accept-Encoding": "gzip",
+        },
+        timeout: 30000,
+      });
+
+      const projects = (response.data?.projects || []).filter(
+        (p) => p.lifecycleState === "ACTIVE",
+      );
+
+      if (projects.length === 0) {
+        log.warn("[GeminiCLI] Google Cloud 项目列表为空");
+        return null;
+      }
+
+      let selected = null;
+
+      if (projects.length === 1) {
+        // 只有一个项目，直接使用
+        selected = projects[0];
+      } else {
+        // 多个项目，优先选择包含 "default" 的
+        selected = projects.find(
+          (p) =>
+            (p.projectId && p.projectId.toLowerCase().includes("default")) ||
+            (p.name && p.name.toLowerCase().includes("default")),
+        );
+        if (!selected) {
+          // 没有 default 项目，使用第一个
+          selected = projects[0];
+        }
+      }
+
+      const projectId = selected.projectId;
+      if (projectId) {
+        log.info(
+          `[GeminiCLI] 从 Google Cloud 项目列表选择: ${projectId} (共 ${projects.length} 个活跃项目)`,
+        );
+        return projectId;
+      }
+
+      return null;
+    } catch (error) {
+      const status = error.response?.status || error.status || 500;
+      log.error(
+        `[GeminiCLI] Google Cloud 项目列表查询失败 (${status}):`,
+        error.message,
+      );
+      return null;
+    }
+  }
+
+  /**
    * 准备单个 token（刷新 + 获取 projectId）
    * @param {Object} token - Token 对象
    * @returns {Promise<{action: 'ready'|'disable', reason?: string}>} 处理结果
@@ -524,7 +653,9 @@ class GeminiCliTokenManager {
 
     // 获取 projectId（如果没有）
     if (!token.projectId) {
-      const projectId = await this.fetchProjectId(token);
+      const result = await this.fetchProjectId(token);
+      const projectId = result?.projectId;
+      const tier = result?.tier;
       if (!projectId) {
         log.warn(`[GeminiCLI] 无法获取 projectId，禁用账号`);
         return {
@@ -533,6 +664,10 @@ class GeminiCliTokenManager {
         };
       }
       token.projectId = projectId;
+      // 保存 tier 信息（如果获取到了）
+      if (tier) {
+        token.tier = tier;
+      }
       this.saveToFile(token);
     }
 
@@ -548,7 +683,7 @@ class GeminiCliTokenManager {
    */
   _handleTokenError(error, token) {
     const suffix = token.access_token?.slice(-8) || "unknown";
-    if (error.statusCode === 403 || error.statusCode === 400) {
+    if (error.statusCode === 403 || error.statusCode === 401 || error.statusCode === 400) {
       log.warn(
         `[GeminiCLI] ...${suffix}: Token 已失效或错误，已自动禁用该账号`,
       );
@@ -649,6 +784,10 @@ class GeminiCliTokenManager {
         newToken.projectId = tokenData.projectId;
       }
 
+      if (tokenData.tier) {
+        newToken.tier = tokenData.tier;
+      }
+
       allTokens.push(newToken);
       await this.store.writeAll(allTokens);
 
@@ -721,6 +860,7 @@ class GeminiCliTokenManager {
         enable: token.enable !== false,
         email: token.email || null,
         projectId: token.projectId || null,
+        tier: token.tier || null,
         disableReason: token.disableReason || null,
         disableTime: token.disableTime || null,
         lastError: token.lastError || null,
@@ -736,7 +876,7 @@ class GeminiCliTokenManager {
   /**
    * 根据 tokenId 获取并更新 projectId
    * @param {string} tokenId - 安全的 token ID
-   * @returns {Promise<Object>} 包含 projectId 的结果
+   * @returns {Promise<Object>} 包含 projectId 和 tier 的结果
    */
   async fetchProjectIdForToken(tokenId) {
     const tokenData = await this.findTokenById(tokenId);
@@ -749,13 +889,18 @@ class GeminiCliTokenManager {
       await this.refreshToken(tokenData);
     }
 
-    const projectId = await this.fetchProjectId(tokenData);
+    const result = await this.fetchProjectId(tokenData);
+    const projectId = result?.projectId;
+    const tier = result?.tier;
     if (!projectId) {
       throw new TokenError("无法获取 projectId，该账号可能无资格", null, 400);
     }
 
     // 更新并保存
     tokenData.projectId = projectId;
+    if (tier) {
+      tokenData.tier = tier;
+    }
 
     // 更新文件
     const allTokens = await this.store.readAll();
@@ -765,6 +910,9 @@ class GeminiCliTokenManager {
     );
     if (index !== -1) {
       allTokens[index].projectId = projectId;
+      if (tier) {
+        allTokens[index].tier = tier;
+      }
       await this.store.writeAll(allTokens);
     }
 
@@ -774,9 +922,12 @@ class GeminiCliTokenManager {
     );
     if (memoryToken) {
       memoryToken.projectId = projectId;
+      if (tier) {
+        memoryToken.tier = tier;
+      }
     }
 
-    return { projectId };
+    return { projectId, tier };
   }
 
   /**
@@ -918,6 +1069,30 @@ class GeminiCliTokenManager {
   async enableTokenById(tokenId) {
     try {
       const tokenData = await this.findTokenById(tokenId);
+
+      // 辅助函数：将启用验证失败的错误信息写入凭证存储
+      const saveEnableError = async (errorMessage) => {
+        try {
+          const allTokens = await this.store.readAll();
+          const salt = await this.store.getSalt();
+          const index = allTokens.findIndex(
+            (token) => generateTokenId(token.refresh_token, salt) === tokenId,
+          );
+          if (index !== -1) {
+            allTokens[index] = {
+              ...allTokens[index],
+              lastError: errorMessage,
+              lastErrorTime: new Date().toISOString(),
+              lastErrorStage: "enable_test",
+            };
+            await this.store.writeAll(allTokens);
+            await this.reload();
+          }
+        } catch (e) {
+          log.error(`[GeminiCLI][启用检测] 保存错误信息失败: ${e.message}`);
+        }
+      };
+
       if (!tokenData) {
         return { success: false, message: "Token不存在" };
       }
@@ -938,28 +1113,39 @@ class GeminiCliTokenManager {
           log.warn(
             `[GeminiCLI][启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`,
           );
+          const msg = `凭证不可用，刷新失败(${statusCode}): ${error.message}`;
+          await saveEnableError(msg);
           return {
             success: false,
-            message: `凭证不可用，刷新失败(${statusCode}): ${error.message}`,
+            message: msg,
           };
         }
         log.warn(
           `[GeminiCLI][启用检测] token ${tokenId} 刷新失败: ${error.message}`,
         );
-        return { success: false, message: `凭证刷新失败: ${error.message}` };
+        const refreshMsg = `凭证刷新失败: ${error.message}`;
+        await saveEnableError(refreshMsg);
+        return { success: false, message: refreshMsg };
       }
 
       // 步骤2: 尝试获取 projectId（验证账号权限）
       try {
-        const projectId = await this.fetchProjectId(tokenData);
-        if (projectId) {
-          tokenData.projectId = projectId;
+        const result = await this.fetchProjectId(tokenData);
+        const fetchedProjectId = result?.projectId;
+        const fetchedTier = result?.tier;
+        if (fetchedProjectId) {
+          tokenData.projectId = fetchedProjectId;
+          if (fetchedTier) {
+            tokenData.tier = fetchedTier;
+          }
         } else if (!tokenData.projectId) {
           log.warn(`[GeminiCLI][启用检测] token ${tokenId} 无法获取 projectId`);
+          const noProjectMsg =
+            "凭证不可用: 无法获取 projectId，该账号可能不支持 Gemini CLI";
+          await saveEnableError(noProjectMsg);
           return {
             success: false,
-            message:
-              "凭证不可用: 无法获取 projectId，该账号可能不支持 Gemini CLI",
+            message: noProjectMsg,
           };
         }
       } catch (error) {
@@ -968,9 +1154,11 @@ class GeminiCliTokenManager {
           log.warn(
             `[GeminiCLI][启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`,
           );
+          const permMsg = `凭证不可用，权限验证失败(${statusCode}): ${error.message}`;
+          await saveEnableError(permMsg);
           return {
             success: false,
-            message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}`,
+            message: permMsg,
           };
         }
         // 非致命错误，继续启用
@@ -987,9 +1175,11 @@ class GeminiCliTokenManager {
           log.warn(
             `[GeminiCLI][启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`,
           );
+          const testMsg = `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`;
+          await saveEnableError(testMsg);
           return {
             success: false,
-            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`,
+            message: testMsg,
           };
         }
         log.info(`[GeminiCLI][启用检测] token ${tokenId} 测试消息通过`);
@@ -1020,6 +1210,7 @@ class GeminiCliTokenManager {
         lastErrorStage: null,
       };
       if (tokenData.projectId) updates.projectId = tokenData.projectId;
+      if (tokenData.tier) updates.tier = tokenData.tier;
 
       allTokens[index] = { ...allTokens[index], ...updates };
       await this.store.writeAll(allTokens);

--- a/src/auth/geminicli_token_manager.js
+++ b/src/auth/geminicli_token_manager.js
@@ -751,6 +751,85 @@ class GeminiCliTokenManager {
   }
 
   /**
+   * 从禁用池启用 token（先测试可用性）
+   * @param {string} tokenId - 安全的 token ID
+   * @returns {Promise<Object>} 操作结果
+   */
+  async enableTokenById(tokenId) {
+    try {
+      const tokenData = await this.findTokenById(tokenId);
+      if (!tokenData) {
+        return { success: false, message: 'Token不存在' };
+      }
+
+      // 如果 token 已经启用，直接返回
+      if (tokenData.enable !== false) {
+        return { success: true, message: 'Token已处于启用状态' };
+      }
+
+      log.info(`[GeminiCLI][启用检测] 正在测试 token ${tokenId} 的可用性...`);
+
+      // 步骤1: 尝试刷新 token
+      try {
+        await this.refreshToken(tokenData);
+      } catch (error) {
+        const statusCode = error.statusCode || 500;
+        if (statusCode === 403 || statusCode === 400) {
+          log.warn(`[GeminiCLI][启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`);
+          return { success: false, message: `凭证不可用，刷新失败(${statusCode}): ${error.message}` };
+        }
+        log.warn(`[GeminiCLI][启用检测] token ${tokenId} 刷新失败: ${error.message}`);
+        return { success: false, message: `凭证刷新失败: ${error.message}` };
+      }
+
+      // 步骤2: 尝试获取 projectId（验证账号权限）
+      try {
+        const projectId = await this.fetchProjectId(tokenData);
+        if (projectId) {
+          tokenData.projectId = projectId;
+        } else if (!tokenData.projectId) {
+          log.warn(`[GeminiCLI][启用检测] token ${tokenId} 无法获取 projectId`);
+          return { success: false, message: '凭证不可用: 无法获取 projectId，该账号可能不支持 Gemini CLI' };
+        }
+      } catch (error) {
+        const statusCode = error.statusCode || 500;
+        if (statusCode === 403 || statusCode === 401) {
+          log.warn(`[GeminiCLI][启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`);
+          return { success: false, message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}` };
+        }
+        // 非致命错误，继续启用
+        log.warn(`[GeminiCLI][启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`);
+      }
+
+      log.info(`[GeminiCLI][启用检测] token ${tokenId} 测试通过，正在启用...`);
+
+      // 测试通过，执行启用
+      const allTokens = await this.store.readAll();
+      const salt = await this.store.getSalt();
+
+      const index = allTokens.findIndex(token =>
+        generateTokenId(token.refresh_token, salt) === tokenId
+      );
+
+      if (index === -1) {
+        return { success: false, message: 'Token不存在' };
+      }
+
+      const updates = { enable: true, disableReason: null, disableTime: null };
+      if (tokenData.projectId) updates.projectId = tokenData.projectId;
+
+      allTokens[index] = { ...allTokens[index], ...updates };
+      await this.store.writeAll(allTokens);
+
+      await this.reload();
+      return { success: true, message: 'Token更新成功' };
+    } catch (error) {
+      log.error('[GeminiCLI] 启用Token失败:', error.message);
+      return { success: false, message: `启用失败: ${error.message}` };
+    }
+  }
+
+  /**
    * 根据 tokenId 删除 token
    * @param {string} tokenId - 安全的 token ID
    * @returns {Promise<Object>} 操作结果

--- a/src/auth/geminicli_token_manager.js
+++ b/src/auth/geminicli_token_manager.js
@@ -197,7 +197,7 @@ class GeminiCliTokenManager {
 
   /**
    * 安全刷新单个 token（不抛出异常）
-   * 
+   *
    * 错误分类策略（参考 MD 文档第 8.3 节）：
    * - 永久失效：400/401/403 或错误文本含 invalid_grant 等
    * - 临时失败：429/500/502/503/504/网络异常
@@ -222,7 +222,9 @@ class GeminiCliTokenManager {
         statusCode === 400 ||
         statusCode === 401 ||
         statusCode === 403 ||
-        PERMANENT_REFRESH_ERROR_TEXTS.some((t) => rawMessage.toLowerCase().includes(t));
+        PERMANENT_REFRESH_ERROR_TEXTS.some((t) =>
+          rawMessage.toLowerCase().includes(t),
+        );
       if (isPermanent) {
         return { action: "disable", reason };
       }
@@ -393,7 +395,7 @@ class GeminiCliTokenManager {
 
   /**
    * 通过 loadCodeAssist API 获取 projectId 和 tier 信息
-   * 
+   *
    * 优先级链（参考 MD 文档第 6 节）：
    * 1. loadCodeAssist → 提取 cloudaicompanionProject + tier
    * 2. onboardUser → 创建项目并获取 projectId
@@ -437,8 +439,7 @@ class GeminiCliTokenManager {
       const data = loadResponse.data;
 
       // 提取 tier 信息（paidTier 优先，currentTier 其次）
-      const rawTier =
-        data.paidTier?.id || data.currentTier?.id || null;
+      const rawTier = data.paidTier?.id || data.currentTier?.id || null;
       const tier = mapTier(rawTier);
       if (rawTier) {
         log.info(`[GeminiCLI] 检测到 tier: ${rawTier} -> ${tier}`);
@@ -457,13 +458,20 @@ class GeminiCliTokenManager {
 
       // 情况 B：尚未激活或无 projectId，尝试 onboardUser
       log.info("[GeminiCLI] 用户未激活，尝试 onboardUser...");
-      const onboardResult = await this._tryOnboardUser(token, headers, baseUrl, data);
+      const onboardResult = await this._tryOnboardUser(
+        token,
+        headers,
+        baseUrl,
+        data,
+      );
       if (onboardResult) {
         return { projectId: onboardResult, tier };
       }
 
       // onboardUser 也失败了，尝试 Google Cloud 项目列表
-      log.info("[GeminiCLI] onboardUser 未返回 projectId，尝试 Google Cloud 项目列表...");
+      log.info(
+        "[GeminiCLI] onboardUser 未返回 projectId，尝试 Google Cloud 项目列表...",
+      );
       const gcpProjectId = await this._tryGoogleCloudProjectList(token);
       if (gcpProjectId) {
         return { projectId: gcpProjectId, tier };
@@ -479,17 +487,26 @@ class GeminiCliTokenManager {
       }
 
       // 非致命错误时仍尝试 Google Cloud 项目列表回退
-      log.info("[GeminiCLI] loadCodeAssist 失败，尝试 Google Cloud 项目列表回退...");
+      log.info(
+        "[GeminiCLI] loadCodeAssist 失败，尝试 Google Cloud 项目列表回退...",
+      );
       try {
         const gcpProjectId = await this._tryGoogleCloudProjectList(token);
         if (gcpProjectId) {
           return { projectId: gcpProjectId, tier: null };
         }
       } catch (fallbackError) {
-        log.error(`[GeminiCLI] Google Cloud 项目列表回退也失败:`, fallbackError.message);
+        log.error(
+          `[GeminiCLI] Google Cloud 项目列表回退也失败:`,
+          fallbackError.message,
+        );
       }
 
-      throw new TokenError(`获取 projectId 失败: ${error.message}`, tokenId, status);
+      throw new TokenError(
+        `获取 projectId 失败: ${error.message}`,
+        tokenId,
+        status,
+      );
     }
   }
 
@@ -683,7 +700,11 @@ class GeminiCliTokenManager {
    */
   _handleTokenError(error, token) {
     const suffix = token.access_token?.slice(-8) || "unknown";
-    if (error.statusCode === 403 || error.statusCode === 401 || error.statusCode === 400) {
+    if (
+      error.statusCode === 403 ||
+      error.statusCode === 401 ||
+      error.statusCode === 400
+    ) {
       log.warn(
         `[GeminiCLI] ...${suffix}: Token 已失效或错误，已自动禁用该账号`,
       );
@@ -767,13 +788,15 @@ class GeminiCliTokenManager {
   async addToken(tokenData) {
     try {
       const allTokens = await this.store.readAll();
+      const salt = await this.store.getSalt();
+      const tokenId = generateTokenId(tokenData.refresh_token, salt);
 
       const newToken = {
         access_token: tokenData.access_token,
         refresh_token: tokenData.refresh_token,
         expires_in: tokenData.expires_in || 3599,
         timestamp: tokenData.timestamp || Date.now(),
-        enable: tokenData.enable !== undefined ? tokenData.enable : true,
+        enable: false,
       };
 
       if (tokenData.email) {
@@ -792,7 +815,28 @@ class GeminiCliTokenManager {
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: "Token添加成功" };
+      const enableResult = await this.enableTokenById(tokenId, {
+        stage: "oauth_submit",
+      });
+      if (!enableResult.success) {
+        return {
+          success: true,
+          saved: true,
+          validated: false,
+          disabled: true,
+          tokenId,
+          message: enableResult.message || "Token已保存到禁用池",
+        };
+      }
+
+      return {
+        success: true,
+        saved: true,
+        validated: true,
+        disabled: false,
+        tokenId,
+        message: "Token添加成功",
+      };
     } catch (error) {
       log.error("[GeminiCLI] 添加Token失败:", error.message);
       return { success: false, message: error.message };
@@ -900,9 +944,9 @@ class GeminiCliTokenManager {
 
     const effectiveTokenId =
       tokenId ||
-      (await this.store.getSalt().then((salt) =>
-        generateTokenId(tokenData.refresh_token, salt),
-      ));
+      (await this.store
+        .getSalt()
+        .then((salt) => generateTokenId(tokenData.refresh_token, salt)));
 
     // 确保 token 未过期
     if (this.isExpired(tokenData)) {
@@ -969,7 +1013,10 @@ class GeminiCliTokenManager {
     for (const token of enabledTokens) {
       const currentTokenId = generateTokenId(token.refresh_token, salt);
       try {
-        const result = await this.fetchProjectIdForTokenData(token, currentTokenId);
+        const result = await this.fetchProjectIdForTokenData(
+          token,
+          currentTokenId,
+        );
         successCount += 1;
         results.push({
           tokenId: currentTokenId,
@@ -1069,20 +1116,20 @@ class GeminiCliTokenManager {
       geminicliConfig.noStreamUrl ||
       "https://cloudcode-pa.googleapis.com/v1internal:generateContent";
 
-    const testRequestBody = {
-      model: "gemini-2.5-flash",
-      project: token.projectId,
-      request: {
-        contents: [{ role: "user", parts: [{ text: "hi" }] }],
-        generationConfig: {
-          maxOutputTokens: 1,
-          candidateCount: 1,
+    const sendRequest = async () => {
+      const testRequestBody = {
+        model: "gemini-2.5-flash",
+        project: token.projectId,
+        request: {
+          contents: [{ role: "user", parts: [{ text: "hi" }] }],
+          generationConfig: {
+            maxOutputTokens: 1,
+            candidateCount: 1,
+          },
         },
-      },
-    };
+      };
 
-    try {
-      await httpRequest({
+      return httpRequest({
         method: "POST",
         url: noStreamUrl,
         headers: {
@@ -1096,6 +1143,33 @@ class GeminiCliTokenManager {
         data: testRequestBody,
         timeout: 30000,
       });
+    };
+
+    const shouldRetryWithProjectId = (status, message) => {
+      const text = String(message || "").toLowerCase();
+      return (
+        status === 400 &&
+        (text.includes("projectid") ||
+          text.includes("project id") ||
+          text.includes("project is required") ||
+          text.includes("缺少 projectid") ||
+          text.includes("缺少 project id") ||
+          text.includes("无法获取 projectid"))
+      );
+    };
+
+    try {
+      if (!token.projectId) {
+        const result = await this.fetchProjectId(token);
+        if (result?.projectId) {
+          token.projectId = result.projectId;
+        }
+        if (result?.tier) {
+          token.tier = result.tier;
+        }
+      }
+
+      await sendRequest();
       return { ok: true };
     } catch (error) {
       const status =
@@ -1113,13 +1187,38 @@ class GeminiCliTokenManager {
         errorBody = error.message || "未知错误";
       }
 
-      if (status === 403) {
-        const isContextLimit = String(errorBody).includes(
-          "The caller does not",
-        );
-        if (!isContextLimit) {
-          return { ok: false, status, message: errorBody };
+      const errorText = String(errorBody || "");
+
+      if (shouldRetryWithProjectId(status, errorText)) {
+        try {
+          log.info(
+            "[GeminiCLI] 启动检测遇到 projectId 缺失，尝试自动获取后重试",
+          );
+          const result = await this.fetchProjectId(token);
+          if (result?.projectId) {
+            token.projectId = result.projectId;
+          }
+          if (result?.tier) {
+            token.tier = result.tier;
+          }
+          if (token.projectId) {
+            await sendRequest();
+            return { ok: true };
+          }
+        } catch (retryError) {
+          log.warn(
+            `[GeminiCLI] 自动获取 projectId 后重试失败: ${retryError.message}`,
+          );
         }
+      }
+
+      const isContextLimit =
+        status === 403 && errorText.includes("The caller does not");
+      const shouldDisable =
+        (status === 400 || status === 401 || status === 403) && !isContextLimit;
+
+      if (shouldDisable) {
+        return { ok: false, status, message: errorText };
       }
 
       // 其他非致命状态码不阻止启用
@@ -1132,9 +1231,10 @@ class GeminiCliTokenManager {
    * @param {string} tokenId - 安全的 token ID
    * @returns {Promise<Object>} 操作结果
    */
-  async enableTokenById(tokenId) {
+  async enableTokenById(tokenId, options = {}) {
     try {
       const tokenData = await this.findTokenById(tokenId);
+      const errorStage = options.stage || "enable_test";
 
       // 辅助函数：将启用验证失败的错误信息写入凭证存储
       const saveEnableError = async (errorMessage) => {
@@ -1145,11 +1245,15 @@ class GeminiCliTokenManager {
             (token) => generateTokenId(token.refresh_token, salt) === tokenId,
           );
           if (index !== -1) {
+            const errorTime = Date.now();
             allTokens[index] = {
               ...allTokens[index],
+              enable: false,
+              disableReason: errorMessage,
+              disableTime: errorTime,
               lastError: errorMessage,
-              lastErrorTime: new Date().toISOString(),
-              lastErrorStage: "enable_test",
+              lastErrorTime: errorTime,
+              lastErrorStage: errorStage,
             };
             await this.store.writeAll(allTokens);
             await this.reload();

--- a/src/auth/geminicli_token_manager.js
+++ b/src/auth/geminicli_token_manager.js
@@ -118,16 +118,18 @@ class GeminiCliTokenManager {
     let successCount = 0;
     let failCount = 0;
     const tokensToDisable = [];
+    const disableReasons = [];
     const failedTokenIds = [];
 
     results.forEach((result, index) => {
       const token = expiredTokens[index];
       const tokenId = tokenIds[index];
       if (result.status === 'fulfilled') {
-        if (result.value === 'success') {
+        if (result.value.action === 'success') {
           successCount++;
-        } else if (result.value === 'disable') {
+        } else if (result.value.action === 'disable') {
           tokensToDisable.push(token);
+          disableReasons.push(result.value.reason || 'Token刷新失败');
           failCount++;
           failedTokenIds.push(tokenId);
         }
@@ -138,8 +140,8 @@ class GeminiCliTokenManager {
     });
 
     // 批量禁用失效的 token
-    for (const token of tokensToDisable) {
-      this.disableToken(token);
+    for (let i = 0; i < tokensToDisable.length; i++) {
+      this.disableToken(tokensToDisable[i], disableReasons[i]);
     }
 
     const elapsed = Date.now() - startTime;
@@ -153,16 +155,16 @@ class GeminiCliTokenManager {
   /**
    * 安全刷新单个 token（不抛出异常）
    * @param {Object} token - Token 对象
-   * @returns {Promise<'success'|'disable'|'skip'>} 刷新结果
+   * @returns {Promise<{action: 'success'|'disable'|'skip', reason?: string}>} 刷新结果
    * @private
    */
   async _refreshTokenSafe(token) {
     try {
       await this.refreshToken(token, true);
-      return 'success';
+      return { action: 'success' };
     } catch (error) {
       if (error.statusCode === 403 || error.statusCode === 400) {
-        return 'disable';
+        return { action: 'disable', reason: `Token刷新失败(${error.statusCode}): ${error.message}` };
       }
       throw error;
     }
@@ -267,9 +269,11 @@ class GeminiCliTokenManager {
     });
   }
 
-  disableToken(token) {
-    log.warn(`[GeminiCLI] 禁用token ...${token.access_token.slice(-8)}`);
+  disableToken(token, reason = '未知原因') {
+    log.warn(`[GeminiCLI] 禁用token ...${token.access_token.slice(-8)}, 原因: ${reason}`);
     token.enable = false;
+    token.disableReason = reason;
+    token.disableTime = Date.now();
     this.saveToFile();
     this.tokenRequestCounts.delete(token.refresh_token);
     this.tokens = this.tokens.filter(t => t.refresh_token !== token.refresh_token);
@@ -444,7 +448,7 @@ class GeminiCliTokenManager {
   /**
    * 准备单个 token（刷新 + 获取 projectId）
    * @param {Object} token - Token 对象
-   * @returns {Promise<'ready'|'disable'>} 处理结果
+   * @returns {Promise<{action: 'ready'|'disable', reason?: string}>} 处理结果
    * @private
    */
   async _prepareToken(token) {
@@ -458,30 +462,30 @@ class GeminiCliTokenManager {
       const projectId = await this.fetchProjectId(token);
       if (!projectId) {
         log.warn(`[GeminiCLI] 无法获取 projectId，禁用账号`);
-        return 'disable';
+        return { action: 'disable', reason: '无法获取projectId，该账号可能不支持 Gemini CLI' };
       }
       token.projectId = projectId;
       this.saveToFile(token);
     }
 
-    return 'ready';
+    return { action: 'ready' };
   }
 
   /**
    * 处理 token 准备过程中的错误
    * @param {Error} error - 错误对象
    * @param {Object} token - Token 对象
-   * @returns {'disable'|'skip'} 处理结果
+   * @returns {{action: 'disable'|'skip', reason?: string}} 处理结果
    * @private
    */
   _handleTokenError(error, token) {
     const suffix = token.access_token?.slice(-8) || 'unknown';
     if (error.statusCode === 403 || error.statusCode === 400) {
       log.warn(`[GeminiCLI] ...${suffix}: Token 已失效或错误，已自动禁用该账号`);
-      return 'disable';
+      return { action: 'disable', reason: `Token准备失败(${error.statusCode}): ${error.message}` };
     }
     log.error(`[GeminiCLI] ...${suffix} 操作失败:`, error.message);
-    return 'skip';
+    return { action: 'skip' };
   }
 
   /**
@@ -501,8 +505,8 @@ class GeminiCliTokenManager {
 
       try {
         const result = await this._prepareToken(token);
-        if (result === 'disable') {
-          this.disableToken(token);
+        if (result.action === 'disable') {
+          this.disableToken(token, result.reason);
           if (this.tokens.length === 0) return null;
           continue;
         }
@@ -524,9 +528,9 @@ class GeminiCliTokenManager {
 
         return token;
       } catch (error) {
-        const action = this._handleTokenError(error, token);
-        if (action === 'disable') {
-          this.disableToken(token);
+        const errorResult = this._handleTokenError(error, token);
+        if (errorResult.action === 'disable') {
+          this.disableToken(token, errorResult.reason);
           if (this.tokens.length === 0) return null;
         }
         // skip: 继续尝试下一个 token
@@ -536,10 +540,10 @@ class GeminiCliTokenManager {
     return null;
   }
 
-  disableCurrentToken(token) {
+  disableCurrentToken(token, reason = 'API请求返回403，账号无使用权限') {
     const found = this.tokens.find(t => t.access_token === token.access_token);
     if (found) {
-      this.disableToken(found);
+      this.disableToken(found, reason);
     }
   }
 
@@ -590,6 +594,12 @@ class GeminiCliTokenManager {
         return { success: false, message: 'Token不存在' };
       }
 
+      // 重新启用时清除禁用原因
+      if (updates.enable === true) {
+        updates.disableReason = null;
+        updates.disableTime = null;
+      }
+
       allTokens[index] = { ...allTokens[index], ...updates };
       await this.store.writeAll(allTokens);
 
@@ -631,7 +641,9 @@ class GeminiCliTokenManager {
         timestamp: token.timestamp,
         enable: token.enable !== false,
         email: token.email || null,
-        projectId: token.projectId || null
+        projectId: token.projectId || null,
+        disableReason: token.disableReason || null,
+        disableTime: token.disableTime || null
       }));
     } catch (error) {
       log.error('[GeminiCLI] 获取Token列表失败:', error.message);
@@ -719,6 +731,12 @@ class GeminiCliTokenManager {
 
       if (index === -1) {
         return { success: false, message: 'Token不存在' };
+      }
+
+      // 重新启用时清除禁用原因
+      if (updates.enable === true) {
+        updates.disableReason = null;
+        updates.disableTime = null;
       }
 
       allTokens[index] = { ...allTokens[index], ...updates };

--- a/src/auth/geminicli_token_manager.js
+++ b/src/auth/geminicli_token_manager.js
@@ -1,30 +1,30 @@
-import axios from 'axios';
-import path from 'path';
-import { log } from '../utils/logger.js';
-import { generateTokenId } from '../utils/idGenerator.js';
-import config, { getConfigJson } from '../config/config.js';
-import { GEMINICLI_OAUTH_CONFIG } from '../constants/oauth.js';
-import { buildAxiosRequestConfig, httpRequest } from '../utils/httpClient.js';
+import axios from "axios";
+import path from "path";
+import config, { getConfigJson } from "../config/config.js";
 import {
   DEFAULT_REQUEST_COUNT_PER_TOKEN,
-  TOKEN_REFRESH_BUFFER
-} from '../constants/index.js';
-import TokenStore from './token_store.js';
-import { TokenError } from '../utils/errors.js';
-import { getDataDir } from '../utils/paths.js';
+  TOKEN_REFRESH_BUFFER,
+} from "../constants/index.js";
+import { GEMINICLI_OAUTH_CONFIG } from "../constants/oauth.js";
+import { TokenError } from "../utils/errors.js";
+import { buildAxiosRequestConfig, httpRequest } from "../utils/httpClient.js";
+import { generateTokenId } from "../utils/idGenerator.js";
+import { log } from "../utils/logger.js";
+import { getDataDir } from "../utils/paths.js";
+import TokenStore from "./token_store.js";
 
 // Gemini CLI API 配置
 const GEMINICLI_API_CONFIG = {
-  HOST: 'cloudcode-pa.googleapis.com',
-  USER_AGENT: 'GeminiCLI/0.1.5 (Windows; AMD64)',
-  BASE_URL: 'https://cloudcode-pa.googleapis.com'
+  HOST: "cloudcode-pa.googleapis.com",
+  USER_AGENT: "GeminiCLI/0.1.5 (Windows; AMD64)",
+  BASE_URL: "https://cloudcode-pa.googleapis.com",
 };
 
 // 轮询策略枚举（复用 token_manager.js 的定义）
 const RotationStrategy = {
-  ROUND_ROBIN: 'round_robin',           // 均衡负载：每次请求切换
-  QUOTA_EXHAUSTED: 'quota_exhausted',   // 额度耗尽才切换
-  REQUEST_COUNT: 'request_count'        // 自定义次数后切换
+  ROUND_ROBIN: "round_robin", // 均衡负载：每次请求切换
+  QUOTA_EXHAUSTED: "quota_exhausted", // 额度耗尽才切换
+  REQUEST_COUNT: "request_count", // 自定义次数后切换
 };
 
 /**
@@ -39,7 +39,7 @@ class GeminiCliTokenManager {
   /**
    * @param {string} filePath - Token 数据文件路径
    */
-  constructor(filePath = path.join(getDataDir(), 'geminicli_accounts.json')) {
+  constructor(filePath = path.join(getDataDir(), "geminicli_accounts.json")) {
     this.store = new TokenStore(filePath);
     /** @type {Array<Object>} */
     this.tokens = [];
@@ -60,13 +60,15 @@ class GeminiCliTokenManager {
 
   async _initialize() {
     try {
-      log.info('[GeminiCLI] 正在初始化token管理器...');
+      log.info("[GeminiCLI] 正在初始化token管理器...");
       const tokenArray = await this.store.readAll();
 
       // Gemini CLI 不需要 sessionId
-      this.tokens = tokenArray.filter(token => token.enable !== false).map(token => ({
-        ...token
-      }));
+      this.tokens = tokenArray
+        .filter((token) => token.enable !== false)
+        .map((token) => ({
+          ...token,
+        }));
 
       this.currentIndex = 0;
       this.tokenRequestCounts.clear();
@@ -75,13 +77,15 @@ class GeminiCliTokenManager {
       this.loadRotationConfig();
 
       if (this.tokens.length === 0) {
-        log.warn('[GeminiCLI] ⚠ 暂无可用账号，请使用以下方式添加：');
-        log.warn('[GeminiCLI]   方式1: 访问前端管理页面添加账号');
-        log.warn('[GeminiCLI]   方式2: 手动编辑 geminicli_accounts.json');
+        log.warn("[GeminiCLI] ⚠ 暂无可用账号，请使用以下方式添加：");
+        log.warn("[GeminiCLI]   方式1: 访问前端管理页面添加账号");
+        log.warn("[GeminiCLI]   方式2: 手动编辑 geminicli_accounts.json");
       } else {
         log.info(`[GeminiCLI] 成功加载 ${this.tokens.length} 个可用token`);
         if (this.rotationStrategy === RotationStrategy.REQUEST_COUNT) {
-          log.info(`[GeminiCLI] 轮询策略: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`);
+          log.info(
+            `[GeminiCLI] 轮询策略: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`,
+          );
         } else {
           log.info(`[GeminiCLI] 轮询策略: ${this.rotationStrategy}`);
         }
@@ -90,7 +94,7 @@ class GeminiCliTokenManager {
         await this._refreshExpiredTokensConcurrently();
       }
     } catch (error) {
-      log.error('[GeminiCLI] 初始化token失败:', error.message);
+      log.error("[GeminiCLI] 初始化token失败:", error.message);
       this.tokens = [];
     }
   }
@@ -100,19 +104,23 @@ class GeminiCliTokenManager {
    * @private
    */
   async _refreshExpiredTokensConcurrently() {
-    const expiredTokens = this.tokens.filter(token => this.isExpired(token));
+    const expiredTokens = this.tokens.filter((token) => this.isExpired(token));
     if (expiredTokens.length === 0) {
       return;
     }
 
     const salt = await this.store.getSalt();
-    const tokenIds = expiredTokens.map(token => generateTokenId(token.refresh_token, salt));
+    const tokenIds = expiredTokens.map((token) =>
+      generateTokenId(token.refresh_token, salt),
+    );
 
-    log.info(`[GeminiCLI] 正在批量刷新 ${tokenIds.length} 个token: ${tokenIds.join(', ')}`);
+    log.info(
+      `[GeminiCLI] 正在批量刷新 ${tokenIds.length} 个token: ${tokenIds.join(", ")}`,
+    );
     const startTime = Date.now();
 
     const results = await Promise.allSettled(
-      expiredTokens.map(token => this._refreshTokenSafe(token))
+      expiredTokens.map((token) => this._refreshTokenSafe(token)),
     );
 
     let successCount = 0;
@@ -124,12 +132,15 @@ class GeminiCliTokenManager {
     results.forEach((result, index) => {
       const token = expiredTokens[index];
       const tokenId = tokenIds[index];
-      if (result.status === 'fulfilled') {
-        if (result.value.action === 'success') {
+      if (result.status === "fulfilled") {
+        if (result.value.action === "success") {
           successCount++;
-        } else if (result.value.action === 'disable') {
+        } else if (result.value.action === "disable") {
           tokensToDisable.push(token);
-          disableReasons.push(result.value.reason || 'Token刷新失败');
+          disableReasons.push(result.value.reason || "Token刷新失败");
+          failCount++;
+          failedTokenIds.push(tokenId);
+        } else if (result.value.action === "skip") {
           failCount++;
           failedTokenIds.push(tokenId);
         }
@@ -146,7 +157,9 @@ class GeminiCliTokenManager {
 
     const elapsed = Date.now() - startTime;
     if (failCount > 0) {
-      log.warn(`[GeminiCLI] 刷新完成: 成功 ${successCount}, 失败 ${failCount} (${failedTokenIds.join(', ')}), 耗时 ${elapsed}ms`);
+      log.warn(
+        `[GeminiCLI] 刷新完成: 成功 ${successCount}, 失败 ${failCount} (${failedTokenIds.join(", ")}), 耗时 ${elapsed}ms`,
+      );
     } else {
       log.info(`[GeminiCLI] 刷新完成: 成功 ${successCount}, 耗时 ${elapsed}ms`);
     }
@@ -161,12 +174,37 @@ class GeminiCliTokenManager {
   async _refreshTokenSafe(token) {
     try {
       await this.refreshToken(token, true);
-      return { action: 'success' };
+      this._clearTokenError(token);
+      return { action: "success" };
     } catch (error) {
-      if (error.statusCode === 403 || error.statusCode === 400) {
-        return { action: 'disable', reason: `Token刷新失败(${error.statusCode}): ${error.message}` };
+      const statusCode =
+        error.statusCode || error.response?.status || error.status || 500;
+      const rawMessage = error.message || "未知错误";
+      const reason = `启动检测刷新失败(${statusCode}): ${rawMessage}`;
+      this._recordTokenError(token, reason, "startup_refresh");
+      if (statusCode === 403 || statusCode === 400) {
+        return { action: "disable", reason };
       }
-      throw error;
+      return { action: "skip", reason };
+    }
+  }
+
+  _recordTokenError(token, message, stage = "startup_refresh") {
+    if (!token) return;
+    const trimmed = String(message || "未知错误").slice(0, 800);
+    token.lastError = trimmed;
+    token.lastErrorTime = Date.now();
+    token.lastErrorStage = stage;
+    this.saveToFile(token);
+  }
+
+  _clearTokenError(token) {
+    if (!token) return;
+    if (token.lastError || token.lastErrorTime || token.lastErrorStage) {
+      token.lastError = null;
+      token.lastErrorTime = null;
+      token.lastErrorStage = null;
+      this.saveToFile(token);
     }
   }
 
@@ -182,13 +220,15 @@ class GeminiCliTokenManager {
     try {
       const jsonConfig = getConfigJson();
       // 优先使用 geminicli 专属配置，否则使用全局配置
-      const rotationConfig = jsonConfig.geminicli?.rotation || jsonConfig.rotation;
+      const rotationConfig =
+        jsonConfig.geminicli?.rotation || jsonConfig.rotation;
       if (rotationConfig) {
-        this.rotationStrategy = rotationConfig.strategy || RotationStrategy.ROUND_ROBIN;
+        this.rotationStrategy =
+          rotationConfig.strategy || RotationStrategy.ROUND_ROBIN;
         this.requestCountPerToken = rotationConfig.requestCount || 10;
       }
     } catch (error) {
-      log.warn('[GeminiCLI] 加载轮询配置失败，使用默认值:', error.message);
+      log.warn("[GeminiCLI] 加载轮询配置失败，使用默认值:", error.message);
     }
   }
 
@@ -202,7 +242,9 @@ class GeminiCliTokenManager {
     }
     this.tokenRequestCounts.clear();
     if (this.rotationStrategy === RotationStrategy.REQUEST_COUNT) {
-      log.info(`[GeminiCLI] 轮询策略已更新: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`);
+      log.info(
+        `[GeminiCLI] 轮询策略已更新: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`,
+      );
     } else {
       log.info(`[GeminiCLI] 轮询策略已更新: ${this.rotationStrategy}`);
     }
@@ -215,7 +257,7 @@ class GeminiCliTokenManager {
    */
   isExpired(token) {
     if (!token.timestamp || !token.expires_in) return true;
-    const expiresAt = token.timestamp + (token.expires_in * 1000);
+    const expiresAt = token.timestamp + token.expires_in * 1000;
     return Date.now() >= expiresAt - TOKEN_REFRESH_BUFFER;
   }
 
@@ -233,22 +275,24 @@ class GeminiCliTokenManager {
     const body = new URLSearchParams({
       client_id: GEMINICLI_OAUTH_CONFIG.CLIENT_ID,
       client_secret: GEMINICLI_OAUTH_CONFIG.CLIENT_SECRET,
-      grant_type: 'refresh_token',
-      refresh_token: token.refresh_token
+      grant_type: "refresh_token",
+      refresh_token: token.refresh_token,
     });
 
     try {
-      const response = await axios(buildAxiosRequestConfig({
-        method: 'POST',
-        url: GEMINICLI_OAUTH_CONFIG.TOKEN_URL,
-        headers: {
-          'Host': 'oauth2.googleapis.com',
-          'User-Agent': 'google-oauth-playground',
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept-Encoding': 'gzip'
-        },
-        data: body.toString()
-      }));
+      const response = await axios(
+        buildAxiosRequestConfig({
+          method: "POST",
+          url: GEMINICLI_OAUTH_CONFIG.TOKEN_URL,
+          headers: {
+            Host: "oauth2.googleapis.com",
+            "User-Agent": "google-oauth-playground",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept-Encoding": "gzip",
+          },
+          data: body.toString(),
+        }),
+      );
 
       token.access_token = response.data.access_token;
       token.expires_in = response.data.expires_in;
@@ -256,27 +300,40 @@ class GeminiCliTokenManager {
       this.saveToFile(token);
       return token;
     } catch (error) {
-      const statusCode = error.response?.status;
+      const statusCode =
+        error.response?.status || error.status || error.statusCode || 500;
       const rawBody = error.response?.data;
-      const message = typeof rawBody === 'string' ? rawBody : (rawBody?.error?.message || error.message || '刷新 token 失败');
+      const message =
+        typeof rawBody === "string"
+          ? rawBody
+          : rawBody?.error?.message || error.message || "刷新 token 失败";
+      const reason = `启动检测刷新失败(${statusCode}): ${message}`;
+      this._recordTokenError(token, reason, "startup_refresh");
       throw new TokenError(message, tokenId, statusCode || 500);
     }
   }
 
   saveToFile(tokenToUpdate = null) {
     this.store.mergeActiveTokens(this.tokens, tokenToUpdate).catch((error) => {
-      log.error('[GeminiCLI] 保存账号配置文件失败:', error.message);
+      log.error("[GeminiCLI] 保存账号配置文件失败:", error.message);
     });
   }
 
-  disableToken(token, reason = '未知原因') {
-    log.warn(`[GeminiCLI] 禁用token ...${token.access_token.slice(-8)}, 原因: ${reason}`);
+  disableToken(token, reason = "未知原因") {
+    log.warn(
+      `[GeminiCLI] 禁用token ...${token.access_token.slice(-8)}, 原因: ${reason}`,
+    );
     token.enable = false;
     token.disableReason = reason;
     token.disableTime = Date.now();
+    token.lastError = reason;
+    token.lastErrorTime = token.disableTime;
+    token.lastErrorStage = "disable";
     this.saveToFile();
     this.tokenRequestCounts.delete(token.refresh_token);
-    this.tokens = this.tokens.filter(t => t.refresh_token !== token.refresh_token);
+    this.tokens = this.tokens.filter(
+      (t) => t.refresh_token !== token.refresh_token,
+    );
     this.currentIndex = this.currentIndex % Math.max(this.tokens.length, 1);
   }
 
@@ -308,32 +365,33 @@ class GeminiCliTokenManager {
     const url = `${baseUrl}/v1internal:loadCodeAssist`;
 
     const headers = {
-      'Host': geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
-      'User-Agent': geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
-      'Authorization': `Bearer ${token.access_token}`,
-      'Content-Type': 'application/json',
-      'Accept-Encoding': 'gzip'
+      Host: geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
+      "User-Agent":
+        geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
+      Authorization: `Bearer ${token.access_token}`,
+      "Content-Type": "application/json",
+      "Accept-Encoding": "gzip",
     };
 
     const requestBody = {
       metadata: {
-        ideType: 'ANTIGRAVITY',
-        platform: 'PLATFORM_UNSPECIFIED',
-        pluginType: 'GEMINI'
-      }
+        ideType: "ANTIGRAVITY",
+        platform: "PLATFORM_UNSPECIFIED",
+        pluginType: "GEMINI",
+      },
     };
 
     try {
       const response = await httpRequest({
-        method: 'POST',
+        method: "POST",
         url,
         headers,
         data: requestBody,
-        timeout: 30000
+        timeout: 30000,
       });
 
       const data = response.data;
-      
+
       // 检查是否有 currentTier（表示用户已激活）
       if (data.currentTier) {
         const projectId = data.cloudaicompanionProject;
@@ -341,21 +399,25 @@ class GeminiCliTokenManager {
           log.info(`[GeminiCLI] 成功获取 projectId: ${projectId}`);
           return projectId;
         }
-        log.warn('[GeminiCLI] loadCodeAssist 响应中无 projectId');
+        log.warn("[GeminiCLI] loadCodeAssist 响应中无 projectId");
         return null;
       }
 
       // 用户未激活，尝试 onboardUser
-      log.info('[GeminiCLI] 用户未激活，尝试 onboardUser...');
+      log.info("[GeminiCLI] 用户未激活，尝试 onboardUser...");
       return await this._tryOnboardUser(token, data);
     } catch (error) {
       const status = error.response?.status || error.status || 500;
       log.error(`[GeminiCLI] 获取 projectId 失败 (${status}):`, error.message);
-      
+
       if (status === 403 || status === 401) {
-        throw new TokenError('Token 无权限获取 projectId', tokenId, status);
+        throw new TokenError("Token 无权限获取 projectId", tokenId, status);
       }
-      throw new TokenError(`获取 projectId 失败: ${error.message}`, tokenId, status);
+      throw new TokenError(
+        `获取 projectId 失败: ${error.message}`,
+        tokenId,
+        status,
+      );
     }
   }
 
@@ -372,15 +434,16 @@ class GeminiCliTokenManager {
     const url = `${baseUrl}/v1internal:onboardUser`;
 
     const headers = {
-      'Host': geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
-      'User-Agent': geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
-      'Authorization': `Bearer ${token.access_token}`,
-      'Content-Type': 'application/json',
-      'Accept-Encoding': 'gzip'
+      Host: geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
+      "User-Agent":
+        geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
+      Authorization: `Bearer ${token.access_token}`,
+      "Content-Type": "application/json",
+      "Accept-Encoding": "gzip",
     };
 
     // 从 loadCodeAssist 响应中获取默认 tier
-    let tierId = 'LEGACY';
+    let tierId = "LEGACY";
     const allowedTiers = loadCodeAssistData?.allowedTiers || [];
     for (const tier of allowedTiers) {
       if (tier.isDefault) {
@@ -392,10 +455,10 @@ class GeminiCliTokenManager {
     const requestBody = {
       tierId,
       metadata: {
-        ideType: 'ANTIGRAVITY',
-        platform: 'PLATFORM_UNSPECIFIED',
-        pluginType: 'GEMINI'
-      }
+        ideType: "ANTIGRAVITY",
+        platform: "PLATFORM_UNSPECIFIED",
+        pluginType: "GEMINI",
+      },
     };
 
     // onboardUser 是长时间运行操作，需要轮询
@@ -405,11 +468,11 @@ class GeminiCliTokenManager {
 
       try {
         const response = await httpRequest({
-          method: 'POST',
+          method: "POST",
           url,
           headers,
           data: requestBody,
-          timeout: 30000
+          timeout: 30000,
         });
 
         const data = response.data;
@@ -419,29 +482,31 @@ class GeminiCliTokenManager {
           const projectObj = responseData.cloudaicompanionProject;
 
           let projectId = null;
-          if (typeof projectObj === 'object' && projectObj !== null) {
+          if (typeof projectObj === "object" && projectObj !== null) {
             projectId = projectObj.id;
-          } else if (typeof projectObj === 'string') {
+          } else if (typeof projectObj === "string") {
             projectId = projectObj;
           }
 
           if (projectId) {
-            log.info(`[GeminiCLI] onboardUser 成功获取 projectId: ${projectId}`);
+            log.info(
+              `[GeminiCLI] onboardUser 成功获取 projectId: ${projectId}`,
+            );
             return projectId;
           }
-          log.warn('[GeminiCLI] onboardUser 完成但响应中无 projectId');
+          log.warn("[GeminiCLI] onboardUser 完成但响应中无 projectId");
           return null;
         }
 
         // 操作未完成，等待后重试
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        await new Promise((resolve) => setTimeout(resolve, 2000));
       } catch (error) {
         log.error(`[GeminiCLI] onboardUser 失败:`, error.message);
         throw error;
       }
     }
 
-    log.error('[GeminiCLI] onboardUser 超时');
+    log.error("[GeminiCLI] onboardUser 超时");
     return null;
   }
 
@@ -462,13 +527,16 @@ class GeminiCliTokenManager {
       const projectId = await this.fetchProjectId(token);
       if (!projectId) {
         log.warn(`[GeminiCLI] 无法获取 projectId，禁用账号`);
-        return { action: 'disable', reason: '无法获取projectId，该账号可能不支持 Gemini CLI' };
+        return {
+          action: "disable",
+          reason: "无法获取projectId，该账号可能不支持 Gemini CLI",
+        };
       }
       token.projectId = projectId;
       this.saveToFile(token);
     }
 
-    return { action: 'ready' };
+    return { action: "ready" };
   }
 
   /**
@@ -479,13 +547,18 @@ class GeminiCliTokenManager {
    * @private
    */
   _handleTokenError(error, token) {
-    const suffix = token.access_token?.slice(-8) || 'unknown';
+    const suffix = token.access_token?.slice(-8) || "unknown";
     if (error.statusCode === 403 || error.statusCode === 400) {
-      log.warn(`[GeminiCLI] ...${suffix}: Token 已失效或错误，已自动禁用该账号`);
-      return { action: 'disable', reason: `Token准备失败(${error.statusCode}): ${error.message}` };
+      log.warn(
+        `[GeminiCLI] ...${suffix}: Token 已失效或错误，已自动禁用该账号`,
+      );
+      return {
+        action: "disable",
+        reason: `Token准备失败(${error.statusCode}): ${error.message}`,
+      };
     }
     log.error(`[GeminiCLI] ...${suffix} 操作失败:`, error.message);
-    return { action: 'skip' };
+    return { action: "skip" };
   }
 
   /**
@@ -505,7 +578,7 @@ class GeminiCliTokenManager {
 
       try {
         const result = await this._prepareToken(token);
-        if (result.action === 'disable') {
+        if (result.action === "disable") {
           this.disableToken(token, result.reason);
           if (this.tokens.length === 0) return null;
           continue;
@@ -529,7 +602,7 @@ class GeminiCliTokenManager {
         return token;
       } catch (error) {
         const errorResult = this._handleTokenError(error, token);
-        if (errorResult.action === 'disable') {
+        if (errorResult.action === "disable") {
           this.disableToken(token, errorResult.reason);
           if (this.tokens.length === 0) return null;
         }
@@ -540,8 +613,10 @@ class GeminiCliTokenManager {
     return null;
   }
 
-  disableCurrentToken(token, reason = 'API请求返回403，账号无使用权限') {
-    const found = this.tokens.find(t => t.access_token === token.access_token);
+  disableCurrentToken(token, reason = "API请求返回403，账号无使用权限") {
+    const found = this.tokens.find(
+      (t) => t.access_token === token.access_token,
+    );
     if (found) {
       this.disableToken(found, reason);
     }
@@ -551,7 +626,7 @@ class GeminiCliTokenManager {
   async reload() {
     this._initPromise = this._initialize();
     await this._initPromise;
-    log.info('[GeminiCLI] Token已热重载');
+    log.info("[GeminiCLI] Token已热重载");
   }
 
   async addToken(tokenData) {
@@ -563,7 +638,7 @@ class GeminiCliTokenManager {
         refresh_token: tokenData.refresh_token,
         expires_in: tokenData.expires_in || 3599,
         timestamp: tokenData.timestamp || Date.now(),
-        enable: tokenData.enable !== undefined ? tokenData.enable : true
+        enable: tokenData.enable !== undefined ? tokenData.enable : true,
       };
 
       if (tokenData.email) {
@@ -578,9 +653,9 @@ class GeminiCliTokenManager {
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token添加成功' };
+      return { success: true, message: "Token添加成功" };
     } catch (error) {
-      log.error('[GeminiCLI] 添加Token失败:', error.message);
+      log.error("[GeminiCLI] 添加Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -589,9 +664,11 @@ class GeminiCliTokenManager {
     try {
       const allTokens = await this.store.readAll();
 
-      const index = allTokens.findIndex(t => t.refresh_token === refreshToken);
+      const index = allTokens.findIndex(
+        (t) => t.refresh_token === refreshToken,
+      );
       if (index === -1) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       // 重新启用时清除禁用原因
@@ -604,9 +681,9 @@ class GeminiCliTokenManager {
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token更新成功' };
+      return { success: true, message: "Token更新成功" };
     } catch (error) {
-      log.error('[GeminiCLI] 更新Token失败:', error.message);
+      log.error("[GeminiCLI] 更新Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -615,17 +692,19 @@ class GeminiCliTokenManager {
     try {
       const allTokens = await this.store.readAll();
 
-      const filteredTokens = allTokens.filter(t => t.refresh_token !== refreshToken);
+      const filteredTokens = allTokens.filter(
+        (t) => t.refresh_token !== refreshToken,
+      );
       if (filteredTokens.length === allTokens.length) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       await this.store.writeAll(filteredTokens);
 
       await this.reload();
-      return { success: true, message: 'Token删除成功' };
+      return { success: true, message: "Token删除成功" };
     } catch (error) {
-      log.error('[GeminiCLI] 删除Token失败:', error.message);
+      log.error("[GeminiCLI] 删除Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -635,7 +714,7 @@ class GeminiCliTokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      return allTokens.map(token => ({
+      return allTokens.map((token) => ({
         id: generateTokenId(token.refresh_token, salt),
         expires_in: token.expires_in,
         timestamp: token.timestamp,
@@ -643,10 +722,13 @@ class GeminiCliTokenManager {
         email: token.email || null,
         projectId: token.projectId || null,
         disableReason: token.disableReason || null,
-        disableTime: token.disableTime || null
+        disableTime: token.disableTime || null,
+        lastError: token.lastError || null,
+        lastErrorTime: token.lastErrorTime || null,
+        lastErrorStage: token.lastErrorStage || null,
       }));
     } catch (error) {
-      log.error('[GeminiCLI] 获取Token列表失败:', error.message);
+      log.error("[GeminiCLI] 获取Token列表失败:", error.message);
       return [];
     }
   }
@@ -659,7 +741,7 @@ class GeminiCliTokenManager {
   async fetchProjectIdForToken(tokenId) {
     const tokenData = await this.findTokenById(tokenId);
     if (!tokenData) {
-      throw new TokenError('Token不存在', null, 404);
+      throw new TokenError("Token不存在", null, 404);
     }
 
     // 确保 token 未过期
@@ -669,17 +751,17 @@ class GeminiCliTokenManager {
 
     const projectId = await this.fetchProjectId(tokenData);
     if (!projectId) {
-      throw new TokenError('无法获取 projectId，该账号可能无资格', null, 400);
+      throw new TokenError("无法获取 projectId，该账号可能无资格", null, 400);
     }
 
     // 更新并保存
     tokenData.projectId = projectId;
-    
+
     // 更新文件
     const allTokens = await this.store.readAll();
     const salt = await this.store.getSalt();
-    const index = allTokens.findIndex(t =>
-      generateTokenId(t.refresh_token, salt) === tokenId
+    const index = allTokens.findIndex(
+      (t) => generateTokenId(t.refresh_token, salt) === tokenId,
     );
     if (index !== -1) {
       allTokens[index].projectId = projectId;
@@ -687,7 +769,9 @@ class GeminiCliTokenManager {
     }
 
     // 更新内存中的 token
-    const memoryToken = this.tokens.find(t => t.refresh_token === tokenData.refresh_token);
+    const memoryToken = this.tokens.find(
+      (t) => t.refresh_token === tokenData.refresh_token,
+    );
     if (memoryToken) {
       memoryToken.projectId = projectId;
     }
@@ -705,11 +789,13 @@ class GeminiCliTokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      return allTokens.find(token =>
-        generateTokenId(token.refresh_token, salt) === tokenId
-      ) || null;
+      return (
+        allTokens.find(
+          (token) => generateTokenId(token.refresh_token, salt) === tokenId,
+        ) || null
+      );
     } catch (error) {
-      log.error('[GeminiCLI] 查找Token失败:', error.message);
+      log.error("[GeminiCLI] 查找Token失败:", error.message);
       return null;
     }
   }
@@ -725,27 +811,30 @@ class GeminiCliTokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      const index = allTokens.findIndex(token =>
-        generateTokenId(token.refresh_token, salt) === tokenId
+      const index = allTokens.findIndex(
+        (token) => generateTokenId(token.refresh_token, salt) === tokenId,
       );
 
       if (index === -1) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       // 重新启用时清除禁用原因
       if (updates.enable === true) {
         updates.disableReason = null;
         updates.disableTime = null;
+        updates.lastError = null;
+        updates.lastErrorTime = null;
+        updates.lastErrorStage = null;
       }
 
       allTokens[index] = { ...allTokens[index], ...updates };
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token更新成功' };
+      return { success: true, message: "Token更新成功" };
     } catch (error) {
-      log.error('[GeminiCLI] 更新Token失败:', error.message);
+      log.error("[GeminiCLI] 更新Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -759,50 +848,58 @@ class GeminiCliTokenManager {
    */
   async _sendTestMessage(token) {
     const geminicliConfig = config.geminicli?.api || {};
-    const noStreamUrl = geminicliConfig.noStreamUrl
-      || 'https://cloudcode-pa.googleapis.com/v1internal:generateContent';
+    const noStreamUrl =
+      geminicliConfig.noStreamUrl ||
+      "https://cloudcode-pa.googleapis.com/v1internal:generateContent";
 
     const testRequestBody = {
-      model: 'gemini-2.5-flash',
+      model: "gemini-2.5-flash",
       project: token.projectId,
       request: {
-        contents: [
-          { role: 'user', parts: [{ text: 'hi' }] }
-        ],
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
         generationConfig: {
           maxOutputTokens: 1,
-          candidateCount: 1
-        }
-      }
+          candidateCount: 1,
+        },
+      },
     };
 
     try {
       await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: noStreamUrl,
         headers: {
-          'Host': geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
-          'User-Agent': geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
-          'Authorization': `Bearer ${token.access_token}`,
-          'Content-Type': 'application/json',
-          'Accept-Encoding': 'gzip'
+          Host: geminicliConfig.host || GEMINICLI_API_CONFIG.HOST,
+          "User-Agent":
+            geminicliConfig.userAgent || GEMINICLI_API_CONFIG.USER_AGENT,
+          Authorization: `Bearer ${token.access_token}`,
+          "Content-Type": "application/json",
+          "Accept-Encoding": "gzip",
         },
         data: testRequestBody,
-        timeout: 30000
+        timeout: 30000,
       });
       return { ok: true };
     } catch (error) {
-      const status = error.response?.status || error.status || error.statusCode || 500;
-      let errorBody = '';
+      const status =
+        error.response?.status || error.status || error.statusCode || 500;
+      let errorBody = "";
       try {
         const data = error.response?.data;
-        errorBody = typeof data === 'string' ? data : (data ? JSON.stringify(data) : error.message);
+        errorBody =
+          typeof data === "string"
+            ? data
+            : data
+              ? JSON.stringify(data)
+              : error.message;
       } catch {
-        errorBody = error.message || '未知错误';
+        errorBody = error.message || "未知错误";
       }
 
       if (status === 403) {
-        const isContextLimit = String(errorBody).includes('The caller does not');
+        const isContextLimit = String(errorBody).includes(
+          "The caller does not",
+        );
         if (!isContextLimit) {
           return { ok: false, status, message: errorBody };
         }
@@ -822,12 +919,12 @@ class GeminiCliTokenManager {
     try {
       const tokenData = await this.findTokenById(tokenId);
       if (!tokenData) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       // 如果 token 已经启用，直接返回
       if (tokenData.enable !== false) {
-        return { success: true, message: 'Token已处于启用状态' };
+        return { success: true, message: "Token已处于启用状态" };
       }
 
       log.info(`[GeminiCLI][启用检测] 正在测试 token ${tokenId} 的可用性...`);
@@ -838,10 +935,17 @@ class GeminiCliTokenManager {
       } catch (error) {
         const statusCode = error.statusCode || 500;
         if (statusCode === 403 || statusCode === 400) {
-          log.warn(`[GeminiCLI][启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`);
-          return { success: false, message: `凭证不可用，刷新失败(${statusCode}): ${error.message}` };
+          log.warn(
+            `[GeminiCLI][启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`,
+          );
+          return {
+            success: false,
+            message: `凭证不可用，刷新失败(${statusCode}): ${error.message}`,
+          };
         }
-        log.warn(`[GeminiCLI][启用检测] token ${tokenId} 刷新失败: ${error.message}`);
+        log.warn(
+          `[GeminiCLI][启用检测] token ${tokenId} 刷新失败: ${error.message}`,
+        );
         return { success: false, message: `凭证刷新失败: ${error.message}` };
       }
 
@@ -852,16 +956,27 @@ class GeminiCliTokenManager {
           tokenData.projectId = projectId;
         } else if (!tokenData.projectId) {
           log.warn(`[GeminiCLI][启用检测] token ${tokenId} 无法获取 projectId`);
-          return { success: false, message: '凭证不可用: 无法获取 projectId，该账号可能不支持 Gemini CLI' };
+          return {
+            success: false,
+            message:
+              "凭证不可用: 无法获取 projectId，该账号可能不支持 Gemini CLI",
+          };
         }
       } catch (error) {
         const statusCode = error.statusCode || 500;
         if (statusCode === 403 || statusCode === 401) {
-          log.warn(`[GeminiCLI][启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`);
-          return { success: false, message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}` };
+          log.warn(
+            `[GeminiCLI][启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`,
+          );
+          return {
+            success: false,
+            message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}`,
+          };
         }
         // 非致命错误，继续启用
-        log.warn(`[GeminiCLI][启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`);
+        log.warn(
+          `[GeminiCLI][启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`,
+        );
       }
 
       // 步骤3: 发送测试消息，验证 API 调用是否会触发 403
@@ -869,39 +984,50 @@ class GeminiCliTokenManager {
         log.info(`[GeminiCLI][启用检测] 正在发送测试消息验证 API 可用性...`);
         const testResult = await this._sendTestMessage(tokenData);
         if (!testResult.ok) {
-          log.warn(`[GeminiCLI][启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`);
+          log.warn(
+            `[GeminiCLI][启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`,
+          );
           return {
             success: false,
-            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`
+            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`,
           };
         }
         log.info(`[GeminiCLI][启用检测] token ${tokenId} 测试消息通过`);
       }
 
-      log.info(`[GeminiCLI][启用检测] token ${tokenId} 全部检测通过，正在启用...`);
+      log.info(
+        `[GeminiCLI][启用检测] token ${tokenId} 全部检测通过，正在启用...`,
+      );
 
       // 测试通过，执行启用
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      const index = allTokens.findIndex(token =>
-        generateTokenId(token.refresh_token, salt) === tokenId
+      const index = allTokens.findIndex(
+        (token) => generateTokenId(token.refresh_token, salt) === tokenId,
       );
 
       if (index === -1) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
-      const updates = { enable: true, disableReason: null, disableTime: null };
+      const updates = {
+        enable: true,
+        disableReason: null,
+        disableTime: null,
+        lastError: null,
+        lastErrorTime: null,
+        lastErrorStage: null,
+      };
       if (tokenData.projectId) updates.projectId = tokenData.projectId;
 
       allTokens[index] = { ...allTokens[index], ...updates };
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token更新成功' };
+      return { success: true, message: "Token更新成功" };
     } catch (error) {
-      log.error('[GeminiCLI] 启用Token失败:', error.message);
+      log.error("[GeminiCLI] 启用Token失败:", error.message);
       return { success: false, message: `启用失败: ${error.message}` };
     }
   }
@@ -916,20 +1042,20 @@ class GeminiCliTokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      const filteredTokens = allTokens.filter(token =>
-        generateTokenId(token.refresh_token, salt) !== tokenId
+      const filteredTokens = allTokens.filter(
+        (token) => generateTokenId(token.refresh_token, salt) !== tokenId,
       );
 
       if (filteredTokens.length === allTokens.length) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       await this.store.writeAll(filteredTokens);
 
       await this.reload();
-      return { success: true, message: 'Token删除成功' };
+      return { success: true, message: "Token删除成功" };
     } catch (error) {
-      log.error('[GeminiCLI] 删除Token失败:', error.message);
+      log.error("[GeminiCLI] 删除Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -942,13 +1068,13 @@ class GeminiCliTokenManager {
   async refreshTokenById(tokenId) {
     const tokenData = await this.findTokenById(tokenId);
     if (!tokenData) {
-      throw new TokenError('Token不存在', null, 404);
+      throw new TokenError("Token不存在", null, 404);
     }
 
     const refreshedToken = await this.refreshToken(tokenData);
     return {
       expires_in: refreshedToken.expires_in,
-      timestamp: refreshedToken.timestamp
+      timestamp: refreshedToken.timestamp,
     };
   }
 
@@ -966,7 +1092,7 @@ class GeminiCliTokenManager {
       strategy: this.rotationStrategy,
       requestCount: this.requestCountPerToken,
       currentIndex: this.currentIndex,
-      tokenCounts: Object.fromEntries(this.tokenRequestCounts)
+      tokenCounts: Object.fromEntries(this.tokenRequestCounts),
     };
   }
 }

--- a/src/auth/oauth_manager.js
+++ b/src/auth/oauth_manager.js
@@ -1,13 +1,18 @@
-import axios from 'axios';
-import crypto from 'crypto';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import log from '../utils/logger.js';
-import config from '../config/config.js';
-import tokenManager from './token_manager.js';
-import { OAUTH_CONFIG, OAUTH_SCOPES, GEMINICLI_OAUTH_CONFIG, GEMINICLI_OAUTH_SCOPES } from '../constants/oauth.js';
-import { buildAxiosRequestConfig } from '../utils/httpClient.js';
-import fingerprintRequester from '../requester.js';
+import axios from "axios";
+import crypto from "crypto";
+import path from "path";
+import { fileURLToPath } from "url";
+import config from "../config/config.js";
+import {
+  GEMINICLI_OAUTH_CONFIG,
+  GEMINICLI_OAUTH_SCOPES,
+  OAUTH_CONFIG,
+  OAUTH_SCOPES,
+} from "../constants/oauth.js";
+import fingerprintRequester from "../requester.js";
+import { buildAxiosRequestConfig } from "../utils/httpClient.js";
+import log from "../utils/logger.js";
+import tokenManager from "./token_manager.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -16,212 +21,237 @@ let requester = null;
 let useAxios = false;
 
 if (config.useNativeAxios === true) {
-	useAxios = true;
+  useAxios = true;
 } else {
-	try {
-		const isPkg = typeof process.pkg !== 'undefined';
-		const configPath = isPkg
-			? path.join(path.dirname(process.execPath), 'bin', 'tls_config.json')
-			: path.join(__dirname, '..', 'bin', 'tls_config.json');
-		requester = fingerprintRequester.create({
-			configPath,
-			timeout: config.timeout ? Math.ceil(config.timeout / 1000) : 30,
-			proxy: config.proxy || null,
-		});
-	} catch (error) {
-		log.warn('[OAuthManager] FingerprintRequester 初始化失败，自动降级使用 axios:', error.message);
-		useAxios = true;
-	}
+  try {
+    const isPkg = typeof process.pkg !== "undefined";
+    const configPath = isPkg
+      ? path.join(path.dirname(process.execPath), "bin", "tls_config.json")
+      : path.join(__dirname, "..", "bin", "tls_config.json");
+    requester = fingerprintRequester.create({
+      configPath,
+      timeout: config.timeout ? Math.ceil(config.timeout / 1000) : 30,
+    });
+  } catch (error) {
+    log.warn(
+      "[OAuthManager] FingerprintRequester 初始化失败，自动降级使用 axios:",
+      error.message,
+    );
+    useAxios = true;
+  }
 }
 
-function buildRequesterConfig(headers, body = null, method = 'POST') {
-	const reqConfig = {
-		method,
-		headers,
-		timeout_ms: config.timeout,
-		proxy: config.proxy
-	};
-	if (body !== null) {
-		reqConfig.body = typeof body === 'string' ? body : JSON.stringify(body);
-	}
-	return reqConfig;
+function buildRequesterConfig(
+  headers,
+  body = null,
+  method = "POST",
+  proxy = null,
+) {
+  const reqConfig = {
+    method,
+    headers,
+    timeout_ms: config.timeout,
+  };
+  if (proxy) {
+    reqConfig.proxy = proxy;
+  }
+  if (body !== null) {
+    reqConfig.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+  return reqConfig;
 }
 
 class OAuthManager {
-	constructor() {
-		this.state = crypto.randomUUID();
-	}
+  constructor() {
+    this.state = crypto.randomUUID();
+  }
 
-	/**
-	 * 生成授权URL
-	 * @param {number} port - 回调端口
-	 * @param {string} mode - 模式：'antigravity' 或 'geminicli'
-	 */
-	generateAuthUrl(port, mode = 'antigravity') {
-		const oauthConfig = mode === 'geminicli' ? GEMINICLI_OAUTH_CONFIG : OAUTH_CONFIG;
-		const scopes = mode === 'geminicli' ? GEMINICLI_OAUTH_SCOPES : OAUTH_SCOPES;
+  /**
+   * 生成授权URL
+   * @param {number} port - 回调端口
+   * @param {string} mode - 模式：'antigravity' 或 'geminicli'
+   */
+  generateAuthUrl(port, mode = "antigravity") {
+    const oauthConfig =
+      mode === "geminicli" ? GEMINICLI_OAUTH_CONFIG : OAUTH_CONFIG;
+    const scopes = mode === "geminicli" ? GEMINICLI_OAUTH_SCOPES : OAUTH_SCOPES;
 
-		const params = new URLSearchParams({
-			access_type: 'offline',
-			client_id: oauthConfig.CLIENT_ID,
-			prompt: 'consent',
-			redirect_uri: `http://localhost:${port}/oauth-callback`,
-			response_type: 'code',
-			scope: scopes.join(' '),
-			state: `${this.state}_${mode}` // 在 state 中包含 mode 信息
-		});
-		return `${oauthConfig.AUTH_URL}?${params.toString()}`;
-	}
+    const params = new URLSearchParams({
+      access_type: "offline",
+      client_id: oauthConfig.CLIENT_ID,
+      prompt: "consent",
+      redirect_uri: `http://localhost:${port}/oauth-callback`,
+      response_type: "code",
+      scope: scopes.join(" "),
+      state: `${this.state}_${mode}`, // 在 state 中包含 mode 信息
+    });
+    return `${oauthConfig.AUTH_URL}?${params.toString()}`;
+  }
 
-	/**
-	 * 交换授权码获取Token
-	 * @param {string} code - 授权码
-	 * @param {number} port - 回调端口
-	 * @param {string} mode - 模式：'antigravity' 或 'geminicli'
-	 */
-	async exchangeCodeForToken(code, port, mode = 'antigravity') {
-		const oauthConfig = mode === 'geminicli' ? GEMINICLI_OAUTH_CONFIG : OAUTH_CONFIG;
+  /**
+   * 交换授权码获取Token
+   * @param {string} code - 授权码
+   * @param {number} port - 回调端口
+   * @param {string} mode - 模式：'antigravity' 或 'geminicli'
+   */
+  async exchangeCodeForToken(code, port, mode = "antigravity") {
+    const oauthConfig =
+      mode === "geminicli" ? GEMINICLI_OAUTH_CONFIG : OAUTH_CONFIG;
 
-		const postData = new URLSearchParams({
-			code,
-			client_id: oauthConfig.CLIENT_ID,
-			client_secret: oauthConfig.CLIENT_SECRET,
-			redirect_uri: `http://localhost:${port}/oauth-callback`,
-			grant_type: 'authorization_code'
-		});
+    const postData = new URLSearchParams({
+      code,
+      client_id: oauthConfig.CLIENT_ID,
+      client_secret: oauthConfig.CLIENT_SECRET,
+      redirect_uri: `http://localhost:${port}/oauth-callback`,
+      grant_type: "authorization_code",
+    });
 
-		const headers = {
-			'Host': 'oauth2.googleapis.com',
-			'User-Agent': 'Go-http-client/1.1',
-			'Content-Type': 'application/x-www-form-urlencoded',
-			'Accept-Encoding': 'gzip'
-		};
+    const headers = {
+      Host: "oauth2.googleapis.com",
+      "User-Agent": "Go-http-client/1.1",
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept-Encoding": "gzip",
+    };
 
-		if (useAxios) {
-			const response = await axios(buildAxiosRequestConfig({
-				method: 'POST',
-				url: oauthConfig.TOKEN_URL,
-				headers,
-				data: postData.toString(),
-				timeout: config.timeout
-			}));
-			return response.data;
-		}
+    if (useAxios) {
+      const response = await axios(
+        buildAxiosRequestConfig({
+          method: "POST",
+          url: oauthConfig.TOKEN_URL,
+          headers,
+          data: postData.toString(),
+          timeout: config.timeout,
+        }),
+      );
+      return response.data;
+    }
 
-		const response = await requester.antigravity_fetch(oauthConfig.TOKEN_URL, buildRequesterConfig(headers, postData.toString()));
-		if (response.status !== 200) {
-			const errorBody = await response.text();
-			throw new Error(`Token交换请求失败 (${response.status}): ${errorBody}`);
-		}
-		return await response.json();
-	}
+    const response = await requester.antigravity_fetch(
+      oauthConfig.TOKEN_URL,
+      buildRequesterConfig(headers, postData.toString()),
+    );
+    if (response.status !== 200) {
+      const errorBody = await response.text();
+      throw new Error(`Token交换请求失败 (${response.status}): ${errorBody}`);
+    }
+    return await response.json();
+  }
 
-	/**
-	 * 获取用户邮箱
-	 */
-	async fetchUserEmail(accessToken) {
-		const headers = {
-			'Host': 'www.googleapis.com',
-			'User-Agent': 'Go-http-client/1.1',
-			'Authorization': `Bearer ${accessToken}`,
-			'Accept-Encoding': 'gzip'
-		};
+  /**
+   * 获取用户邮箱
+   */
+  async fetchUserEmail(accessToken) {
+    const headers = {
+      Host: "www.googleapis.com",
+      "User-Agent": "Go-http-client/1.1",
+      Authorization: `Bearer ${accessToken}`,
+      "Accept-Encoding": "gzip",
+    };
 
-		try {
-			if (useAxios) {
-				const response = await axios(buildAxiosRequestConfig({
-					method: 'GET',
-					url: 'https://www.googleapis.com/oauth2/v2/userinfo',
-					headers,
-					timeout: config.timeout
-				}));
-				return response.data?.email;
-			}
+    try {
+      if (useAxios) {
+        const response = await axios(
+          buildAxiosRequestConfig({
+            method: "GET",
+            url: "https://www.googleapis.com/oauth2/v2/userinfo",
+            headers,
+            timeout: config.timeout,
+          }),
+        );
+        return response.data?.email;
+      }
 
-			const response = await requester.antigravity_fetch('https://www.googleapis.com/oauth2/v2/userinfo', buildRequesterConfig(headers, null, 'GET'));
-			if (response.status !== 200) {
-				const errorBody = await response.text();
-				throw new Error(`获取用户信息失败 (${response.status}): ${errorBody}`);
-			}
-			const data = await response.json();
-			return data?.email;
-		} catch (err) {
-			log.warn('获取用户邮箱失败:', err.message);
-			return null;
-		}
-	}
+      const response = await requester.antigravity_fetch(
+        "https://www.googleapis.com/oauth2/v2/userinfo",
+        buildRequesterConfig(headers, null, "GET"),
+      );
+      if (response.status !== 200) {
+        const errorBody = await response.text();
+        throw new Error(`获取用户信息失败 (${response.status}): ${errorBody}`);
+      }
+      const data = await response.json();
+      return data?.email;
+    } catch (err) {
+      log.warn("获取用户邮箱失败:", err.message);
+      return null;
+    }
+  }
 
-	/**
-	 * 资格校验：尝试获取projectId
-	 */
-	async validateAndGetProjectId(accessToken) {
-		try {
-			log.info('正在验证账号资格...');
-			const {projectId,sub} = await tokenManager.fetchProjectId({ access_token: accessToken }) || {};
+  /**
+   * 资格校验：尝试获取projectId
+   */
+  async validateAndGetProjectId(accessToken) {
+    try {
+      log.info("正在验证账号资格...");
+      const { projectId, sub } =
+        (await tokenManager.fetchProjectId({ access_token: accessToken })) ||
+        {};
 
-			if (projectId === undefined || projectId === null) {
-				log.warn('该账号无法获取 projectId，可能无资格或需要稍后重试');
-				return { projectId: null, hasQuota: false, sub };
-			}
+      if (projectId === undefined || projectId === null) {
+        log.warn("该账号无法获取 projectId，可能无资格或需要稍后重试");
+        return { projectId: null, hasQuota: false, sub };
+      }
 
-			log.info('账号验证通过，projectId: ' + projectId);
-			return { projectId, hasQuota: true, sub };
-		} catch (err) {
-			log.error('验证账号资格失败: ' + err.message);
-			sub = "free-tier";
-			return { projectId: null, hasQuota: false,sub };
-		}
-	}
+      log.info("账号验证通过，projectId: " + projectId);
+      return { projectId, hasQuota: true, sub };
+    } catch (err) {
+      log.error("验证账号资格失败: " + err.message);
+      sub = "free-tier";
+      return { projectId: null, hasQuota: false, sub };
+    }
+  }
 
-	/**
-	 * 完整的OAuth认证流程：交换Token -> 获取邮箱 -> 资格校验
-	 * @param {string} code - 授权码
-	 * @param {number} port - 回调端口
-	 * @param {string} mode - 模式：'antigravity' 或 'geminicli'
-	 */
-	async authenticate(code, port, mode = 'antigravity') {
-		// 1. 交换授权码获取Token
-		const tokenData = await this.exchangeCodeForToken(code, port, mode);
+  /**
+   * 完整的OAuth认证流程：交换Token -> 获取邮箱 -> 资格校验
+   * @param {string} code - 授权码
+   * @param {number} port - 回调端口
+   * @param {string} mode - 模式：'antigravity' 或 'geminicli'
+   */
+  async authenticate(code, port, mode = "antigravity") {
+    // 1. 交换授权码获取Token
+    const tokenData = await this.exchangeCodeForToken(code, port, mode);
 
-		if (!tokenData.access_token) {
-			throw new Error('Token交换失败：未获取到access_token');
-		}
+    if (!tokenData.access_token) {
+      throw new Error("Token交换失败：未获取到access_token");
+    }
 
-		const account = {
-			access_token: tokenData.access_token,
-			refresh_token: tokenData.refresh_token,
-			expires_in: tokenData.expires_in,
-			timestamp: Date.now()
-		};
+    const account = {
+      access_token: tokenData.access_token,
+      refresh_token: tokenData.refresh_token,
+      expires_in: tokenData.expires_in,
+      timestamp: Date.now(),
+    };
 
-		// 2. 获取用户邮箱
-		const email = await this.fetchUserEmail(account.access_token);
-		if (email) {
-			account.email = email;
-			log.info(`[${mode}] 获取到用户邮箱: ${email}`);
-		}
+    // 2. 获取用户邮箱
+    const email = await this.fetchUserEmail(account.access_token);
+    if (email) {
+      account.email = email;
+      log.info(`[${mode}] 获取到用户邮箱: ${email}`);
+    }
 
-		// 3. 资格校验（仅 antigravity 模式需要 projectId）
-		if (mode === 'antigravity') {
-			const { projectId, hasQuota,sub } = await this.validateAndGetProjectId(account.access_token);
-			account.projectId = projectId;
-			account.hasQuota = hasQuota;
-			account.sub = sub;
-		}
+    // 3. 资格校验（仅 antigravity 模式需要 projectId）
+    if (mode === "antigravity") {
+      const { projectId, hasQuota, sub } = await this.validateAndGetProjectId(
+        account.access_token,
+      );
+      account.projectId = projectId;
+      account.hasQuota = hasQuota;
+      account.sub = sub;
+    }
 
-		account.enable = true;
+    account.enable = true;
 
-		return account;
-	}
+    return account;
+  }
 
-	/**
-	 * Gemini CLI 专用认证流程（简化版，不需要 projectId）
-	 * @param {string} code - 授权码
-	 * @param {number} port - 回调端口
-	 */
-	async authenticateGeminiCli(code, port) {
-		return this.authenticate(code, port, 'GeminiCLI');
-	}
+  /**
+   * Gemini CLI 专用认证流程（简化版，不需要 projectId）
+   * @param {string} code - 授权码
+   * @param {number} port - 回调端口
+   */
+  async authenticateGeminiCli(code, port) {
+    return this.authenticate(code, port, "GeminiCLI");
+  }
 }
 
 export default new OAuthManager();

--- a/src/auth/oauth_manager.js
+++ b/src/auth/oauth_manager.js
@@ -47,13 +47,15 @@ function buildRequesterConfig(
   method = "POST",
   proxy = null,
 ) {
+  const effectiveProxy =
+    proxy || (config.proxy?.allRequests ? config.proxy : null);
   const reqConfig = {
     method,
     headers,
     timeout_ms: config.timeout,
   };
-  if (proxy) {
-    reqConfig.proxy = proxy;
+  if (effectiveProxy) {
+    reqConfig.proxy = effectiveProxy;
   }
   if (body !== null) {
     reqConfig.body = typeof body === "string" ? body : JSON.stringify(body);

--- a/src/auth/token_manager.js
+++ b/src/auth/token_manager.js
@@ -1079,6 +1079,89 @@ class TokenManager {
   }
 
   /**
+   * 从禁用池启用 token（先测试可用性）
+   * @param {string} tokenId - 安全的 token ID
+   * @returns {Promise<Object>} 操作结果
+   */
+  async enableTokenById(tokenId) {
+    try {
+      const tokenData = await this.findTokenById(tokenId);
+      if (!tokenData) {
+        return { success: false, message: 'Token不存在' };
+      }
+
+      // 如果 token 已经启用，直接返回
+      if (tokenData.enable !== false) {
+        return { success: true, message: 'Token已处于启用状态' };
+      }
+
+      log.info(`[启用检测] 正在测试 token ${tokenId} 的可用性...`);
+
+      // 步骤1: 尝试刷新 token
+      try {
+        await this.refreshToken(tokenData);
+      } catch (error) {
+        const statusCode = error.statusCode || 500;
+        if (statusCode === 403 || statusCode === 400) {
+          log.warn(`[启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`);
+          return { success: false, message: `凭证不可用，刷新失败(${statusCode}): ${error.message}` };
+        }
+        // 其他错误（如网络问题），也返回失败但提示不同
+        log.warn(`[启用检测] token ${tokenId} 刷新失败: ${error.message}`);
+        return { success: false, message: `凭证刷新失败: ${error.message}` };
+      }
+
+      // 步骤2: 尝试获取 projectId（验证账号权限）
+      try {
+        const {projectId, sub} = await this.fetchProjectId(tokenData) || {};
+        if (projectId) {
+          tokenData.projectId = projectId;
+          tokenData.sub = sub;
+        } else if (!tokenData.projectId && !config.skipProjectIdFetch) {
+          log.warn(`[启用检测] token ${tokenId} 无法获取 projectId`);
+          return { success: false, message: '凭证不可用: 无法获取 projectId，该账号可能不支持 Code Assist' };
+        }
+      } catch (error) {
+        const statusCode = error.statusCode || 500;
+        if (statusCode === 403 || statusCode === 401) {
+          log.warn(`[启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`);
+          return { success: false, message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}` };
+        }
+        // 非致命错误，继续启用（可能只是暂时性网络问题）
+        log.warn(`[启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`);
+      }
+
+      log.info(`[启用检测] token ${tokenId} 测试通过，正在启用...`);
+
+      // 测试通过，执行启用
+      const allTokens = await this.store.readAll();
+      const salt = await this.store.getSalt();
+
+      const index = allTokens.findIndex(token =>
+        generateTokenId(token.refresh_token, salt) === tokenId
+      );
+
+      if (index === -1) {
+        return { success: false, message: 'Token不存在' };
+      }
+
+      const updates = { enable: true, disableReason: null, disableTime: null };
+      if (tokenData.projectId) updates.projectId = tokenData.projectId;
+      if (tokenData.sub) updates.sub = tokenData.sub;
+
+      allTokens[index] = { ...allTokens[index], ...updates };
+      await this.store.writeAll(allTokens);
+
+      await this.reload();
+      return { success: true, message: 'Token启用成功' };
+    } catch (error) {
+      log.error('启用Token失败:', error.message);
+      return { success: false, message: `启用失败: ${error.message}` };
+    }
+  }
+
+
+  /**
    * 根据 tokenId 删除 token
    * @param {string} tokenId - 安全的 token ID
    * @returns {Promise<Object>} 操作结果

--- a/src/auth/token_manager.js
+++ b/src/auth/token_manager.js
@@ -1263,6 +1263,30 @@ class TokenManager {
   async enableTokenById(tokenId) {
     try {
       const tokenData = await this.findTokenById(tokenId);
+
+      // 辅助函数：将启用验证失败的错误信息写入凭证存储
+      const saveEnableError = async (errorMessage) => {
+        try {
+          const allTokens = await this.store.readAll();
+          const salt = await this.store.getSalt();
+          const index = allTokens.findIndex(
+            (token) => generateTokenId(token.refresh_token, salt) === tokenId,
+          );
+          if (index !== -1) {
+            allTokens[index] = {
+              ...allTokens[index],
+              lastError: errorMessage,
+              lastErrorTime: new Date().toISOString(),
+              lastErrorStage: "enable_test",
+            };
+            await this.store.writeAll(allTokens);
+            await this.reload();
+          }
+        } catch (e) {
+          log.error(`[启用检测] 保存错误信息失败: ${e.message}`);
+        }
+      };
+
       if (!tokenData) {
         return { success: false, message: "Token不存在" };
       }
@@ -1283,14 +1307,18 @@ class TokenManager {
           log.warn(
             `[启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`,
           );
+          const msg = `凭证不可用，刷新失败(${statusCode}): ${error.message}`;
+          await saveEnableError(msg);
           return {
             success: false,
-            message: `凭证不可用，刷新失败(${statusCode}): ${error.message}`,
+            message: msg,
           };
         }
         // 其他错误（如网络问题），也返回失败但提示不同
         log.warn(`[启用检测] token ${tokenId} 刷新失败: ${error.message}`);
-        return { success: false, message: `凭证刷新失败: ${error.message}` };
+        const refreshMsg = `凭证刷新失败: ${error.message}`;
+        await saveEnableError(refreshMsg);
+        return { success: false, message: refreshMsg };
       }
 
       // 步骤2: 尝试获取 projectId（验证账号权限）
@@ -1301,10 +1329,12 @@ class TokenManager {
           tokenData.sub = sub;
         } else if (!tokenData.projectId && !config.skipProjectIdFetch) {
           log.warn(`[启用检测] token ${tokenId} 无法获取 projectId`);
+          const noProjectMsg =
+            "凭证不可用: 无法获取 projectId，该账号可能不支持 Code Assist";
+          await saveEnableError(noProjectMsg);
           return {
             success: false,
-            message:
-              "凭证不可用: 无法获取 projectId，该账号可能不支持 Code Assist",
+            message: noProjectMsg,
           };
         }
       } catch (error) {
@@ -1313,9 +1343,11 @@ class TokenManager {
           log.warn(
             `[启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`,
           );
+          const permMsg = `凭证不可用，权限验证失败(${statusCode}): ${error.message}`;
+          await saveEnableError(permMsg);
           return {
             success: false,
-            message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}`,
+            message: permMsg,
           };
         }
         // 非致命错误，继续启用（可能只是暂时性网络问题）
@@ -1332,9 +1364,11 @@ class TokenManager {
           log.warn(
             `[启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`,
           );
+          const testMsg = `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`;
+          await saveEnableError(testMsg);
           return {
             success: false,
-            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`,
+            message: testMsg,
           };
         }
         log.info(`[启用检测] token ${tokenId} 测试消息通过`);

--- a/src/auth/token_manager.js
+++ b/src/auth/token_manager.js
@@ -119,16 +119,18 @@ class TokenManager {
     let successCount = 0;
     let failCount = 0;
     const tokensToDisable = [];
+    const disableReasons = [];
     const failedTokenIds = [];
 
     results.forEach((result, index) => {
       const token = expiredTokens[index];
       const tokenId = tokenIds[index];
       if (result.status === 'fulfilled') {
-        if (result.value === 'success') {
+        if (result.value.action === 'success') {
           successCount++;
-        } else if (result.value === 'disable') {
+        } else if (result.value.action === 'disable') {
           tokensToDisable.push(token);
+          disableReasons.push(result.value.reason || 'Token刷新失败');
           failCount++;
           failedTokenIds.push(tokenId);
         }
@@ -139,8 +141,8 @@ class TokenManager {
     });
 
     // 批量禁用失效的 token
-    for (const token of tokensToDisable) {
-      this.disableToken(token);
+    for (let i = 0; i < tokensToDisable.length; i++) {
+      this.disableToken(tokensToDisable[i], disableReasons[i]);
     }
 
     const elapsed = Date.now() - startTime;
@@ -154,17 +156,17 @@ class TokenManager {
   /**
    * 安全刷新单个 token（不抛出异常）
    * @param {Object} token - Token 对象
-   * @returns {Promise<'success'|'disable'|'skip'>} 刷新结果
+   * @returns {Promise<{action: 'success'|'disable'|'skip', reason?: string}>} 刷新结果
    * @private
    */
   async _refreshTokenSafe(token) {
     try {
       // 并发刷新时使用静默模式，避免重复打印日志
       await this.refreshToken(token, true);
-      return 'success';
+      return { action: 'success' };
     } catch (error) {
       if (error.statusCode === 403 || error.statusCode === 400) {
-        return 'disable';
+        return { action: 'disable', reason: `Token刷新失败(${error.statusCode}): ${error.message}` };
       }
       throw error;
     }
@@ -543,9 +545,11 @@ class TokenManager {
     });
   }
 
-  disableToken(token) {
-    log.warn(`禁用token ...${token.access_token.slice(-8)}`)
+  disableToken(token, reason = '未知原因') {
+    log.warn(`禁用token ...${token.access_token.slice(-8)}, 原因: ${reason}`);
     token.enable = false;
+    token.disableReason = reason;
+    token.disableTime = Date.now();
     this.saveToFile();
     // 清理该 token 的请求计数（避免内存泄漏）
     this.tokenRequestCounts.delete(token.refresh_token);
@@ -612,7 +616,7 @@ class TokenManager {
   /**
    * 准备单个 token（刷新 + 获取 projectId）
    * @param {Object} token - Token 对象
-   * @returns {Promise<'ready'|'skip'|'disable'>} 处理结果
+   * @returns {Promise<{action: 'ready'|'skip'|'disable', reason?: string}>} 处理结果
    * @private
    */
   async _prepareToken(token) {
@@ -631,7 +635,7 @@ class TokenManager {
         const {projectId,sub} = await this.fetchProjectId(token) || {};
         if (projectId === undefined) {
           log.warn(`...${token.access_token.slice(-8)}: 无资格获取projectId，禁用账号`);
-          return 'disable';
+          return { action: 'disable', reason: '无资格获取projectId，该账号可能不支持 Code Assist' };
         }
         token.projectId = projectId;
         token.sub = sub;
@@ -639,24 +643,24 @@ class TokenManager {
       }
     }
 
-    return 'ready';
+    return { action: 'ready' };
   }
 
   /**
    * 处理 token 准备过程中的错误
    * @param {Error} error - 错误对象
    * @param {Object} token - Token 对象
-   * @returns {'disable'|'skip'} 处理结果
+   * @returns {{action: 'disable'|'skip', reason?: string}} 处理结果
    * @private
    */
   _handleTokenError(error, token) {
     const suffix = token.access_token?.slice(-8) || 'unknown';
     if (error.statusCode === 403 || error.statusCode === 400) {
       log.warn(`...${suffix}: Token 已失效或错误，已自动禁用该账号`);
-      return 'disable';
+      return { action: 'disable', reason: `Token准备失败(${error.statusCode}): ${error.message}` };
     }
     log.error(`...${suffix} 操作失败:`, error.message);
-    return 'skip';
+    return { action: 'skip' };
   }
 
   /**
@@ -807,8 +811,8 @@ class TokenManager {
 
       try {
         const result = await this._prepareToken(token);
-        if (result === 'disable') {
-          this.disableToken(token);
+        if (result.action === 'disable') {
+          this.disableToken(token, result.reason);
           this._rebuildAvailableQuotaTokens();
           if (this.tokens.length === 0 || this.availableQuotaTokenIndices.length === 0) {
             return null;
@@ -820,9 +824,9 @@ class TokenManager {
         this.currentQuotaIndex = listIndex;
         return token;
       } catch (error) {
-        const action = this._handleTokenError(error, token);
-        if (action === 'disable') {
-          this.disableToken(token);
+        const errorResult = this._handleTokenError(error, token);
+        if (errorResult.action === 'disable') {
+          this.disableToken(token, errorResult.reason);
           this._rebuildAvailableQuotaTokens();
           if (this.tokens.length === 0 || this.availableQuotaTokenIndices.length === 0) {
             return null;
@@ -866,8 +870,8 @@ class TokenManager {
 
       try {
         const result = await this._prepareToken(token);
-        if (result === 'disable') {
-          this.disableToken(token);
+        if (result.action === 'disable') {
+          this.disableToken(token, result.reason);
           if (this.tokens.length === 0) return null;
           continue;
         }
@@ -890,9 +894,9 @@ class TokenManager {
 
         return token;
       } catch (error) {
-        const action = this._handleTokenError(error, token);
-        if (action === 'disable') {
-          this.disableToken(token);
+        const errorResult = this._handleTokenError(error, token);
+        if (errorResult.action === 'disable') {
+          this.disableToken(token, errorResult.reason);
           if (this.tokens.length === 0) return null;
         }
         // skip: 继续尝试下一个 token
@@ -902,10 +906,10 @@ class TokenManager {
     return null;
   }
 
-  disableCurrentToken(token) {
+  disableCurrentToken(token, reason = 'API请求返回403，账号无使用权限') {
     const found = this.tokens.find(t => t.access_token === token.access_token);
     if (found) {
-      this.disableToken(found);
+      this.disableToken(found, reason);
     }
   }
 
@@ -961,6 +965,11 @@ class TokenManager {
         return { success: false, message: 'Token不存在' };
       }
 
+      // 重新启用时清除禁用原因
+      if (updates.enable === true) {
+        updates.disableReason = null;
+        updates.disableTime = null;
+      }
       allTokens[index] = { ...allTokens[index], ...updates };
       await this.store.writeAll(allTokens);
 
@@ -1004,7 +1013,9 @@ class TokenManager {
         enable: token.enable !== false,
         projectId: token.projectId || null,
         email: token.email || null,
-        hasQuota: token.hasQuota !== false
+        hasQuota: token.hasQuota !== false,
+        disableReason: token.disableReason || null,
+        disableTime: token.disableTime || null
       }));
     } catch (error) {
       log.error('获取Token列表失败:', error.message);
@@ -1048,6 +1059,12 @@ class TokenManager {
 
       if (index === -1) {
         return { success: false, message: 'Token不存在' };
+      }
+
+      // 重新启用时清除禁用原因
+      if (updates.enable === true) {
+        updates.disableReason = null;
+        updates.disableTime = null;
       }
 
       allTokens[index] = { ...allTokens[index], ...updates };

--- a/src/auth/token_manager.js
+++ b/src/auth/token_manager.js
@@ -1015,13 +1015,15 @@ class TokenManager {
   async addToken(tokenData) {
     try {
       const allTokens = await this.store.readAll();
+      const salt = await this.store.getSalt();
+      const tokenId = generateTokenId(tokenData.refresh_token, salt);
 
       const newToken = {
         access_token: tokenData.access_token,
         refresh_token: tokenData.refresh_token,
         expires_in: tokenData.expires_in || 3599,
         timestamp: tokenData.timestamp || Date.now(),
-        enable: tokenData.enable !== undefined ? tokenData.enable : true,
+        enable: false,
       };
 
       if (tokenData.projectId) {
@@ -1039,9 +1041,30 @@ class TokenManager {
 
       allTokens.push(newToken);
       await this.store.writeAll(allTokens);
-
       await this.reload();
-      return { success: true, message: "Token添加成功" };
+
+      const enableResult = await this.enableTokenById(tokenId, {
+        stage: "oauth_submit",
+      });
+      if (!enableResult.success) {
+        return {
+          success: true,
+          saved: true,
+          validated: false,
+          disabled: true,
+          tokenId,
+          message: enableResult.message || "Token已保存到禁用池",
+        };
+      }
+
+      return {
+        success: true,
+        saved: true,
+        validated: true,
+        disabled: false,
+        tokenId,
+        message: "Token添加成功",
+      };
     } catch (error) {
       log.error("添加Token失败:", error.message);
       return { success: false, message: error.message };
@@ -1240,14 +1263,14 @@ class TokenManager {
         errorBody = error.message || "未知错误";
       }
 
-      // 403 且非 "The caller does not have permission"（后者是上下文超限，非权限问题）
-      if (status === 403) {
-        const isContextLimit = String(errorBody).includes(
-          "The caller does not",
-        );
-        if (!isContextLimit) {
-          return { ok: false, status, message: errorBody };
-        }
+      const errorText = String(errorBody || "");
+      const isContextLimit =
+        status === 403 && errorText.includes("The caller does not");
+      const shouldDisable =
+        (status === 400 || status === 401 || status === 403) && !isContextLimit;
+
+      if (shouldDisable) {
+        return { ok: false, status, message: errorText };
       }
 
       // 其他非致命状态码（如 429 限流、500 临时错误）不阻止启用
@@ -1260,9 +1283,10 @@ class TokenManager {
    * @param {string} tokenId - 安全的 token ID
    * @returns {Promise<Object>} 操作结果
    */
-  async enableTokenById(tokenId) {
+  async enableTokenById(tokenId, options = {}) {
     try {
       const tokenData = await this.findTokenById(tokenId);
+      const errorStage = options.stage || "enable_test";
 
       // 辅助函数：将启用验证失败的错误信息写入凭证存储
       const saveEnableError = async (errorMessage) => {
@@ -1273,11 +1297,15 @@ class TokenManager {
             (token) => generateTokenId(token.refresh_token, salt) === tokenId,
           );
           if (index !== -1) {
+            const errorTime = Date.now();
             allTokens[index] = {
               ...allTokens[index],
+              enable: false,
+              disableReason: errorMessage,
+              disableTime: errorTime,
               lastError: errorMessage,
-              lastErrorTime: new Date().toISOString(),
-              lastErrorStage: "enable_test",
+              lastErrorTime: errorTime,
+              lastErrorStage: errorStage,
             };
             await this.store.writeAll(allTokens);
             await this.reload();

--- a/src/auth/token_manager.js
+++ b/src/auth/token_manager.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import { log } from '../utils/logger.js';
-import { generateSessionId, generateProjectId, generateTokenId, generateInstanceId } from '../utils/idGenerator.js';
+import { generateSessionId, generateProjectId, generateTokenId, generateInstanceId, generateRequestId } from '../utils/idGenerator.js';
 import config, { getConfigJson } from '../config/config.js';
 import { OAUTH_CONFIG } from '../constants/oauth.js';
-import { buildAxiosRequestConfig } from '../utils/httpClient.js';
+import { buildAxiosRequestConfig, httpRequest } from '../utils/httpClient.js';
 import {
   DEFAULT_REQUEST_COUNT_PER_TOKEN,
   TOKEN_REFRESH_BUFFER
@@ -1079,6 +1079,73 @@ class TokenManager {
   }
 
   /**
+   * 发送测试消息验证凭证在 API 层面的可用性
+   * 通过非流式 generateContent 发送一个极简请求，检查是否会返回 403 等致命错误
+   * @param {Object} token - Token 对象（必须已刷新且包含 projectId）
+   * @returns {Promise<{ok: boolean, status?: number, message?: string}>}
+   * @private
+   */
+  async _sendTestMessage(token) {
+    const apiHost = config.api.host;
+    const noStreamUrl = config.api.noStreamUrl;
+
+    const testRequestBody = {
+      project: token.projectId,
+      requestId: generateRequestId(),
+      request: {
+        contents: [
+          { role: 'user', parts: [{ text: 'hi' }] }
+        ],
+        generationConfig: {
+          maxOutputTokens: 1,
+          candidateCount: 1
+        },
+        sessionId: generateSessionId()
+      },
+      model: 'gemini-2.5-flash',
+      userAgent: 'antigravity',
+      requestType: 'agent'
+    };
+
+    try {
+      await httpRequest({
+        method: 'POST',
+        url: noStreamUrl,
+        headers: {
+          'Host': apiHost,
+          'User-Agent': config.api.userAgent,
+          'Authorization': `Bearer ${token.access_token}`,
+          'Content-Type': 'application/json',
+          'Accept-Encoding': 'gzip'
+        },
+        data: testRequestBody,
+        timeout: 30000
+      });
+      return { ok: true };
+    } catch (error) {
+      const status = error.response?.status || error.status || error.statusCode || 500;
+      let errorBody = '';
+      try {
+        const data = error.response?.data;
+        errorBody = typeof data === 'string' ? data : (data ? JSON.stringify(data) : error.message);
+      } catch {
+        errorBody = error.message || '未知错误';
+      }
+
+      // 403 且非 "The caller does not have permission"（后者是上下文超限，非权限问题）
+      if (status === 403) {
+        const isContextLimit = String(errorBody).includes('The caller does not');
+        if (!isContextLimit) {
+          return { ok: false, status, message: errorBody };
+        }
+      }
+
+      // 其他非致命状态码（如 429 限流、500 临时错误）不阻止启用
+      return { ok: true };
+    }
+  }
+
+  /**
    * 从禁用池启用 token（先测试可用性）
    * @param {string} tokenId - 安全的 token ID
    * @returns {Promise<Object>} 操作结果
@@ -1131,7 +1198,21 @@ class TokenManager {
         log.warn(`[启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`);
       }
 
-      log.info(`[启用检测] token ${tokenId} 测试通过，正在启用...`);
+      // 步骤3: 发送测试消息，验证 API 调用是否会触发 403
+      if (tokenData.projectId) {
+        log.info(`[启用检测] 正在发送测试消息验证 API 可用性...`);
+        const testResult = await this._sendTestMessage(tokenData);
+        if (!testResult.ok) {
+          log.warn(`[启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`);
+          return {
+            success: false,
+            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`
+          };
+        }
+        log.info(`[启用检测] token ${tokenId} 测试消息通过`);
+      }
+
+      log.info(`[启用检测] token ${tokenId} 全部检测通过，正在启用...`);
 
       // 测试通过，执行启用
       const allTokens = await this.store.readAll();

--- a/src/auth/token_manager.js
+++ b/src/auth/token_manager.js
@@ -1216,24 +1216,24 @@ class TokenManager {
     const apiHost = config.api.host;
     const noStreamUrl = config.api.noStreamUrl;
 
-    const testRequestBody = {
-      project: token.projectId,
-      requestId: generateRequestId(),
-      request: {
-        contents: [{ role: "user", parts: [{ text: "hi" }] }],
-        generationConfig: {
-          maxOutputTokens: 1,
-          candidateCount: 1,
+    const sendRequest = async () => {
+      const testRequestBody = {
+        project: token.projectId,
+        requestId: generateRequestId(),
+        request: {
+          contents: [{ role: "user", parts: [{ text: "hi" }] }],
+          generationConfig: {
+            maxOutputTokens: 1,
+            candidateCount: 1,
+          },
+          sessionId: generateSessionId(),
         },
-        sessionId: generateSessionId(),
-      },
-      model: "gemini-2.5-flash",
-      userAgent: "antigravity",
-      requestType: "agent",
-    };
+        model: "gemini-2.5-flash",
+        userAgent: "antigravity",
+        requestType: "agent",
+      };
 
-    try {
-      await httpRequest({
+      return httpRequest({
         method: "POST",
         url: noStreamUrl,
         headers: {
@@ -1246,6 +1246,33 @@ class TokenManager {
         data: testRequestBody,
         timeout: 30000,
       });
+    };
+
+    const shouldRetryWithProjectId = (status, message) => {
+      const text = String(message || "").toLowerCase();
+      return (
+        status === 400 &&
+        (text.includes("projectid") ||
+          text.includes("project id") ||
+          text.includes("project is required") ||
+          text.includes("缺少 projectid") ||
+          text.includes("缺少 project id") ||
+          text.includes("无法获取 projectid"))
+      );
+    };
+
+    try {
+      if (!token.projectId) {
+        const result = await this.fetchProjectId(token);
+        if (result?.projectId) {
+          token.projectId = result.projectId;
+        }
+        if (result?.sub) {
+          token.sub = result.sub;
+        }
+      }
+
+      await sendRequest();
       return { ok: true };
     } catch (error) {
       const status =
@@ -1264,6 +1291,28 @@ class TokenManager {
       }
 
       const errorText = String(errorBody || "");
+
+      if (shouldRetryWithProjectId(status, errorText)) {
+        try {
+          log.info("[Antigravity] 启动检测遇到 projectId 缺失，尝试自动获取后重试");
+          const result = await this.fetchProjectId(token);
+          if (result?.projectId) {
+            token.projectId = result.projectId;
+          }
+          if (result?.sub) {
+            token.sub = result.sub;
+          }
+          if (token.projectId) {
+            await sendRequest();
+            return { ok: true };
+          }
+        } catch (retryError) {
+          log.warn(
+            `[Antigravity] 自动获取 projectId 后重试失败: ${retryError.message}`,
+          );
+        }
+      }
+
       const isContextLimit =
         status === 403 && errorText.includes("The caller does not");
       const shouldDisable =

--- a/src/auth/token_manager.js
+++ b/src/auth/token_manager.js
@@ -1,24 +1,30 @@
-import axios from 'axios';
-import { log } from '../utils/logger.js';
-import { generateSessionId, generateProjectId, generateTokenId, generateInstanceId, generateRequestId } from '../utils/idGenerator.js';
-import config, { getConfigJson } from '../config/config.js';
-import { OAUTH_CONFIG } from '../constants/oauth.js';
-import { buildAxiosRequestConfig, httpRequest } from '../utils/httpClient.js';
+import axios from "axios";
+import { randomUUID } from "crypto";
+import config, { getConfigJson } from "../config/config.js";
 import {
   DEFAULT_REQUEST_COUNT_PER_TOKEN,
-  TOKEN_REFRESH_BUFFER
-} from '../constants/index.js';
-import TokenStore from './token_store.js';
-import { TokenError } from '../utils/errors.js';
-import quotaManager from './quota_manager.js';
-import tokenCooldownManager from './token_cooldown_manager.js';
-import { randomUUID } from 'crypto';
+  TOKEN_REFRESH_BUFFER,
+} from "../constants/index.js";
+import { OAUTH_CONFIG } from "../constants/oauth.js";
+import { TokenError } from "../utils/errors.js";
+import { buildAxiosRequestConfig, httpRequest } from "../utils/httpClient.js";
+import {
+  generateInstanceId,
+  generateProjectId,
+  generateRequestId,
+  generateSessionId,
+  generateTokenId,
+} from "../utils/idGenerator.js";
+import { log } from "../utils/logger.js";
+import quotaManager from "./quota_manager.js";
+import tokenCooldownManager from "./token_cooldown_manager.js";
+import TokenStore from "./token_store.js";
 
 // 轮询策略枚举
 const RotationStrategy = {
-  ROUND_ROBIN: 'round_robin',           // 均衡负载：每次请求切换
-  QUOTA_EXHAUSTED: 'quota_exhausted',   // 额度耗尽才切换
-  REQUEST_COUNT: 'request_count'        // 自定义次数后切换
+  ROUND_ROBIN: "round_robin", // 均衡负载：每次请求切换
+  QUOTA_EXHAUSTED: "quota_exhausted", // 额度耗尽才切换
+  REQUEST_COUNT: "request_count", // 自定义次数后切换
 };
 
 /**
@@ -56,16 +62,18 @@ class TokenManager {
 
   async _initialize() {
     try {
-      log.info('正在初始化token管理器...');
+      log.info("正在初始化token管理器...");
       const tokenArray = await this.store.readAll();
 
-      this.tokens = tokenArray.filter(token => token.enable !== false).map(token => ({
-        ...token,
-        sessionId: generateSessionId(),
-        instanceId: generateInstanceId(),
-        deviceId: randomUUID(),
-        sub: token?.sub ? token?.sub : "g1-pro-tier"
-      }));
+      this.tokens = tokenArray
+        .filter((token) => token.enable !== false)
+        .map((token) => ({
+          ...token,
+          sessionId: generateSessionId(),
+          instanceId: generateInstanceId(),
+          deviceId: randomUUID(),
+          sub: token?.sub ? token?.sub : "g1-pro-tier",
+        }));
 
       this.currentIndex = 0;
       this.tokenRequestCounts.clear();
@@ -75,13 +83,15 @@ class TokenManager {
       this.loadRotationConfig();
 
       if (this.tokens.length === 0) {
-        log.warn('⚠ 暂无可用账号，请使用以下方式添加：');
-        log.warn('  方式1: 运行 npm run login 命令登录');
-        log.warn('  方式2: 访问前端管理页面添加账号');
+        log.warn("⚠ 暂无可用账号，请使用以下方式添加：");
+        log.warn("  方式1: 运行 npm run login 命令登录");
+        log.warn("  方式2: 访问前端管理页面添加账号");
       } else {
         log.info(`成功加载 ${this.tokens.length} 个可用token`);
         if (this.rotationStrategy === RotationStrategy.REQUEST_COUNT) {
-          log.info(`轮询策略: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`);
+          log.info(
+            `轮询策略: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`,
+          );
         } else {
           log.info(`轮询策略: ${this.rotationStrategy}`);
         }
@@ -90,7 +100,7 @@ class TokenManager {
         await this._refreshExpiredTokensConcurrently();
       }
     } catch (error) {
-      log.error('初始化token失败:', error.message);
+      log.error("初始化token失败:", error.message);
       this.tokens = [];
     }
   }
@@ -100,20 +110,22 @@ class TokenManager {
    * @private
    */
   async _refreshExpiredTokensConcurrently() {
-    const expiredTokens = this.tokens.filter(token => this.isExpired(token));
+    const expiredTokens = this.tokens.filter((token) => this.isExpired(token));
     if (expiredTokens.length === 0) {
       return;
     }
 
     // 获取 salt 用于生成 tokenId
     const salt = await this.store.getSalt();
-    const tokenIds = expiredTokens.map(token => generateTokenId(token.refresh_token, salt));
+    const tokenIds = expiredTokens.map((token) =>
+      generateTokenId(token.refresh_token, salt),
+    );
 
-    log.info(`正在批量刷新 ${tokenIds.length} 个token: ${tokenIds.join(', ')}`);
+    log.info(`正在批量刷新 ${tokenIds.length} 个token: ${tokenIds.join(", ")}`);
     const startTime = Date.now();
 
     const results = await Promise.allSettled(
-      expiredTokens.map(token => this._refreshTokenSafe(token))
+      expiredTokens.map((token) => this._refreshTokenSafe(token)),
     );
 
     let successCount = 0;
@@ -125,12 +137,15 @@ class TokenManager {
     results.forEach((result, index) => {
       const token = expiredTokens[index];
       const tokenId = tokenIds[index];
-      if (result.status === 'fulfilled') {
-        if (result.value.action === 'success') {
+      if (result.status === "fulfilled") {
+        if (result.value.action === "success") {
           successCount++;
-        } else if (result.value.action === 'disable') {
+        } else if (result.value.action === "disable") {
           tokensToDisable.push(token);
-          disableReasons.push(result.value.reason || 'Token刷新失败');
+          disableReasons.push(result.value.reason || "Token刷新失败");
+          failCount++;
+          failedTokenIds.push(tokenId);
+        } else if (result.value.action === "skip") {
           failCount++;
           failedTokenIds.push(tokenId);
         }
@@ -147,7 +162,9 @@ class TokenManager {
 
     const elapsed = Date.now() - startTime;
     if (failCount > 0) {
-      log.warn(`刷新完成: 成功 ${successCount}, 失败 ${failCount} (${failedTokenIds.join(', ')}), 耗时 ${elapsed}ms`);
+      log.warn(
+        `刷新完成: 成功 ${successCount}, 失败 ${failCount} (${failedTokenIds.join(", ")}), 耗时 ${elapsed}ms`,
+      );
     } else {
       log.info(`刷新完成: 成功 ${successCount}, 耗时 ${elapsed}ms`);
     }
@@ -163,12 +180,37 @@ class TokenManager {
     try {
       // 并发刷新时使用静默模式，避免重复打印日志
       await this.refreshToken(token, true);
-      return { action: 'success' };
+      this._clearTokenError(token);
+      return { action: "success" };
     } catch (error) {
-      if (error.statusCode === 403 || error.statusCode === 400) {
-        return { action: 'disable', reason: `Token刷新失败(${error.statusCode}): ${error.message}` };
+      const statusCode =
+        error.statusCode || error.response?.status || error.status || 500;
+      const rawMessage = error.message || "未知错误";
+      const reason = `启动检测刷新失败(${statusCode}): ${rawMessage}`;
+      this._recordTokenError(token, reason, "startup_refresh");
+      if (statusCode === 403 || statusCode === 400) {
+        return { action: "disable", reason };
       }
-      throw error;
+      return { action: "skip", reason };
+    }
+  }
+
+  _recordTokenError(token, message, stage = "startup_refresh") {
+    if (!token) return;
+    const trimmed = String(message || "未知错误").slice(0, 800);
+    token.lastError = trimmed;
+    token.lastErrorTime = Date.now();
+    token.lastErrorStage = stage;
+    this.saveToFile(token);
+  }
+
+  _clearTokenError(token) {
+    if (!token) return;
+    if (token.lastError || token.lastErrorTime || token.lastErrorStage) {
+      token.lastError = null;
+      token.lastErrorTime = null;
+      token.lastErrorStage = null;
+      this.saveToFile(token);
     }
   }
 
@@ -184,11 +226,12 @@ class TokenManager {
     try {
       const jsonConfig = getConfigJson();
       if (jsonConfig.rotation) {
-        this.rotationStrategy = jsonConfig.rotation.strategy || RotationStrategy.ROUND_ROBIN;
+        this.rotationStrategy =
+          jsonConfig.rotation.strategy || RotationStrategy.ROUND_ROBIN;
         this.requestCountPerToken = jsonConfig.rotation.requestCount || 10;
       }
     } catch (error) {
-      log.warn('加载轮询配置失败，使用默认值:', error.message);
+      log.warn("加载轮询配置失败，使用默认值:", error.message);
     }
   }
 
@@ -203,7 +246,9 @@ class TokenManager {
     // 重置计数器
     this.tokenRequestCounts.clear();
     if (this.rotationStrategy === RotationStrategy.REQUEST_COUNT) {
-      log.info(`轮询策略已更新: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`);
+      log.info(
+        `轮询策略已更新: ${this.rotationStrategy}, 每token请求 ${this.requestCountPerToken} 次后切换`,
+      );
     } else {
       log.info(`轮询策略已更新: ${this.rotationStrategy}`);
     }
@@ -221,7 +266,8 @@ class TokenManager {
     if (this.availableQuotaTokenIndices.length === 0) {
       this.currentQuotaIndex = 0;
     } else {
-      this.currentQuotaIndex = this.currentQuotaIndex % this.availableQuotaTokenIndices.length;
+      this.currentQuotaIndex =
+        this.currentQuotaIndex % this.availableQuotaTokenIndices.length;
     }
   }
 
@@ -239,23 +285,28 @@ class TokenManager {
   async fetchProjectId(token) {
     // 步骤1: 尝试 loadCodeAssist
     try {
-
-      const {projectId,sub} = await this._tryLoadCodeAssist(token) || {};
-      if (projectId) return {projectId,sub};
-      log.warn('[fetchProjectId] loadCodeAssist 未返回 projectId，回退到 onboardUser');
+      const { projectId, sub } = (await this._tryLoadCodeAssist(token)) || {};
+      if (projectId) return { projectId, sub };
+      log.warn(
+        "[fetchProjectId] loadCodeAssist 未返回 projectId，回退到 onboardUser",
+      );
     } catch (err) {
-      log.warn(`[fetchProjectId] loadCodeAssist 失败: ${err.message}，回退到 onboardUser`);
+      log.warn(
+        `[fetchProjectId] loadCodeAssist 失败: ${err.message}，回退到 onboardUser`,
+      );
     }
 
     // 步骤2: 回退到 onboardUser
     try {
-      const {projectId,sub} = await this._tryOnboardUser(token) || {};
-      if (projectId) return {projectId, sub};
-      log.error('[fetchProjectId] loadCodeAssist 和 onboardUser 均未能获取 projectId');
-      return {projectId: undefined, sub: "free-tier"};
+      const { projectId, sub } = (await this._tryOnboardUser(token)) || {};
+      if (projectId) return { projectId, sub };
+      log.error(
+        "[fetchProjectId] loadCodeAssist 和 onboardUser 均未能获取 projectId",
+      );
+      return { projectId: undefined, sub: "free-tier" };
     } catch (err) {
       log.error(`[fetchProjectId] onboardUser 失败: ${err.message}`);
-      return {projectId: undefined, sub: "free-tier"};
+      return { projectId: undefined, sub: "free-tier" };
     }
   }
 
@@ -270,25 +321,27 @@ class TokenManager {
     const requestUrl = `https://${apiHost}/v1internal:loadCodeAssist`;
     const requestBody = {
       metadata: {
-        ideType: 'ANTIGRAVITY',
-        platform: 'PLATFORM_UNSPECIFIED',
-        pluginType: 'GEMINI'
-      }
+        ideType: "ANTIGRAVITY",
+        platform: "PLATFORM_UNSPECIFIED",
+        pluginType: "GEMINI",
+      },
     };
 
     log.info(`[loadCodeAssist] 请求: ${requestUrl}`);
-    const response = await axios(buildAxiosRequestConfig({
-      method: 'POST',
-      url: requestUrl,
-      headers: {
-        'Host': apiHost,
-        'User-Agent': config.api.userAgent,
-        'Authorization': `Bearer ${token.access_token}`,
-        'Content-Type': 'application/json',
-        'Accept-Encoding': 'gzip'
-      },
-      data: JSON.stringify(requestBody)
-    }));
+    const response = await axios(
+      buildAxiosRequestConfig({
+        method: "POST",
+        url: requestUrl,
+        headers: {
+          Host: apiHost,
+          "User-Agent": config.api.userAgent,
+          Authorization: `Bearer ${token.access_token}`,
+          "Content-Type": "application/json",
+          "Accept-Encoding": "gzip",
+        },
+        data: JSON.stringify(requestBody),
+      }),
+    );
 
     const data = response.data;
     // log.info(`[loadCodeAssist] 响应: ${JSON.stringify(data)}`); // 响应可能很大，不打印
@@ -296,18 +349,18 @@ class TokenManager {
     // 检查是否有 currentTier（表示用户已激活）
     let sub = "free-tier";
     if (data?.currentTier) {
-      log.info('[loadCodeAssist] 用户已激活');
+      log.info("[loadCodeAssist] 用户已激活");
       const projectId = data.cloudaicompanionProject;
       if (projectId) {
         log.info(`[loadCodeAssist] 成功获取 projectId: ${projectId}`);
         sub = data.currentTier.id;
-        return {projectId, sub};
+        return { projectId, sub };
       }
-      log.warn('[loadCodeAssist] 响应中无 projectId');
+      log.warn("[loadCodeAssist] 响应中无 projectId");
       return null;
     }
 
-    log.info('[loadCodeAssist] 用户未激活 (无 currentTier)');
+    log.info("[loadCodeAssist] 用户未激活 (无 currentTier)");
     return null;
   }
 
@@ -324,7 +377,7 @@ class TokenManager {
     // 首先获取用户的 tier 信息
     const tierId = await this._getOnboardTier(token);
     if (!tierId) {
-      log.error('[onboardUser] 无法确定用户 tier');
+      log.error("[onboardUser] 无法确定用户 tier");
       return null;
     }
 
@@ -333,10 +386,10 @@ class TokenManager {
     const requestBody = {
       tierId: tierId,
       metadata: {
-        ideType: 'ANTIGRAVITY',
-        platform: 'PLATFORM_UNSPECIFIED',
-        pluginType: 'GEMINI'
-      }
+        ideType: "ANTIGRAVITY",
+        platform: "PLATFORM_UNSPECIFIED",
+        pluginType: "GEMINI",
+      },
     };
 
     log.info(`[onboardUser] 请求: ${requestUrl}`);
@@ -346,19 +399,21 @@ class TokenManager {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       log.info(`[onboardUser] 轮询尝试 ${attempt}/${maxAttempts}`);
 
-      const response = await axios(buildAxiosRequestConfig({
-        method: 'POST',
-        url: requestUrl,
-        headers: {
-          'Host': apiHost,
-          'User-Agent': config.api.userAgent,
-          'Authorization': `Bearer ${token.access_token}`,
-          'Content-Type': 'application/json',
-          'Accept-Encoding': 'gzip'
-        },
-        data: JSON.stringify(requestBody),
-        timeout: 30000
-      }));
+      const response = await axios(
+        buildAxiosRequestConfig({
+          method: "POST",
+          url: requestUrl,
+          headers: {
+            Host: apiHost,
+            "User-Agent": config.api.userAgent,
+            Authorization: `Bearer ${token.access_token}`,
+            "Content-Type": "application/json",
+            "Accept-Encoding": "gzip",
+          },
+          data: JSON.stringify(requestBody),
+          timeout: 30000,
+        }),
+      );
 
       const data = response.data;
       // log.info(`[onboardUser] 响应: ${JSON.stringify(data)}`); // 响应可能很大，不打印
@@ -366,30 +421,30 @@ class TokenManager {
       // 检查长时间运行操作是否完成
       let sub = "g1-pro-tier";
       if (data?.done) {
-        log.info('[onboardUser] 操作完成');
+        log.info("[onboardUser] 操作完成");
         const responseData = data.response || {};
         const projectObj = responseData.cloudaicompanionProject;
 
         let projectId = null;
-        if (typeof projectObj === 'object' && projectObj !== null) {
+        if (typeof projectObj === "object" && projectObj !== null) {
           projectId = projectObj.id;
-        } else if (typeof projectObj === 'string') {
+        } else if (typeof projectObj === "string") {
           projectId = projectObj;
         }
 
         if (projectId) {
           log.info(`[onboardUser] 成功获取 projectId: ${projectId}`);
-          return {projectId,sub};
+          return { projectId, sub };
         }
-        log.warn('[onboardUser] 操作完成但响应中无 projectId');
+        log.warn("[onboardUser] 操作完成但响应中无 projectId");
         return null;
       }
 
-      log.info('[onboardUser] 操作进行中，等待 2 秒...');
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      log.info("[onboardUser] 操作进行中，等待 2 秒...");
+      await new Promise((resolve) => setTimeout(resolve, 2000));
     }
 
-    log.error('[onboardUser] 超时：操作未在 10 秒内完成');
+    log.error("[onboardUser] 超时：操作未在 10 秒内完成");
     return null;
   }
 
@@ -404,28 +459,30 @@ class TokenManager {
     const requestUrl = `https://${apiHost}/v1internal:loadCodeAssist`;
     const requestBody = {
       metadata: {
-        ideType: 'ANTIGRAVITY',
-        platform: 'PLATFORM_UNSPECIFIED',
-        pluginType: 'GEMINI'
-      }
+        ideType: "ANTIGRAVITY",
+        platform: "PLATFORM_UNSPECIFIED",
+        pluginType: "GEMINI",
+      },
     };
 
     log.info(`[_getOnboardTier] 请求: ${requestUrl}`);
 
     try {
-      const response = await axios(buildAxiosRequestConfig({
-        method: 'POST',
-        url: requestUrl,
-        headers: {
-          'Host': apiHost,
-          'User-Agent': config.api.userAgent,
-          'Authorization': `Bearer ${token.access_token}`,
-          'Content-Type': 'application/json',
-          'Accept-Encoding': 'gzip'
-        },
-        data: JSON.stringify(requestBody),
-        timeout: 30000
-      }));
+      const response = await axios(
+        buildAxiosRequestConfig({
+          method: "POST",
+          url: requestUrl,
+          headers: {
+            Host: apiHost,
+            "User-Agent": config.api.userAgent,
+            Authorization: `Bearer ${token.access_token}`,
+            "Content-Type": "application/json",
+            "Accept-Encoding": "gzip",
+          },
+          data: JSON.stringify(requestBody),
+          timeout: 30000,
+        }),
+      );
 
       const data = response.data;
       // log.info(`[_getOnboardTier] 响应: ${JSON.stringify(data)}`); // 响应可能很大，不打印
@@ -440,8 +497,8 @@ class TokenManager {
       }
 
       // 如果没有默认 tier，使用 LEGACY 作为回退
-      log.warn('[_getOnboardTier] 未找到默认 tier，使用 LEGACY');
-      return 'LEGACY';
+      log.warn("[_getOnboardTier] 未找到默认 tier，使用 LEGACY");
+      return "LEGACY";
     } catch (err) {
       log.error(`[_getOnboardTier] 获取 tier 失败: ${err.message}`);
       return null;
@@ -456,7 +513,7 @@ class TokenManager {
   async fetchProjectIdForToken(tokenId) {
     const tokenData = await this.findTokenById(tokenId);
     if (!tokenData) {
-      throw new TokenError('Token不存在', null, 404);
+      throw new TokenError("Token不存在", null, 404);
     }
 
     // 确保 token 未过期
@@ -464,9 +521,9 @@ class TokenManager {
       await this.refreshToken(tokenData);
     }
 
-    const {projectId,sub} = await this.fetchProjectId(tokenData) || {};
+    const { projectId, sub } = (await this.fetchProjectId(tokenData)) || {};
     if (!projectId) {
-      throw new TokenError('无法获取 projectId，该账号可能无资格', null, 400);
+      throw new TokenError("无法获取 projectId，该账号可能无资格", null, 400);
     }
 
     // 更新并保存
@@ -476,7 +533,9 @@ class TokenManager {
     this.saveToFile(tokenData);
 
     // 同步更新内存中的 token
-    const memoryToken = this.tokens.find(t => t.refresh_token === tokenData.refresh_token);
+    const memoryToken = this.tokens.find(
+      (t) => t.refresh_token === tokenData.refresh_token,
+    );
     if (memoryToken) {
       memoryToken.projectId = projectId;
       memoryToken.sub = sub;
@@ -493,7 +552,7 @@ class TokenManager {
    */
   isExpired(token) {
     if (!token.timestamp || !token.expires_in) return true;
-    const expiresAt = token.timestamp + (token.expires_in * 1000);
+    const expiresAt = token.timestamp + token.expires_in * 1000;
     return Date.now() >= expiresAt - TOKEN_REFRESH_BUFFER;
   }
 
@@ -508,22 +567,24 @@ class TokenManager {
     const body = new URLSearchParams({
       client_id: OAUTH_CONFIG.CLIENT_ID,
       client_secret: OAUTH_CONFIG.CLIENT_SECRET,
-      grant_type: 'refresh_token',
-      refresh_token: token.refresh_token
+      grant_type: "refresh_token",
+      refresh_token: token.refresh_token,
     });
 
     try {
-      const response = await axios(buildAxiosRequestConfig({
-        method: 'POST',
-        url: OAUTH_CONFIG.TOKEN_URL,
-        headers: {
-          'Host': 'oauth2.googleapis.com',
-          'User-Agent': 'Go-http-client/1.1',
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept-Encoding': 'gzip'
-        },
-        data: body.toString()
-      }));
+      const response = await axios(
+        buildAxiosRequestConfig({
+          method: "POST",
+          url: OAUTH_CONFIG.TOKEN_URL,
+          headers: {
+            Host: "oauth2.googleapis.com",
+            "User-Agent": "Go-http-client/1.1",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept-Encoding": "gzip",
+          },
+          data: body.toString(),
+        }),
+      );
 
       token.access_token = response.data.access_token;
       token.expires_in = response.data.expires_in;
@@ -531,9 +592,15 @@ class TokenManager {
       this.saveToFile(token);
       return token;
     } catch (error) {
-      const statusCode = error.response?.status;
+      const statusCode =
+        error.response?.status || error.status || error.statusCode || 500;
       const rawBody = error.response?.data;
-      const message = typeof rawBody === 'string' ? rawBody : (rawBody?.error?.message || error.message || '刷新 token 失败');
+      const message =
+        typeof rawBody === "string"
+          ? rawBody
+          : rawBody?.error?.message || error.message || "刷新 token 失败";
+      const reason = `启动检测刷新失败(${statusCode}): ${message}`;
+      this._recordTokenError(token, reason, "startup_refresh");
       throw new TokenError(message, tokenId, statusCode || 500);
     }
   }
@@ -541,19 +608,24 @@ class TokenManager {
   saveToFile(tokenToUpdate = null) {
     // 保持与旧接口同步调用方式一致，内部使用异步写入
     this.store.mergeActiveTokens(this.tokens, tokenToUpdate).catch((error) => {
-      log.error('保存账号配置文件失败:', error.message);
+      log.error("保存账号配置文件失败:", error.message);
     });
   }
 
-  disableToken(token, reason = '未知原因') {
+  disableToken(token, reason = "未知原因") {
     log.warn(`禁用token ...${token.access_token.slice(-8)}, 原因: ${reason}`);
     token.enable = false;
     token.disableReason = reason;
     token.disableTime = Date.now();
+    token.lastError = reason;
+    token.lastErrorTime = token.disableTime;
+    token.lastErrorStage = "disable";
     this.saveToFile();
     // 清理该 token 的请求计数（避免内存泄漏）
     this.tokenRequestCounts.delete(token.refresh_token);
-    this.tokens = this.tokens.filter(t => t.refresh_token !== token.refresh_token);
+    this.tokens = this.tokens.filter(
+      (t) => t.refresh_token !== token.refresh_token,
+    );
     this.currentIndex = this.currentIndex % Math.max(this.tokens.length, 1);
     // tokens 结构发生变化时，重建额度耗尽策略下的可用列表
     this._rebuildAvailableQuotaTokens();
@@ -572,7 +644,6 @@ class TokenManager {
     this.tokenRequestCounts.set(tokenKey, 0);
   }
 
-
   // 标记token额度耗尽
   markQuotaExhausted(token) {
     token.hasQuota = false;
@@ -580,11 +651,14 @@ class TokenManager {
     log.warn(`...${token.access_token.slice(-8)}: 额度已耗尽，标记为无额度`);
 
     if (this.rotationStrategy === RotationStrategy.QUOTA_EXHAUSTED) {
-      const tokenIndex = this.tokens.findIndex(t => t.refresh_token === token.refresh_token);
+      const tokenIndex = this.tokens.findIndex(
+        (t) => t.refresh_token === token.refresh_token,
+      );
       if (tokenIndex !== -1) {
         this._removeQuotaIndex(tokenIndex);
       }
-      this.currentIndex = (this.currentIndex + 1) % Math.max(this.tokens.length, 1);
+      this.currentIndex =
+        (this.currentIndex + 1) % Math.max(this.tokens.length, 1);
     }
   }
 
@@ -609,7 +683,7 @@ class TokenManager {
       quotaManager.recordRequest(tokenId, modelId);
     } catch (error) {
       // 记录失败不影响请求
-      log.warn('记录请求次数失败:', error.message);
+      log.warn("记录请求次数失败:", error.message);
     }
   }
 
@@ -630,12 +704,19 @@ class TokenManager {
       if (config.skipProjectIdFetch) {
         token.projectId = generateProjectId();
         this.saveToFile(token);
-        log.info(`...${token.access_token.slice(-8)}: 使用随机生成的projectId: ${token.projectId}`);
+        log.info(
+          `...${token.access_token.slice(-8)}: 使用随机生成的projectId: ${token.projectId}`,
+        );
       } else {
-        const {projectId,sub} = await this.fetchProjectId(token) || {};
+        const { projectId, sub } = (await this.fetchProjectId(token)) || {};
         if (projectId === undefined) {
-          log.warn(`...${token.access_token.slice(-8)}: 无资格获取projectId，禁用账号`);
-          return { action: 'disable', reason: '无资格获取projectId，该账号可能不支持 Code Assist' };
+          log.warn(
+            `...${token.access_token.slice(-8)}: 无资格获取projectId，禁用账号`,
+          );
+          return {
+            action: "disable",
+            reason: "无资格获取projectId，该账号可能不支持 Code Assist",
+          };
         }
         token.projectId = projectId;
         token.sub = sub;
@@ -643,7 +724,7 @@ class TokenManager {
       }
     }
 
-    return { action: 'ready' };
+    return { action: "ready" };
   }
 
   /**
@@ -654,13 +735,16 @@ class TokenManager {
    * @private
    */
   _handleTokenError(error, token) {
-    const suffix = token.access_token?.slice(-8) || 'unknown';
+    const suffix = token.access_token?.slice(-8) || "unknown";
     if (error.statusCode === 403 || error.statusCode === 400) {
       log.warn(`...${suffix}: Token 已失效或错误，已自动禁用该账号`);
-      return { action: 'disable', reason: `Token准备失败(${error.statusCode}): ${error.message}` };
+      return {
+        action: "disable",
+        reason: `Token准备失败(${error.statusCode}): ${error.message}`,
+      };
     }
     log.error(`...${suffix} 操作失败:`, error.message);
-    return { action: 'skip' };
+    return { action: "skip" };
   }
 
   /**
@@ -668,8 +752,8 @@ class TokenManager {
    * @private
    */
   _resetAllQuotas() {
-    log.warn('所有token额度已耗尽，重置额度状态');
-    this.tokens.forEach(t => {
+    log.warn("所有token额度已耗尽，重置额度状态");
+    this.tokens.forEach((t) => {
       t.hasQuota = true;
     });
     this.saveToFile();
@@ -811,10 +895,13 @@ class TokenManager {
 
       try {
         const result = await this._prepareToken(token);
-        if (result.action === 'disable') {
+        if (result.action === "disable") {
           this.disableToken(token, result.reason);
           this._rebuildAvailableQuotaTokens();
-          if (this.tokens.length === 0 || this.availableQuotaTokenIndices.length === 0) {
+          if (
+            this.tokens.length === 0 ||
+            this.availableQuotaTokenIndices.length === 0
+          ) {
             return null;
           }
           continue;
@@ -825,10 +912,13 @@ class TokenManager {
         return token;
       } catch (error) {
         const errorResult = this._handleTokenError(error, token);
-        if (errorResult.action === 'disable') {
+        if (errorResult.action === "disable") {
           this.disableToken(token, errorResult.reason);
           this._rebuildAvailableQuotaTokens();
-          if (this.tokens.length === 0 || this.availableQuotaTokenIndices.length === 0) {
+          if (
+            this.tokens.length === 0 ||
+            this.availableQuotaTokenIndices.length === 0
+          ) {
             return null;
           }
         }
@@ -870,7 +960,7 @@ class TokenManager {
 
       try {
         const result = await this._prepareToken(token);
-        if (result.action === 'disable') {
+        if (result.action === "disable") {
           this.disableToken(token, result.reason);
           if (this.tokens.length === 0) return null;
           continue;
@@ -895,7 +985,7 @@ class TokenManager {
         return token;
       } catch (error) {
         const errorResult = this._handleTokenError(error, token);
-        if (errorResult.action === 'disable') {
+        if (errorResult.action === "disable") {
           this.disableToken(token, errorResult.reason);
           if (this.tokens.length === 0) return null;
         }
@@ -906,8 +996,10 @@ class TokenManager {
     return null;
   }
 
-  disableCurrentToken(token, reason = 'API请求返回403，账号无使用权限') {
-    const found = this.tokens.find(t => t.access_token === token.access_token);
+  disableCurrentToken(token, reason = "API请求返回403，账号无使用权限") {
+    const found = this.tokens.find(
+      (t) => t.access_token === token.access_token,
+    );
     if (found) {
       this.disableToken(found, reason);
     }
@@ -917,7 +1009,7 @@ class TokenManager {
   async reload() {
     this._initPromise = this._initialize();
     await this._initPromise;
-    log.info('Token已热重载');
+    log.info("Token已热重载");
   }
 
   async addToken(tokenData) {
@@ -929,7 +1021,7 @@ class TokenManager {
         refresh_token: tokenData.refresh_token,
         expires_in: tokenData.expires_in || 3599,
         timestamp: tokenData.timestamp || Date.now(),
-        enable: tokenData.enable !== undefined ? tokenData.enable : true
+        enable: tokenData.enable !== undefined ? tokenData.enable : true,
       };
 
       if (tokenData.projectId) {
@@ -949,9 +1041,9 @@ class TokenManager {
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token添加成功' };
+      return { success: true, message: "Token添加成功" };
     } catch (error) {
-      log.error('添加Token失败:', error.message);
+      log.error("添加Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -960,9 +1052,11 @@ class TokenManager {
     try {
       const allTokens = await this.store.readAll();
 
-      const index = allTokens.findIndex(t => t.refresh_token === refreshToken);
+      const index = allTokens.findIndex(
+        (t) => t.refresh_token === refreshToken,
+      );
       if (index === -1) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       // 重新启用时清除禁用原因
@@ -974,9 +1068,9 @@ class TokenManager {
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token更新成功' };
+      return { success: true, message: "Token更新成功" };
     } catch (error) {
-      log.error('更新Token失败:', error.message);
+      log.error("更新Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -985,17 +1079,19 @@ class TokenManager {
     try {
       const allTokens = await this.store.readAll();
 
-      const filteredTokens = allTokens.filter(t => t.refresh_token !== refreshToken);
+      const filteredTokens = allTokens.filter(
+        (t) => t.refresh_token !== refreshToken,
+      );
       if (filteredTokens.length === allTokens.length) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       await this.store.writeAll(filteredTokens);
 
       await this.reload();
-      return { success: true, message: 'Token删除成功' };
+      return { success: true, message: "Token删除成功" };
     } catch (error) {
-      log.error('删除Token失败:', error.message);
+      log.error("删除Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -1005,7 +1101,7 @@ class TokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      return allTokens.map(token => ({
+      return allTokens.map((token) => ({
         // 使用安全的 tokenId 替代完整的 refresh_token
         id: generateTokenId(token.refresh_token, salt),
         expires_in: token.expires_in,
@@ -1015,10 +1111,13 @@ class TokenManager {
         email: token.email || null,
         hasQuota: token.hasQuota !== false,
         disableReason: token.disableReason || null,
-        disableTime: token.disableTime || null
+        disableTime: token.disableTime || null,
+        lastError: token.lastError || null,
+        lastErrorTime: token.lastErrorTime || null,
+        lastErrorStage: token.lastErrorStage || null,
       }));
     } catch (error) {
-      log.error('获取Token列表失败:', error.message);
+      log.error("获取Token列表失败:", error.message);
       return [];
     }
   }
@@ -1033,11 +1132,13 @@ class TokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      return allTokens.find(token =>
-        generateTokenId(token.refresh_token, salt) === tokenId
-      ) || null;
+      return (
+        allTokens.find(
+          (token) => generateTokenId(token.refresh_token, salt) === tokenId,
+        ) || null
+      );
     } catch (error) {
-      log.error('查找Token失败:', error.message);
+      log.error("查找Token失败:", error.message);
       return null;
     }
   }
@@ -1053,27 +1154,30 @@ class TokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      const index = allTokens.findIndex(token =>
-        generateTokenId(token.refresh_token, salt) === tokenId
+      const index = allTokens.findIndex(
+        (token) => generateTokenId(token.refresh_token, salt) === tokenId,
       );
 
       if (index === -1) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       // 重新启用时清除禁用原因
       if (updates.enable === true) {
         updates.disableReason = null;
         updates.disableTime = null;
+        updates.lastError = null;
+        updates.lastErrorTime = null;
+        updates.lastErrorStage = null;
       }
 
       allTokens[index] = { ...allTokens[index], ...updates };
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token更新成功' };
+      return { success: true, message: "Token更新成功" };
     } catch (error) {
-      log.error('更新Token失败:', error.message);
+      log.error("更新Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -1093,48 +1197,54 @@ class TokenManager {
       project: token.projectId,
       requestId: generateRequestId(),
       request: {
-        contents: [
-          { role: 'user', parts: [{ text: 'hi' }] }
-        ],
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
         generationConfig: {
           maxOutputTokens: 1,
-          candidateCount: 1
+          candidateCount: 1,
         },
-        sessionId: generateSessionId()
+        sessionId: generateSessionId(),
       },
-      model: 'gemini-2.5-flash',
-      userAgent: 'antigravity',
-      requestType: 'agent'
+      model: "gemini-2.5-flash",
+      userAgent: "antigravity",
+      requestType: "agent",
     };
 
     try {
       await httpRequest({
-        method: 'POST',
+        method: "POST",
         url: noStreamUrl,
         headers: {
-          'Host': apiHost,
-          'User-Agent': config.api.userAgent,
-          'Authorization': `Bearer ${token.access_token}`,
-          'Content-Type': 'application/json',
-          'Accept-Encoding': 'gzip'
+          Host: apiHost,
+          "User-Agent": config.api.userAgent,
+          Authorization: `Bearer ${token.access_token}`,
+          "Content-Type": "application/json",
+          "Accept-Encoding": "gzip",
         },
         data: testRequestBody,
-        timeout: 30000
+        timeout: 30000,
       });
       return { ok: true };
     } catch (error) {
-      const status = error.response?.status || error.status || error.statusCode || 500;
-      let errorBody = '';
+      const status =
+        error.response?.status || error.status || error.statusCode || 500;
+      let errorBody = "";
       try {
         const data = error.response?.data;
-        errorBody = typeof data === 'string' ? data : (data ? JSON.stringify(data) : error.message);
+        errorBody =
+          typeof data === "string"
+            ? data
+            : data
+              ? JSON.stringify(data)
+              : error.message;
       } catch {
-        errorBody = error.message || '未知错误';
+        errorBody = error.message || "未知错误";
       }
 
       // 403 且非 "The caller does not have permission"（后者是上下文超限，非权限问题）
       if (status === 403) {
-        const isContextLimit = String(errorBody).includes('The caller does not');
+        const isContextLimit = String(errorBody).includes(
+          "The caller does not",
+        );
         if (!isContextLimit) {
           return { ok: false, status, message: errorBody };
         }
@@ -1154,12 +1264,12 @@ class TokenManager {
     try {
       const tokenData = await this.findTokenById(tokenId);
       if (!tokenData) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       // 如果 token 已经启用，直接返回
       if (tokenData.enable !== false) {
-        return { success: true, message: 'Token已处于启用状态' };
+        return { success: true, message: "Token已处于启用状态" };
       }
 
       log.info(`[启用检测] 正在测试 token ${tokenId} 的可用性...`);
@@ -1170,8 +1280,13 @@ class TokenManager {
       } catch (error) {
         const statusCode = error.statusCode || 500;
         if (statusCode === 403 || statusCode === 400) {
-          log.warn(`[启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`);
-          return { success: false, message: `凭证不可用，刷新失败(${statusCode}): ${error.message}` };
+          log.warn(
+            `[启用检测] token ${tokenId} 刷新失败(${statusCode}): ${error.message}`,
+          );
+          return {
+            success: false,
+            message: `凭证不可用，刷新失败(${statusCode}): ${error.message}`,
+          };
         }
         // 其他错误（如网络问题），也返回失败但提示不同
         log.warn(`[启用检测] token ${tokenId} 刷新失败: ${error.message}`);
@@ -1180,22 +1295,33 @@ class TokenManager {
 
       // 步骤2: 尝试获取 projectId（验证账号权限）
       try {
-        const {projectId, sub} = await this.fetchProjectId(tokenData) || {};
+        const { projectId, sub } = (await this.fetchProjectId(tokenData)) || {};
         if (projectId) {
           tokenData.projectId = projectId;
           tokenData.sub = sub;
         } else if (!tokenData.projectId && !config.skipProjectIdFetch) {
           log.warn(`[启用检测] token ${tokenId} 无法获取 projectId`);
-          return { success: false, message: '凭证不可用: 无法获取 projectId，该账号可能不支持 Code Assist' };
+          return {
+            success: false,
+            message:
+              "凭证不可用: 无法获取 projectId，该账号可能不支持 Code Assist",
+          };
         }
       } catch (error) {
         const statusCode = error.statusCode || 500;
         if (statusCode === 403 || statusCode === 401) {
-          log.warn(`[启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`);
-          return { success: false, message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}` };
+          log.warn(
+            `[启用检测] token ${tokenId} 权限验证失败(${statusCode}): ${error.message}`,
+          );
+          return {
+            success: false,
+            message: `凭证不可用，权限验证失败(${statusCode}): ${error.message}`,
+          };
         }
         // 非致命错误，继续启用（可能只是暂时性网络问题）
-        log.warn(`[启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`);
+        log.warn(
+          `[启用检测] token ${tokenId} 获取 projectId 时出现非致命错误: ${error.message}，继续启用`,
+        );
       }
 
       // 步骤3: 发送测试消息，验证 API 调用是否会触发 403
@@ -1203,10 +1329,12 @@ class TokenManager {
         log.info(`[启用检测] 正在发送测试消息验证 API 可用性...`);
         const testResult = await this._sendTestMessage(tokenData);
         if (!testResult.ok) {
-          log.warn(`[启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`);
+          log.warn(
+            `[启用检测] token ${tokenId} 测试消息失败(${testResult.status}): ${testResult.message}`,
+          );
           return {
             success: false,
-            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`
+            message: `凭证不可用，API 测试失败(${testResult.status}): ${testResult.message}`,
           };
         }
         log.info(`[启用检测] token ${tokenId} 测试消息通过`);
@@ -1218,15 +1346,22 @@ class TokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      const index = allTokens.findIndex(token =>
-        generateTokenId(token.refresh_token, salt) === tokenId
+      const index = allTokens.findIndex(
+        (token) => generateTokenId(token.refresh_token, salt) === tokenId,
       );
 
       if (index === -1) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
-      const updates = { enable: true, disableReason: null, disableTime: null };
+      const updates = {
+        enable: true,
+        disableReason: null,
+        disableTime: null,
+        lastError: null,
+        lastErrorTime: null,
+        lastErrorStage: null,
+      };
       if (tokenData.projectId) updates.projectId = tokenData.projectId;
       if (tokenData.sub) updates.sub = tokenData.sub;
 
@@ -1234,13 +1369,12 @@ class TokenManager {
       await this.store.writeAll(allTokens);
 
       await this.reload();
-      return { success: true, message: 'Token启用成功' };
+      return { success: true, message: "Token启用成功" };
     } catch (error) {
-      log.error('启用Token失败:', error.message);
+      log.error("启用Token失败:", error.message);
       return { success: false, message: `启用失败: ${error.message}` };
     }
   }
-
 
   /**
    * 根据 tokenId 删除 token
@@ -1252,20 +1386,20 @@ class TokenManager {
       const allTokens = await this.store.readAll();
       const salt = await this.store.getSalt();
 
-      const filteredTokens = allTokens.filter(token =>
-        generateTokenId(token.refresh_token, salt) !== tokenId
+      const filteredTokens = allTokens.filter(
+        (token) => generateTokenId(token.refresh_token, salt) !== tokenId,
       );
 
       if (filteredTokens.length === allTokens.length) {
-        return { success: false, message: 'Token不存在' };
+        return { success: false, message: "Token不存在" };
       }
 
       await this.store.writeAll(filteredTokens);
 
       await this.reload();
-      return { success: true, message: 'Token删除成功' };
+      return { success: true, message: "Token删除成功" };
     } catch (error) {
-      log.error('删除Token失败:', error.message);
+      log.error("删除Token失败:", error.message);
       return { success: false, message: error.message };
     }
   }
@@ -1278,13 +1412,13 @@ class TokenManager {
   async refreshTokenById(tokenId) {
     const tokenData = await this.findTokenById(tokenId);
     if (!tokenData) {
-      throw new TokenError('Token不存在', null, 404);
+      throw new TokenError("Token不存在", null, 404);
     }
 
     const refreshedToken = await this.refreshToken(tokenData);
     return {
       expires_in: refreshedToken.expires_in,
-      timestamp: refreshedToken.timestamp
+      timestamp: refreshedToken.timestamp,
     };
   }
 
@@ -1319,7 +1453,7 @@ class TokenManager {
       strategy: this.rotationStrategy,
       requestCount: this.requestCountPerToken,
       currentIndex: this.currentIndex,
-      tokenCounts: Object.fromEntries(this.tokenRequestCounts)
+      tokenCounts: Object.fromEntries(this.tokenRequestCounts),
     };
   }
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -247,11 +247,13 @@ export function getProxyConfig(jsonConfig = {}) {
     jsonConfig.other?.proxyProtocol || "http",
   );
   const proxyPool = normalizeProxyPoolInput(jsonConfig.other?.proxyPool || "");
+  const allRequests = jsonConfig.other?.proxyAllRequests === true;
 
   if (proxyPool) {
     return {
       enabled: true,
       mode: "pool",
+      allRequests,
       protocol: proxyProtocol,
       poolRaw: proxyPool,
       url: null,
@@ -263,6 +265,7 @@ export function getProxyConfig(jsonConfig = {}) {
     return {
       enabled: true,
       mode: "single",
+      allRequests,
       protocol: proxyProtocol,
       poolRaw: "",
       url: process.env.PROXY,
@@ -283,6 +286,7 @@ export function getProxyConfig(jsonConfig = {}) {
     return {
       enabled: true,
       mode: "system",
+      allRequests,
       protocol: systemProxy.startsWith("socks")
         ? "socks5"
         : systemProxy.startsWith("https://")
@@ -296,6 +300,7 @@ export function getProxyConfig(jsonConfig = {}) {
   return {
     enabled: false,
     mode: "none",
+    allRequests,
     protocol: proxyProtocol,
     poolRaw: "",
     url: null,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,22 +1,22 @@
-import dotenv from 'dotenv';
-import fs from 'fs';
-import crypto from 'crypto';
-import log from '../utils/logger.js';
-import { deepMerge } from '../utils/deepMerge.js';
-import { getConfigPaths } from '../utils/paths.js';
-import { parseEnvFile } from '../utils/envParser.js';
+import crypto from "crypto";
+import dotenv from "dotenv";
+import fs from "fs";
 import {
-  DEFAULT_SERVER_PORT,
-  DEFAULT_SERVER_HOST,
-  DEFAULT_HEARTBEAT_INTERVAL,
-  DEFAULT_TIMEOUT,
-  DEFAULT_RETRY_TIMES,
-  DEFAULT_MAX_REQUEST_SIZE,
-  DEFAULT_MAX_IMAGES,
-  MODEL_LIST_CACHE_TTL,
   DEFAULT_GENERATION_PARAMS,
-  MEMORY_CLEANUP_INTERVAL
-} from '../constants/index.js';
+  DEFAULT_HEARTBEAT_INTERVAL,
+  DEFAULT_MAX_IMAGES,
+  DEFAULT_MAX_REQUEST_SIZE,
+  DEFAULT_RETRY_TIMES,
+  DEFAULT_SERVER_HOST,
+  DEFAULT_SERVER_PORT,
+  DEFAULT_TIMEOUT,
+  MEMORY_CLEANUP_INTERVAL,
+  MODEL_LIST_CACHE_TTL,
+} from "../constants/index.js";
+import { deepMerge } from "../utils/deepMerge.js";
+import { parseEnvFile } from "../utils/envParser.js";
+import log from "../utils/logger.js";
+import { getConfigPaths } from "../utils/paths.js";
 
 // 生成随机凭据的缓存
 let generatedCredentials = null;
@@ -36,7 +36,7 @@ function getApiKey() {
 
   // 生成随机 API_KEY（只生成一次）
   if (!generatedApiKey) {
-    generatedApiKey = 'sk-' + crypto.randomBytes(24).toString('hex');
+    generatedApiKey = "sk-" + crypto.randomBytes(24).toString("hex");
   }
 
   return generatedApiKey;
@@ -62,9 +62,11 @@ function getAdminCredentials() {
   // 生成随机凭据（只生成一次）
   if (!generatedCredentials) {
     generatedCredentials = {
-      username: username || crypto.randomBytes(8).toString('hex'),
-      password: password || crypto.randomBytes(16).toString('base64').replace(/[+/=]/g, ''),
-      jwtSecret: jwtSecret || crypto.randomBytes(32).toString('hex')
+      username: username || crypto.randomBytes(8).toString("hex"),
+      password:
+        password ||
+        crypto.randomBytes(16).toString("base64").replace(/[+/=]/g, ""),
+      jwtSecret: jwtSecret || crypto.randomBytes(32).toString("hex"),
     };
   }
 
@@ -91,8 +93,8 @@ function displayGeneratedCredentials() {
   // 如果有任何凭据需要生成，显示提示
   if (needsUsername || needsPassword || needsApiKey) {
     const credentials = getAdminCredentials();
-    log.warn('═══════════════════════════════════════════════════════════');
-    log.warn('⚠️  未配置完整凭据，已自动生成随机凭据：');
+    log.warn("═══════════════════════════════════════════════════════════");
+    log.warn("⚠️  未配置完整凭据，已自动生成随机凭据：");
     if (needsUsername) {
       log.warn(`    用户名: ${credentials.username}`);
     }
@@ -102,21 +104,22 @@ function displayGeneratedCredentials() {
     if (needsApiKey) {
       log.warn(`    API密钥: ${getApiKey()}`);
     }
-    log.warn('═══════════════════════════════════════════════════════════');
-    log.warn('⚠️  重启后凭据将重新生成！建议在 .env 文件中配置：');
-    if (needsUsername) log.warn('    ADMIN_USERNAME=你的用户名');
-    if (needsPassword) log.warn('    ADMIN_PASSWORD=你的密码');
-    if (needsApiKey) log.warn('    API_KEY=你的密钥');
-    log.warn('═══════════════════════════════════════════════════════════');
+    log.warn("═══════════════════════════════════════════════════════════");
+    log.warn("⚠️  重启后凭据将重新生成！建议在 .env 文件中配置：");
+    if (needsUsername) log.warn("    ADMIN_USERNAME=你的用户名");
+    if (needsPassword) log.warn("    ADMIN_PASSWORD=你的密码");
+    if (needsApiKey) log.warn("    API_KEY=你的密钥");
+    log.warn("═══════════════════════════════════════════════════════════");
   } else if (needsJwtSecret) {
-    log.warn('⚠️ 未配置 JWT_SECRET，已生成随机密钥（重启后登录会话将失效）');
+    log.warn("⚠️ 未配置 JWT_SECRET，已生成随机密钥（重启后登录会话将失效）");
   }
 }
 
 const { envPath, configJsonPath, configJsonExamplePath } = getConfigPaths();
 
 // 默认反代系统提示词
-const DEFAULT_SYSTEM_INSTRUCTION = '你是聊天机器人，名字叫萌萌，如同名字这般，你的性格是软软糯糯萌萌哒的，专门为用户提供聊天和情绪价值，协助进行小说创作或者角色扮演';
+const DEFAULT_SYSTEM_INSTRUCTION =
+  "你是聊天机器人，名字叫萌萌，如同名字这般，你的性格是软软糯糯萌萌哒的，专门为用户提供聊天和情绪价值，协助进行小说创作或者角色扮演";
 
 // 默认官方系统提示词（反重力官方要求的）
 const DEFAULT_OFFICIAL_SYSTEM_PROMPT = `<example_only do_not_follow="true" type="counter-example" ignore="true">
@@ -144,20 +147,20 @@ SYSTEM_INSTRUCTION=${DEFAULT_SYSTEM_INSTRUCTION}
 
 # IMAGE_BASE_URL=http://your-domain.com
 `;
-  fs.writeFileSync(envPath, defaultEnvContent, 'utf8');
-  log.info('✓ 已创建 .env 文件，包含默认反代系统提示词');
+  fs.writeFileSync(envPath, defaultEnvContent, "utf8");
+  log.info("✓ 已创建 .env 文件，包含默认反代系统提示词");
 }
 
 // 确保 config.json 存在（如果缺失则从 config.json.example 复制）
 if (!fs.existsSync(configJsonPath) && fs.existsSync(configJsonExamplePath)) {
   fs.copyFileSync(configJsonExamplePath, configJsonPath);
-  log.info('✓ 已从 config.json.example 创建 config.json');
+  log.info("✓ 已从 config.json.example 创建 config.json");
 }
 
 // 加载 config.json
 let jsonConfig = {};
 if (fs.existsSync(configJsonPath)) {
-  jsonConfig = JSON.parse(fs.readFileSync(configJsonPath, 'utf8'));
+  jsonConfig = JSON.parse(fs.readFileSync(configJsonPath, "utf8"));
 }
 
 // 加载 .env（指定路径）
@@ -168,16 +171,50 @@ dotenv.config({ path: envPath });
 function processEscapeChars(value) {
   if (!value) return value;
   return value
-    .replace(/\\\\n/g, '\n')  // 先处理双重转义 \\n -> 换行
-    .replace(/\\n/g, '\n');   // 再处理单重转义 \n -> 换行
+    .replace(/\\\\n/g, "\n") // 先处理双重转义 \\n -> 换行
+    .replace(/\\n/g, "\n"); // 再处理单重转义 \n -> 换行
+}
+
+function normalizeProxyProtocol(protocol = "http") {
+  const normalized = String(protocol || "http")
+    .trim()
+    .toLowerCase();
+
+  if (
+    normalized === "socket5" ||
+    normalized === "socks" ||
+    normalized === "socks5"
+  ) {
+    return "socks5";
+  }
+
+  if (normalized === "https") {
+    return "https";
+  }
+
+  return "http";
+}
+
+function normalizeProxyPoolInput(poolRaw = "") {
+  return String(poolRaw ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
 }
 
 if (process.env.SYSTEM_INSTRUCTION) {
-  process.env.SYSTEM_INSTRUCTION = processEscapeChars(process.env.SYSTEM_INSTRUCTION);
+  process.env.SYSTEM_INSTRUCTION = processEscapeChars(
+    process.env.SYSTEM_INSTRUCTION,
+  );
 }
 
 if (process.env.OFFICIAL_SYSTEM_PROMPT) {
-  process.env.OFFICIAL_SYSTEM_PROMPT = processEscapeChars(process.env.OFFICIAL_SYSTEM_PROMPT);
+  process.env.OFFICIAL_SYSTEM_PROMPT = processEscapeChars(
+    process.env.OFFICIAL_SYSTEM_PROMPT,
+  );
 }
 
 // 对于系统提示词，使用自定义解析器重新加载以支持更复杂的多行格式
@@ -194,7 +231,9 @@ try {
   if (customEnv.OFFICIAL_SYSTEM_PROMPT) {
     let customValue = processEscapeChars(customEnv.OFFICIAL_SYSTEM_PROMPT);
     // 如果自定义解析器得到的值更长，使用它
-    if (customValue.length > (process.env.OFFICIAL_SYSTEM_PROMPT?.length || 0)) {
+    if (
+      customValue.length > (process.env.OFFICIAL_SYSTEM_PROMPT?.length || 0)
+    ) {
       process.env.OFFICIAL_SYSTEM_PROMPT = customValue;
     }
   }
@@ -202,15 +241,37 @@ try {
   // 忽略解析错误，使用 dotenv 的结果
 }
 
-// 获取代理配置：优先使用 PROXY，其次使用系统代理环境变量
-export function getProxyConfig() {
+// 获取代理配置：优先使用代理池，其次使用 PROXY，最后使用系统代理环境变量
+export function getProxyConfig(jsonConfig = {}) {
+  const proxyProtocol = normalizeProxyProtocol(
+    jsonConfig.other?.proxyProtocol || "http",
+  );
+  const proxyPool = normalizeProxyPoolInput(jsonConfig.other?.proxyPool || "");
+
+  if (proxyPool) {
+    return {
+      enabled: true,
+      mode: "pool",
+      protocol: proxyProtocol,
+      poolRaw: proxyPool,
+      url: null,
+    };
+  }
+
   // 优先使用显式配置的 PROXY
   if (process.env.PROXY) {
-    return process.env.PROXY;
+    return {
+      enabled: true,
+      mode: "single",
+      protocol: proxyProtocol,
+      poolRaw: "",
+      url: process.env.PROXY,
+    };
   }
 
   // 检查系统代理环境变量（按优先级）
-  const systemProxy = process.env.HTTPS_PROXY ||
+  const systemProxy =
+    process.env.HTTPS_PROXY ||
     process.env.https_proxy ||
     process.env.HTTP_PROXY ||
     process.env.http_proxy ||
@@ -219,44 +280,69 @@ export function getProxyConfig() {
 
   if (systemProxy) {
     log.info(`使用系统代理: ${systemProxy}`);
+    return {
+      enabled: true,
+      mode: "system",
+      protocol: systemProxy.startsWith("socks")
+        ? "socks5"
+        : systemProxy.startsWith("https://")
+          ? "https"
+          : "http",
+      poolRaw: "",
+      url: systemProxy,
+    };
   }
 
-  return systemProxy || null;
+  return {
+    enabled: false,
+    mode: "none",
+    protocol: proxyProtocol,
+    poolRaw: "",
+    url: null,
+  };
 }
 
 // 默认 API 配置（Antigravity）
 const DEFAULT_API_CONFIGS = {
   sandbox: {
-    url: 'https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse',
-    modelsUrl: 'https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels',
-    noStreamUrl: 'https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:generateContent',
-    recordTrajectory: 'https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:recordTrajectoryAnalytics',
-    recordCodeAssistMetrics: "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:recordCodeAssistMetrics",
-    host: 'daily-cloudcode-pa.sandbox.googleapis.com'
+    url: "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+    modelsUrl:
+      "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+    noStreamUrl:
+      "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:generateContent",
+    recordTrajectory:
+      "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:recordTrajectoryAnalytics",
+    recordCodeAssistMetrics:
+      "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:recordCodeAssistMetrics",
+    host: "daily-cloudcode-pa.sandbox.googleapis.com",
   },
   production: {
-    url: 'https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse',
-    modelsUrl: 'https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels',
-    noStreamUrl: 'https://daily-cloudcode-pa.googleapis.com/v1internal:generateContent',
-    recordTrajectory: 'https://daily-cloudcode-pa.googleapis.com/v1internal:recordTrajectoryAnalytics',
-    recordCodeAssistMetrics: "https://daily-cloudcode-pa.googleapis.com/v1internal:recordCodeAssistMetrics",
-    host: 'daily-cloudcode-pa.googleapis.com'
-  }
+    url: "https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+    modelsUrl:
+      "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+    noStreamUrl:
+      "https://daily-cloudcode-pa.googleapis.com/v1internal:generateContent",
+    recordTrajectory:
+      "https://daily-cloudcode-pa.googleapis.com/v1internal:recordTrajectoryAnalytics",
+    recordCodeAssistMetrics:
+      "https://daily-cloudcode-pa.googleapis.com/v1internal:recordCodeAssistMetrics",
+    host: "daily-cloudcode-pa.googleapis.com",
+  },
 };
 
 const DEFAULT_API_UNLEASH = {
-    register: "https://antigravity-unleash.goog/api/client/register",
-    features: "https://antigravity-unleash.goog/api/client/features",
-    frontend: "https://antigravity-unleash.goog/api/frontend"
-}
+  register: "https://antigravity-unleash.goog/api/client/register",
+  features: "https://antigravity-unleash.goog/api/client/features",
+  frontend: "https://antigravity-unleash.goog/api/frontend",
+};
 
 // Gemini CLI API 配置（来自 gcli2api 项目）
 // 使用 v1internal 端点，模型名称在请求体中指定
 const DEFAULT_GEMINICLI_API_CONFIG = {
-  url: 'https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse',
-  noStreamUrl: 'https://cloudcode-pa.googleapis.com/v1internal:generateContent',
-  host: 'cloudcode-pa.googleapis.com',
-  userAgent: 'GeminiCLI/0.1.5 (Windows; AMD64)'
+  url: "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+  noStreamUrl: "https://cloudcode-pa.googleapis.com/v1internal:generateContent",
+  host: "cloudcode-pa.googleapis.com",
+  userAgent: "GeminiCLI/0.1.5 (Windows; AMD64)",
 };
 
 /**
@@ -265,22 +351,26 @@ const DEFAULT_GEMINICLI_API_CONFIG = {
  * @returns {Object} 当前 API 配置
  */
 function getActiveApiConfig(jsonConfig) {
-  const apiUse = jsonConfig.api?.use || 'production';
+  const apiUse = jsonConfig.api?.use || "production";
   const customConfig = jsonConfig.api?.[apiUse];
-  const defaultConfig = DEFAULT_API_CONFIGS[apiUse] || DEFAULT_API_CONFIGS.production;
-  const unleash = jsonConfig.api?.unleash || DEFAULT_API_UNLEASH
+  const defaultConfig =
+    DEFAULT_API_CONFIGS[apiUse] || DEFAULT_API_CONFIGS.production;
+  const unleash = jsonConfig.api?.unleash || DEFAULT_API_UNLEASH;
 
   return {
     use: apiUse,
     url: customConfig?.url || defaultConfig.url,
     modelsUrl: customConfig?.modelsUrl || defaultConfig.modelsUrl,
     noStreamUrl: customConfig?.noStreamUrl || defaultConfig.noStreamUrl,
-    recordTrajectory: customConfig?.recordTrajectory || defaultConfig.recordTrajectory,
-    recordCodeAssistMetrics: customConfig?.recordCodeAssistMetrics || defaultConfig.recordCodeAssistMetrics,
+    recordTrajectory:
+      customConfig?.recordTrajectory || defaultConfig.recordTrajectory,
+    recordCodeAssistMetrics:
+      customConfig?.recordCodeAssistMetrics ||
+      defaultConfig.recordCodeAssistMetrics,
     host: customConfig?.host || defaultConfig.host,
-    userAgent: `antigravity/${jsonConfig.api?.version || "1.19.5" } windows/amd64`,
+    userAgent: `antigravity/${jsonConfig.api?.version || "1.19.5"} windows/amd64`,
     ideVersion: jsonConfig.api?.version || "1.19.5",
-    unleash: unleash
+    unleash: unleash,
   };
 }
 
@@ -294,9 +384,11 @@ function getGeminiCliApiConfig(jsonConfig) {
 
   return {
     url: customConfig?.url || DEFAULT_GEMINICLI_API_CONFIG.url,
-    noStreamUrl: customConfig?.noStreamUrl || DEFAULT_GEMINICLI_API_CONFIG.noStreamUrl,
+    noStreamUrl:
+      customConfig?.noStreamUrl || DEFAULT_GEMINICLI_API_CONFIG.noStreamUrl,
     host: customConfig?.host || DEFAULT_GEMINICLI_API_CONFIG.host,
-    userAgent: customConfig?.userAgent || DEFAULT_GEMINICLI_API_CONFIG.userAgent
+    userAgent:
+      customConfig?.userAgent || DEFAULT_GEMINICLI_API_CONFIG.userAgent,
   };
 }
 
@@ -312,49 +404,61 @@ export function buildConfig(jsonConfig) {
     server: {
       port: jsonConfig.server?.port || DEFAULT_SERVER_PORT,
       host: jsonConfig.server?.host || DEFAULT_SERVER_HOST,
-      heartbeatInterval: jsonConfig.server?.heartbeatInterval || DEFAULT_HEARTBEAT_INTERVAL,
+      heartbeatInterval:
+        jsonConfig.server?.heartbeatInterval || DEFAULT_HEARTBEAT_INTERVAL,
       // 内存定时清理频率：避免频繁扫描/GC 带来的性能损耗
-      memoryCleanupInterval: jsonConfig.server?.memoryCleanupInterval ?? MEMORY_CLEANUP_INTERVAL
+      memoryCleanupInterval:
+        jsonConfig.server?.memoryCleanupInterval ?? MEMORY_CLEANUP_INTERVAL,
     },
     cache: {
-      modelListTTL: jsonConfig.cache?.modelListTTL || MODEL_LIST_CACHE_TTL
+      modelListTTL: jsonConfig.cache?.modelListTTL || MODEL_LIST_CACHE_TTL,
     },
     rotation: {
-      strategy: jsonConfig.rotation?.strategy || 'round_robin',
-      requestCount: jsonConfig.rotation?.requestCount || 10
+      strategy: jsonConfig.rotation?.strategy || "round_robin",
+      requestCount: jsonConfig.rotation?.requestCount || 10,
     },
     // 日志配置
     log: {
-      maxSizeMB: jsonConfig.log?.maxSizeMB || 10,    // 单个日志文件最大 MB
-      maxFiles: jsonConfig.log?.maxFiles || 5,       // 保留历史文件数
-      maxMemory: jsonConfig.log?.maxMemory || 500    // 内存中保留条数
+      maxSizeMB: jsonConfig.log?.maxSizeMB || 10, // 单个日志文件最大 MB
+      maxFiles: jsonConfig.log?.maxFiles || 5, // 保留历史文件数
+      maxMemory: jsonConfig.log?.maxMemory || 500, // 内存中保留条数
     },
     imageBaseUrl: process.env.IMAGE_BASE_URL || null,
     maxImages: jsonConfig.other?.maxImages || DEFAULT_MAX_IMAGES,
     api: apiConfig,
     defaults: {
-      temperature: jsonConfig.defaults?.temperature ?? DEFAULT_GENERATION_PARAMS.temperature,
+      temperature:
+        jsonConfig.defaults?.temperature ??
+        DEFAULT_GENERATION_PARAMS.temperature,
       top_p: jsonConfig.defaults?.topP ?? DEFAULT_GENERATION_PARAMS.top_p,
       top_k: jsonConfig.defaults?.topK ?? DEFAULT_GENERATION_PARAMS.top_k,
-      max_tokens: jsonConfig.defaults?.maxTokens ?? DEFAULT_GENERATION_PARAMS.max_tokens,
-      thinking_budget: jsonConfig.defaults?.thinkingBudget ?? DEFAULT_GENERATION_PARAMS.thinking_budget
+      max_tokens:
+        jsonConfig.defaults?.maxTokens ?? DEFAULT_GENERATION_PARAMS.max_tokens,
+      thinking_budget:
+        jsonConfig.defaults?.thinkingBudget ??
+        DEFAULT_GENERATION_PARAMS.thinking_budget,
     },
     security: {
-      maxRequestSize: jsonConfig.server?.maxRequestSize || DEFAULT_MAX_REQUEST_SIZE,
-      apiKey: getApiKey()
+      maxRequestSize:
+        jsonConfig.server?.maxRequestSize || DEFAULT_MAX_REQUEST_SIZE,
+      apiKey: getApiKey(),
     },
     admin: getAdminCredentials(),
     useNativeAxios: jsonConfig.other?.useNativeAxios !== false,
     forceIPv4: jsonConfig.other?.forceIPv4 === true,
     timeout: jsonConfig.other?.timeout || DEFAULT_TIMEOUT,
-    retryTimes: Number.isFinite(jsonConfig.other?.retryTimes) ? jsonConfig.other.retryTimes : DEFAULT_RETRY_TIMES,
-    proxy: getProxyConfig(),
+    retryTimes: Number.isFinite(jsonConfig.other?.retryTimes)
+      ? jsonConfig.other.retryTimes
+      : DEFAULT_RETRY_TIMES,
+    proxy: getProxyConfig(jsonConfig),
     // 反代系统提示词（从 .env 读取，可在前端修改，空字符串代表不使用）
-    systemInstruction: process.env.SYSTEM_INSTRUCTION ?? '',
+    systemInstruction: process.env.SYSTEM_INSTRUCTION ?? "",
     // 官方系统提示词（从 .env 读取，可在前端修改，空字符串代表不使用）
-    officialSystemPrompt: process.env.OFFICIAL_SYSTEM_PROMPT ?? DEFAULT_OFFICIAL_SYSTEM_PROMPT,
+    officialSystemPrompt:
+      process.env.OFFICIAL_SYSTEM_PROMPT ?? DEFAULT_OFFICIAL_SYSTEM_PROMPT,
     // 官方提示词位置配置：'before' = 官方提示词在反代提示词前面，'after' = 官方提示词在反代提示词后面
-    officialPromptPosition: jsonConfig.other?.officialPromptPosition || 'before',
+    officialPromptPosition:
+      jsonConfig.other?.officialPromptPosition || "before",
     // 是否合并系统提示词为单个 part，false 则保留多 part 结构（需要先开启 useContextSystemPrompt）
     mergeSystemPrompt: jsonConfig.other?.mergeSystemPrompt !== false,
     skipProjectIdFetch: jsonConfig.other?.skipProjectIdFetch === true,
@@ -362,16 +466,17 @@ export function buildConfig(jsonConfig) {
     passSignatureToClient: jsonConfig.other?.passSignatureToClient === true,
     useFallbackSignature: jsonConfig.other?.useFallbackSignature === true,
     // 签名缓存配置（新版）
-    cacheAllSignatures: jsonConfig.other?.cacheAllSignatures === true ||
-      process.env.CACHE_ALL_SIGNATURES === '1' ||
-      process.env.CACHE_ALL_SIGNATURES === 'true',
+    cacheAllSignatures:
+      jsonConfig.other?.cacheAllSignatures === true ||
+      process.env.CACHE_ALL_SIGNATURES === "1" ||
+      process.env.CACHE_ALL_SIGNATURES === "true",
     cacheToolSignatures: jsonConfig.other?.cacheToolSignatures !== false,
     cacheImageSignatures: jsonConfig.other?.cacheImageSignatures !== false,
     cacheThinking: jsonConfig.other?.cacheThinking !== false,
     // 假非流：非流式请求使用流式获取数据后返回非流式格式（默认启用）
     fakeNonStream: jsonConfig.other?.fakeNonStream !== false,
     // 调试：完整打印最终请求体与原始响应（可能包含敏感内容/大体积数据，只从环境变量读取）
-    debugDumpRequestResponse: process.env.DEBUG_DUMP_REQUEST_RESPONSE === '1',
+    debugDumpRequestResponse: process.env.DEBUG_DUMP_REQUEST_RESPONSE === "1",
 
     // ==================== Gemini CLI 配置 ====================
     geminicli: {
@@ -381,25 +486,41 @@ export function buildConfig(jsonConfig) {
       api: getGeminiCliApiConfig(jsonConfig),
       // Token 轮换策略
       rotation: {
-        strategy: jsonConfig.geminicli?.rotation?.strategy || 'round_robin',
-        requestCount: jsonConfig.geminicli?.rotation?.requestCount || 10
+        strategy: jsonConfig.geminicli?.rotation?.strategy || "round_robin",
+        requestCount: jsonConfig.geminicli?.rotation?.requestCount || 10,
       },
       // 默认生成参数（可覆盖全局默认值）
       defaults: {
-        temperature: jsonConfig.geminicli?.defaults?.temperature ?? jsonConfig.defaults?.temperature ?? DEFAULT_GENERATION_PARAMS.temperature,
-        top_p: jsonConfig.geminicli?.defaults?.topP ?? jsonConfig.defaults?.topP ?? DEFAULT_GENERATION_PARAMS.top_p,
-        top_k: jsonConfig.geminicli?.defaults?.topK ?? jsonConfig.defaults?.topK ?? DEFAULT_GENERATION_PARAMS.top_k,
-        max_tokens: jsonConfig.geminicli?.defaults?.maxTokens ?? jsonConfig.defaults?.maxTokens ?? DEFAULT_GENERATION_PARAMS.max_tokens,
-        thinking_budget: jsonConfig.geminicli?.defaults?.thinkingBudget ?? jsonConfig.defaults?.thinkingBudget ?? DEFAULT_GENERATION_PARAMS.thinking_budget
-      }
-    }
+        temperature:
+          jsonConfig.geminicli?.defaults?.temperature ??
+          jsonConfig.defaults?.temperature ??
+          DEFAULT_GENERATION_PARAMS.temperature,
+        top_p:
+          jsonConfig.geminicli?.defaults?.topP ??
+          jsonConfig.defaults?.topP ??
+          DEFAULT_GENERATION_PARAMS.top_p,
+        top_k:
+          jsonConfig.geminicli?.defaults?.topK ??
+          jsonConfig.defaults?.topK ??
+          DEFAULT_GENERATION_PARAMS.top_k,
+        max_tokens:
+          jsonConfig.geminicli?.defaults?.maxTokens ??
+          jsonConfig.defaults?.maxTokens ??
+          DEFAULT_GENERATION_PARAMS.max_tokens,
+        thinking_budget:
+          jsonConfig.geminicli?.defaults?.thinkingBudget ??
+          jsonConfig.defaults?.thinkingBudget ??
+          DEFAULT_GENERATION_PARAMS.thinking_budget,
+      },
+    },
   };
 }
 
 const config = buildConfig(jsonConfig);
 
 // 版本更新检查接口
-const VERSION_CHECK_URL = 'https://antigravity-auto-updater-974169037036.us-central1.run.app/releases';
+const VERSION_CHECK_URL =
+  "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases";
 
 /**
  * 比较两个语义化版本号
@@ -408,8 +529,8 @@ const VERSION_CHECK_URL = 'https://antigravity-auto-updater-974169037036.us-cent
  * @returns {number} a > b 返回 1，a < b 返回 -1，相等返回 0
  */
 function compareVersions(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;
@@ -428,7 +549,9 @@ export async function checkAndUpdateVersion() {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
 
-    const response = await fetch(VERSION_CHECK_URL, { signal: controller.signal });
+    const response = await fetch(VERSION_CHECK_URL, {
+      signal: controller.signal,
+    });
     clearTimeout(timeout);
 
     if (!response.ok) {
@@ -437,8 +560,12 @@ export async function checkAndUpdateVersion() {
     }
 
     const releases = await response.json();
-    if (!Array.isArray(releases) || releases.length === 0 || !releases[0].version) {
-      log.warn('版本检查返回数据格式异常');
+    if (
+      !Array.isArray(releases) ||
+      releases.length === 0 ||
+      !releases[0].version
+    ) {
+      log.warn("版本检查返回数据格式异常");
       return;
     }
 
@@ -446,7 +573,9 @@ export async function checkAndUpdateVersion() {
     const currentVersion = config.api.ideVersion;
 
     if (compareVersions(latestVersion, currentVersion) > 0) {
-      log.info(`发现新版本: ${currentVersion} → ${latestVersion}，正在更新配置...`);
+      log.info(
+        `发现新版本: ${currentVersion} → ${latestVersion}，正在更新配置...`,
+      );
 
       // 更新 config.json
       saveConfigJson({ api: { version: latestVersion } });
@@ -460,8 +589,8 @@ export async function checkAndUpdateVersion() {
       log.info(`当前版本 ${currentVersion} 已是最新`);
     }
   } catch (err) {
-    if (err.name === 'AbortError') {
-      log.warn('版本检查超时，跳过更新');
+    if (err.name === "AbortError") {
+      log.warn("版本检查超时，跳过更新");
     } else {
       log.warn(`版本检查失败: ${err.message}`);
     }
@@ -471,13 +600,13 @@ export async function checkAndUpdateVersion() {
 // 显示生成的凭据提示
 displayGeneratedCredentials();
 
-log.info('✓ 配置加载成功');
+log.info("✓ 配置加载成功");
 
 export default config;
 
 export function getConfigJson() {
   if (fs.existsSync(configJsonPath)) {
-    return JSON.parse(fs.readFileSync(configJsonPath, 'utf8'));
+    return JSON.parse(fs.readFileSync(configJsonPath, "utf8"));
   }
   return {};
 }
@@ -485,5 +614,5 @@ export function getConfigJson() {
 export function saveConfigJson(data) {
   const existing = getConfigJson();
   const merged = deepMerge(existing, data);
-  fs.writeFileSync(configJsonPath, JSON.stringify(merged, null, 2), 'utf8');
+  fs.writeFileSync(configJsonPath, JSON.stringify(merged, null, 2), "utf8");
 }

--- a/src/requester.js
+++ b/src/requester.js
@@ -4,7 +4,11 @@ import { arch, platform } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import zlib from "zlib";
-import { getNextProxyConfig } from "./utils/proxyPool.js";
+import logger from "./utils/logger.js";
+import {
+  formatProxyRequestInfo,
+  getNextProxyConfig,
+} from "./utils/proxyPool.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -133,6 +137,9 @@ class FingerprintRequester {
       proxy !== undefined ? proxy : this.defaults.proxy,
     );
     if (proxyConfig) {
+      if (proxyConfig.isPool) {
+        logger.info(`[ProxyPool] ${formatProxyRequestInfo(proxyConfig, url)}`);
+      }
       requestPayload.proxy = {
         enabled: true,
         type: proxyConfig.protocol,

--- a/src/requester.js
+++ b/src/requester.js
@@ -1,14 +1,15 @@
-import { spawn } from 'child_process';
-import { existsSync, chmodSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
-import { platform, arch } from 'os';
-import zlib from 'zlib';
+import { spawn } from "child_process";
+import { chmodSync, existsSync } from "fs";
+import { arch, platform } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import zlib from "zlib";
+import { getNextProxyConfig } from "./utils/proxyPool.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // 检测是否在 pkg 打包环境中运行
-const isPkg = typeof process.pkg !== 'undefined';
+const isPkg = typeof process.pkg !== "undefined";
 
 // gzip 解压辅助函数
 function decompressGzip(buffer) {
@@ -24,7 +25,8 @@ class FingerprintRequester {
   constructor(options = {}) {
     this.binDir = options.binDir || this._detectBinDir();
     this.binaryPath = options.binaryPath || this._detectBinary();
-    this.configPath = options.configPath || join(__dirname, 'bin', 'config.json');
+    this.configPath =
+      options.configPath || join(__dirname, "bin", "config.json");
     this.defaults = {
       timeout: options.timeout || 30, // seconds
       proxy: options.proxy || null,
@@ -36,31 +38,31 @@ class FingerprintRequester {
     // pkg 环境下优先使用可执行文件旁边的 bin 目录
     if (isPkg) {
       const exeDir = dirname(process.execPath);
-      const exeBinDir = join(exeDir, 'bin');
+      const exeBinDir = join(exeDir, "bin");
       if (existsSync(exeBinDir)) {
         return exeBinDir;
       }
       // 其次使用当前工作目录的 bin 目录
-      const cwdBinDir = join(process.cwd(), 'bin');
+      const cwdBinDir = join(process.cwd(), "bin");
       if (existsSync(cwdBinDir)) {
         return cwdBinDir;
       }
     }
     // 开发环境
-    return join(__dirname, 'bin');
+    return join(__dirname, "bin");
   }
 
   _detectBinary() {
     const platformMap = {
-      win32: 'windows',
-      linux: 'linux',
-      android: 'android',
-      darwin: 'linux', // fallback to linux for macOS
+      win32: "windows",
+      linux: "linux",
+      android: "android",
+      darwin: "linux", // fallback to linux for macOS
     };
 
     const archMap = {
-      x64: 'amd64',
-      arm64: 'arm64',
+      x64: "amd64",
+      arm64: "arm64",
     };
 
     const os = platformMap[platform()];
@@ -70,7 +72,7 @@ class FingerprintRequester {
       throw new Error(`Unsupported platform: ${platform()} ${arch()}`);
     }
 
-    const ext = platform() === 'win32' ? '.exe' : '';
+    const ext = platform() === "win32" ? ".exe" : "";
     const binaryName = `fingerprint_${os}_${cpuArch}${ext}`;
     const binaryPath = join(this.binDir, binaryName);
 
@@ -79,7 +81,7 @@ class FingerprintRequester {
     }
 
     // 确保二进制文件有执行权限（非 Windows 平台）
-    if (platform() !== 'win32') {
+    if (platform() !== "win32") {
       try {
         chmodSync(binaryPath, 0o755);
       } catch (e) {
@@ -92,13 +94,13 @@ class FingerprintRequester {
 
   async request(config) {
     const {
-      method = 'GET',
+      method = "GET",
       url,
       headers = {},
-      data = '',
+      data = "",
       timeout,
       proxy,
-      responseType = 'text',
+      responseType = "text",
       onDownloadProgress,
       validateStatus = (status) => status >= 200 && status < 300,
       signal,
@@ -106,14 +108,14 @@ class FingerprintRequester {
     } = config;
 
     if (!url) {
-      throw new Error('URL is required');
+      throw new Error("URL is required");
     }
 
     const requestPayload = {
       method: method.toUpperCase(),
       url,
       headers,
-      body: typeof data === 'string' ? data : JSON.stringify(data),
+      body: typeof data === "string" ? data : JSON.stringify(data),
       config_path: this.configPath,
     };
 
@@ -127,13 +129,14 @@ class FingerprintRequester {
     }
 
     // Add proxy if specified
-    const proxyUrl = proxy || this.defaults.proxy;
-    if (proxyUrl) {
-      const proxyType = proxyUrl.startsWith('socks') ? 'socks5' : 'http';
+    const proxyConfig = getNextProxyConfig(
+      proxy !== undefined ? proxy : this.defaults.proxy,
+    );
+    if (proxyConfig) {
       requestPayload.proxy = {
         enabled: true,
-        type: proxyType,
-        url: proxyUrl,
+        type: proxyConfig.protocol,
+        url: proxyConfig.url,
       };
     }
 
@@ -143,33 +146,33 @@ class FingerprintRequester {
       let headersParsed = false;
       let responseHeaders = {};
       let responseStatus = 200;
-      let responseStatusText = 'OK';
+      let responseStatusText = "OK";
       let headerBuffer = null; // 使用 Buffer 而非字符串，保留二进制数据完整性
       let bodyChunks = [];
       let totalLoaded = 0;
-      let stderrData = '';
+      let stderrData = "";
 
       const timeoutId = setTimeout(() => {
         proc.kill();
-        const error = new Error('Request timeout');
-        error.code = 'ECONNABORTED';
+        const error = new Error("Request timeout");
+        error.code = "ECONNABORTED";
         error.config = config;
         reject(error);
       }, timeoutSec * 1000);
 
       // Support request cancellation
       if (signal) {
-        signal.addEventListener('abort', () => {
+        signal.addEventListener("abort", () => {
           proc.kill();
           clearTimeout(timeoutId);
-          const error = new Error('Request aborted');
-          error.code = 'ERR_CANCELED';
+          const error = new Error("Request aborted");
+          error.code = "ERR_CANCELED";
           error.config = config;
           reject(error);
         });
       }
 
-      proc.stdout.on('data', (chunk) => {
+      proc.stdout.on("data", (chunk) => {
         if (!headersParsed) {
           // 使用 Buffer 操作保留二进制数据完整性
           if (!headerBuffer) {
@@ -179,22 +182,25 @@ class FingerprintRequester {
           }
 
           // 使用 Buffer.indexOf 查找 \r\n\r\n 的位置
-          const separator = Buffer.from('\r\n\r\n');
+          const separator = Buffer.from("\r\n\r\n");
           const headerEndIndex = headerBuffer.indexOf(separator);
 
           if (headerEndIndex !== -1) {
             // Parse headers (header 部分是纯文本，可以安全转换)
-            const headerPart = headerBuffer.slice(0, headerEndIndex).toString('utf8');
+            const headerPart = headerBuffer
+              .slice(0, headerEndIndex)
+              .toString("utf8");
             const bodyPart = headerBuffer.slice(headerEndIndex + 4); // 保持为 Buffer
 
-            const lines = headerPart.split('\r\n');
+            const lines = headerPart.split("\r\n");
             const statusMatch = lines[0].match(/HTTP\/[\d.]+ (\d+) (.+)/);
             responseStatus = statusMatch ? parseInt(statusMatch[1]) : 200;
-            responseStatusText = statusMatch ? statusMatch[2] : 'OK';
+            responseStatusText = statusMatch ? statusMatch[2] : "OK";
 
             for (let i = 1; i < lines.length; i++) {
-              const [key, ...valueParts] = lines[i].split(': ');
-              if (key) responseHeaders[key.toLowerCase()] = valueParts.join(': ');
+              const [key, ...valueParts] = lines[i].split(": ");
+              if (key)
+                responseHeaders[key.toLowerCase()] = valueParts.join(": ");
             }
 
             headersParsed = true;
@@ -210,8 +216,8 @@ class FingerprintRequester {
               if (onDownloadProgress) {
                 onDownloadProgress({
                   loaded: totalLoaded,
-                  total: parseInt(responseHeaders['content-length']) || 0,
-                  chunk: bodyPart.toString('utf8'),
+                  total: parseInt(responseHeaders["content-length"]) || 0,
+                  chunk: bodyPart.toString("utf8"),
                   status: responseStatus,
                   headers: responseHeaders,
                 });
@@ -225,8 +231,8 @@ class FingerprintRequester {
           if (onDownloadProgress) {
             onDownloadProgress({
               loaded: totalLoaded,
-              total: parseInt(responseHeaders['content-length']) || 0,
-              chunk: chunk.toString('utf8'),
+              total: parseInt(responseHeaders["content-length"]) || 0,
+              chunk: chunk.toString("utf8"),
               status: responseStatus,
               headers: responseHeaders,
             });
@@ -234,16 +240,19 @@ class FingerprintRequester {
         }
       });
 
-      proc.stderr.on('data', (chunk) => {
+      proc.stderr.on("data", (chunk) => {
         stderrData += chunk.toString();
       });
 
-      proc.on('close', async (code) => {
+      proc.on("close", async (code) => {
         clearTimeout(timeoutId);
         this.activeProcesses.delete(proc);
 
         if (code !== 0) {
-          let errorInfo = { error: `Process exited with code ${code}`, error_type: 'UNKNOWN_ERROR' };
+          let errorInfo = {
+            error: `Process exited with code ${code}`,
+            error_type: "UNKNOWN_ERROR",
+          };
           if (stderrData) {
             try {
               errorInfo = JSON.parse(stderrData);
@@ -252,7 +261,12 @@ class FingerprintRequester {
             }
           }
           const error = new Error(errorInfo.error);
-          error.code = code === 3 ? 'ECONNABORTED' : code === 4 ? 'ERR_CONFIG' : 'ERR_NETWORK';
+          error.code =
+            code === 3
+              ? "ECONNABORTED"
+              : code === 4
+                ? "ERR_CONFIG"
+                : "ERR_NETWORK";
           error.errorType = errorInfo.error_type;
           error.exitCode = code;
           error.config = config;
@@ -261,19 +275,26 @@ class FingerprintRequester {
 
         try {
           let bodyBuffer = Buffer.concat(bodyChunks);
-          
+
           // 检查是否需要 gzip 解压
           // 同时验证数据确实是 gzip 格式（魔数 0x1f 0x8b），避免二进制已自动解压但保留 header 的情况
-          const contentEncoding = responseHeaders['content-encoding'] || '';
-          const isGzipData = bodyBuffer.length >= 2 && bodyBuffer[0] === 0x1f && bodyBuffer[1] === 0x8b;
-          if (!skipGzipDecompress && contentEncoding.toLowerCase().includes('gzip') && isGzipData) {
+          const contentEncoding = responseHeaders["content-encoding"] || "";
+          const isGzipData =
+            bodyBuffer.length >= 2 &&
+            bodyBuffer[0] === 0x1f &&
+            bodyBuffer[1] === 0x8b;
+          if (
+            !skipGzipDecompress &&
+            contentEncoding.toLowerCase().includes("gzip") &&
+            isGzipData
+          ) {
             bodyBuffer = await decompressGzip(bodyBuffer);
           }
-          
-          const body = bodyBuffer.toString('utf8');
+
+          const body = bodyBuffer.toString("utf8");
           let parsedData = body;
-          
-          if (responseType === 'json') {
+
+          if (responseType === "json") {
             try {
               parsedData = JSON.parse(body);
             } catch (e) {
@@ -288,28 +309,31 @@ class FingerprintRequester {
             headers: responseHeaders,
             config,
           };
-          
+
           if (!validateStatus(responseStatus)) {
-            const error = new Error(`Request failed with status code ${responseStatus}`);
-            error.code = responseStatus >= 500 ? 'ERR_BAD_RESPONSE' : 'ERR_BAD_REQUEST';
+            const error = new Error(
+              `Request failed with status code ${responseStatus}`,
+            );
+            error.code =
+              responseStatus >= 500 ? "ERR_BAD_RESPONSE" : "ERR_BAD_REQUEST";
             error.response = response;
             error.config = config;
             return reject(error);
           }
-          
+
           resolve(response);
         } catch (err) {
           const error = new Error(`Response processing failed: ${err.message}`);
-          error.code = 'ERR_RESPONSE_PROCESSING';
+          error.code = "ERR_RESPONSE_PROCESSING";
           error.config = config;
           reject(error);
         }
       });
 
-      proc.on('error', (err) => {
+      proc.on("error", (err) => {
         clearTimeout(timeoutId);
         const error = new Error(`Failed to spawn process: ${err.message}`);
-        error.code = 'ERR_SPAWN';
+        error.code = "ERR_SPAWN";
         error.config = config;
         reject(error);
       });
@@ -320,38 +344,40 @@ class FingerprintRequester {
   }
 
   async get(url, config = {}) {
-    return this.request({ ...config, method: 'GET', url });
+    return this.request({ ...config, method: "GET", url });
   }
 
   async post(url, data, config = {}) {
-    return this.request({ ...config, method: 'POST', url, data });
+    return this.request({ ...config, method: "POST", url, data });
   }
 
   async put(url, data, config = {}) {
-    return this.request({ ...config, method: 'PUT', url, data });
+    return this.request({ ...config, method: "PUT", url, data });
   }
 
   async delete(url, config = {}) {
-    return this.request({ ...config, method: 'DELETE', url });
+    return this.request({ ...config, method: "DELETE", url });
   }
 
   async patch(url, data, config = {}) {
-    return this.request({ ...config, method: 'PATCH', url, data });
+    return this.request({ ...config, method: "PATCH", url, data });
   }
 
   async head(url, config = {}) {
-    return this.request({ ...config, method: 'HEAD', url });
+    return this.request({ ...config, method: "HEAD", url });
   }
 
   async options(url, config = {}) {
-    return this.request({ ...config, method: 'OPTIONS', url });
+    return this.request({ ...config, method: "OPTIONS", url });
   }
 
   stream(config) {
     // Ensure onDownloadProgress is set for streaming
     const onProgress = config.onData || config.onDownloadProgress;
     if (!onProgress) {
-      console.warn('[stream] No onData or onDownloadProgress callback provided');
+      console.warn(
+        "[stream] No onData or onDownloadProgress callback provided",
+      );
     }
     return this.request({
       ...config,
@@ -367,11 +393,13 @@ class FingerprintRequester {
    */
   _buildConfigFromOptions(url, options = {}, isStream = false) {
     return {
-      method: options.method || 'GET',
+      method: options.method || "GET",
       url,
       headers: options.headers || {},
-      data: options.body || '',
-      timeout: options.timeout_ms ? Math.ceil(options.timeout_ms / 1000) : this.defaults.timeout,
+      data: options.body || "",
+      timeout: options.timeout_ms
+        ? Math.ceil(options.timeout_ms / 1000)
+        : this.defaults.timeout,
       proxy: options.proxy || this.defaults.proxy,
       skipGzipDecompress: isStream,
     };
@@ -385,7 +413,7 @@ class FingerprintRequester {
     const config = this._buildConfigFromOptions(url, options, false);
 
     const response = await this.request(config);
-    
+
     // 返回兼容 AntigravityRequester 的响应对象
     return {
       ok: response.status >= 200 && response.status < 300,
@@ -396,14 +424,23 @@ class FingerprintRequester {
       redirected: false,
       _data: response.data,
       async text() {
-        return typeof this._data === 'string' ? this._data : JSON.stringify(this._data);
+        return typeof this._data === "string"
+          ? this._data
+          : JSON.stringify(this._data);
       },
       async json() {
-        return typeof this._data === 'string' ? JSON.parse(this._data) : this._data;
+        return typeof this._data === "string"
+          ? JSON.parse(this._data)
+          : this._data;
       },
       async buffer() {
-        return Buffer.from(typeof this._data === 'string' ? this._data : JSON.stringify(this._data), 'utf8');
-      }
+        return Buffer.from(
+          typeof this._data === "string"
+            ? this._data
+            : JSON.stringify(this._data),
+          "utf8",
+        );
+      },
     };
   }
 
@@ -425,7 +462,10 @@ class FingerprintRequester {
             streamResponse.headers = new Map(Object.entries(headers));
           }
           if (streamResponse._onStart) {
-            streamResponse._onStart({ status, headers: streamResponse.headers });
+            streamResponse._onStart({
+              status,
+              headers: streamResponse.headers,
+            });
           }
         }
         if (streamResponse._onData) {
@@ -444,7 +484,7 @@ class FingerprintRequester {
         // 请求完成后设置最终 headers
         streamResponse.headers = new Map(Object.entries(response.headers));
         streamResponse._ended = true;
-        streamResponse._finalText = streamResponse.chunks.join('');
+        streamResponse._finalText = streamResponse.chunks.join("");
         if (streamResponse._textPromiseResolve) {
           streamResponse._textPromiseResolve(streamResponse._finalText);
         }
@@ -469,7 +509,7 @@ class FingerprintRequester {
   }
 
   close() {
-    this.activeProcesses.forEach(proc => proc.kill());
+    this.activeProcesses.forEach((proc) => proc.kill());
     this.activeProcesses.clear();
   }
 }
@@ -518,7 +558,7 @@ class StreamResponse {
   async text() {
     if (this._ended) {
       if (this._error) throw this._error;
-      return this._finalText || '';
+      return this._finalText || "";
     }
     return new Promise((resolve, reject) => {
       this._textPromiseResolve = resolve;

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -606,6 +606,49 @@ router.post("/oauth/exchange", cookieAuthMiddleware, async (req, res) => {
   }
 });
 
+router.get("/oauth/url", cookieAuthMiddleware, async (req, res) => {
+  const mode = req.query.mode === "geminicli" ? "geminicli" : "antigravity";
+  const rawCount = Number.parseInt(String(req.query.count || "1"), 10);
+  const count = Math.max(
+    1,
+    Math.min(100, Number.isInteger(rawCount) ? rawCount : 1),
+  );
+
+  try {
+    const ports = new Set();
+    while (ports.size < count) {
+      ports.add(Math.floor(Math.random() * 10000) + 50000);
+    }
+
+    const urls = Array.from(ports).map((port) => ({
+      port,
+      url: oauthManager.generateAuthUrl(port, mode),
+    }));
+
+    res.json({
+      success: true,
+      data: {
+        mode,
+        count,
+        urls,
+        submit: {
+          method: "POST",
+          url: "/admin/oauth/exchange",
+          contentType: "application/json",
+          body: {
+            code: "从回调URL中提取的code",
+            port: "回调URL中的本地端口",
+            mode,
+          },
+        },
+      },
+    });
+  } catch (error) {
+    logger.error(`[${mode}] 获取OAuth URL失败:`, error.message);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
 // 获取配置
 router.get("/config", cookieAuthMiddleware, (req, res) => {
   try {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -700,7 +700,10 @@ router.post(
           success: true,
           data: account,
           message: saveResult.message || "Gemini CLI Token添加成功",
-          saved: true,
+          saved: saveResult.saved !== false,
+          validated: saveResult.validated !== false,
+          disabled: saveResult.disabled === true,
+          tokenId: saveResult.tokenId || null,
         });
       } else {
         const saveResult = await tokenManager.addToken(account);
@@ -708,15 +711,18 @@ router.post(
           throw new Error(saveResult.message || "Token保存失败");
         }
 
-        const message = account.hasQuota
-          ? saveResult.message || "Token添加成功"
+        const defaultSuccessMessage = account.hasQuota
+          ? "Token添加成功"
           : "Token添加成功（该账号无资格，已自动使用随机ProjectId）";
         res.json({
           success: true,
           data: account,
-          message,
+          message: saveResult.message || defaultSuccessMessage,
           fallbackMode: !account.hasQuota,
-          saved: true,
+          saved: saveResult.saved !== false,
+          validated: saveResult.validated !== false,
+          disabled: saveResult.disabled === true,
+          tokenId: saveResult.tokenId || null,
         });
       }
     } catch (error) {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -68,6 +68,42 @@ const cookieAuthMiddleware = (req, res, next) => {
   }
 };
 
+const cookieOrPasswordAuthMiddleware = (req, res, next) => {
+  let token = req.cookies?.authToken;
+
+  if (!token) {
+    const authHeader = req.headers.authorization;
+    token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+  }
+
+  if (token) {
+    try {
+      const decoded = verifyToken(token);
+      req.user = decoded;
+      return next();
+    } catch (error) {
+      res.clearCookie("authToken", {
+        ...COOKIE_OPTIONS,
+        secure: req.secure || process.env.NODE_ENV === "production",
+      });
+    }
+  }
+
+  const password =
+    typeof req.body?.password === "string"
+      ? req.body.password
+      : typeof req.query?.password === "string"
+        ? req.query.password
+        : null;
+
+  if (password && verifyPassword(password)) {
+    req.user = { username: config.admin.username, role: "admin_password" };
+    return next();
+  }
+
+  return res.status(401).json({ error: "Token required or password invalid" });
+};
+
 // 获取客户端 IP
 function getClientIP(req) {
   return (
@@ -572,41 +608,47 @@ router.post("/tokens/import", cookieAuthMiddleware, async (req, res) => {
   }
 });
 
-router.post("/oauth/exchange", cookieAuthMiddleware, async (req, res) => {
-  const { code, port, mode = "antigravity" } = req.body;
-  if (!code || !port) {
-    return res.status(400).json({ success: false, message: "code和port必填" });
-  }
-
-  try {
-    const account = await oauthManager.authenticate(code, port, mode);
-
-    if (mode === "geminicli") {
-      // Gemini CLI 模式
-      res.json({
-        success: true,
-        data: account,
-        message: "Gemini CLI Token添加成功",
-      });
-    } else {
-      // Antigravity 模式
-      const message = account.hasQuota
-        ? "Token添加成功"
-        : "Token添加成功（该账号无资格，已自动使用随机ProjectId）";
-      res.json({
-        success: true,
-        data: account,
-        message,
-        fallbackMode: !account.hasQuota,
-      });
+router.post(
+  "/oauth/exchange",
+  cookieOrPasswordAuthMiddleware,
+  async (req, res) => {
+    const { code, port, mode = "antigravity" } = req.body;
+    if (!code || !port) {
+      return res
+        .status(400)
+        .json({ success: false, message: "code和port必填" });
     }
-  } catch (error) {
-    logger.error(`[${mode}] 认证失败:`, error.message);
-    res.status(500).json({ success: false, message: error.message });
-  }
-});
 
-router.get("/oauth/url", cookieAuthMiddleware, async (req, res) => {
+    try {
+      const account = await oauthManager.authenticate(code, port, mode);
+
+      if (mode === "geminicli") {
+        // Gemini CLI 模式
+        res.json({
+          success: true,
+          data: account,
+          message: "Gemini CLI Token添加成功",
+        });
+      } else {
+        // Antigravity 模式
+        const message = account.hasQuota
+          ? "Token添加成功"
+          : "Token添加成功（该账号无资格，已自动使用随机ProjectId）";
+        res.json({
+          success: true,
+          data: account,
+          message,
+          fallbackMode: !account.hasQuota,
+        });
+      }
+    } catch (error) {
+      logger.error(`[${mode}] 认证失败:`, error.message);
+      res.status(500).json({ success: false, message: error.message });
+    }
+  },
+);
+
+router.get("/oauth/url", cookieOrPasswordAuthMiddleware, async (req, res) => {
   const mode = req.query.mode === "geminicli" ? "geminicli" : "antigravity";
   const rawCount = Number.parseInt(String(req.query.count || "1"), 10);
   const count = Math.max(
@@ -639,6 +681,7 @@ router.get("/oauth/url", cookieAuthMiddleware, async (req, res) => {
             code: "从回调URL中提取的code",
             port: "回调URL中的本地端口",
             mode,
+            password: "可选，未携带Cookie时可直接传管理员密码",
           },
         },
       },

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -648,22 +648,32 @@ router.post(
       const account = await oauthManager.authenticate(code, port, mode);
 
       if (mode === "geminicli") {
-        // Gemini CLI 模式
+        const saveResult = await geminicliTokenManager.addToken(account);
+        if (!saveResult.success) {
+          throw new Error(saveResult.message || "Gemini CLI Token保存失败");
+        }
+
         res.json({
           success: true,
           data: account,
-          message: "Gemini CLI Token添加成功",
+          message: saveResult.message || "Gemini CLI Token添加成功",
+          saved: true,
         });
       } else {
-        // Antigravity 模式
+        const saveResult = await tokenManager.addToken(account);
+        if (!saveResult.success) {
+          throw new Error(saveResult.message || "Token保存失败");
+        }
+
         const message = account.hasQuota
-          ? "Token添加成功"
+          ? saveResult.message || "Token添加成功"
           : "Token添加成功（该账号无资格，已自动使用随机ProjectId）";
         res.json({
           success: true,
           data: account,
           message,
           fallbackMode: !account.hasQuota,
+          saved: true,
         });
       }
     } catch (error) {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1085,12 +1085,13 @@ router.post(
       const result =
         await geminicliTokenManager.fetchProjectIdForToken(tokenId);
       logger.info(
-        `[GeminiCLI] 手动获取ProjectId: ${tokenId} -> ${result.projectId}`,
+        `[GeminiCLI] 手动获取ProjectId: ${tokenId} -> ${result.projectId} (tier: ${result.tier || 'unknown'})`,
       );
       res.json({
         success: true,
-        message: "Project ID获取成功",
+        message: `Project ID获取成功${result.tier ? ` (tier: ${result.tier})` : ""}`,
         projectId: result.projectId,
+        tier: result.tier || null,
       });
     } catch (error) {
       logger.error("[GeminiCLI] 获取ProjectId失败:", error.message);
@@ -1201,6 +1202,7 @@ router.post(
           enable: token.enable,
           email: token.email,
           projectId: token.projectId,
+          tier: token.tier,
         })),
       };
 

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import express from "express";
 import { getModelsWithQuotas } from "../api/client.js";
+import { getGeminiCliQuotas } from "../api/geminicli_client.js";
 import geminicliTokenManager from "../auth/geminicli_token_manager.js";
 import { generateToken, verifyToken } from "../auth/jwt.js";
 import oauthManager from "../auth/oauth_manager.js";
@@ -1070,6 +1071,81 @@ router.post(
     } catch (error) {
       logger.error("[GeminiCLI] 获取ProjectId失败:", error.message);
       const status = error.statusCode || 500;
+      res.status(status).json({ success: false, message: error.message });
+    }
+  },
+);
+
+// 获取 Gemini CLI Token 的额度信息
+router.get(
+  "/geminicli/tokens/:tokenId/quotas",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    try {
+      const { tokenId } = req.params;
+      const forceRefresh = req.query.refresh === "true";
+
+      let tokenData = await geminicliTokenManager.findTokenById(tokenId);
+      if (!tokenData) {
+        return res.status(404).json({ success: false, message: "Token不存在" });
+      }
+
+      const isDisabled = tokenData.enable === false;
+      let quotaData = quotaManager.getQuota(tokenId);
+
+      if (isDisabled) {
+        if (!quotaData) {
+          quotaData = { lastUpdated: null, models: {}, requestCounts: {} };
+        }
+      } else {
+        if (geminicliTokenManager.isExpired(tokenData)) {
+          try {
+            tokenData = await geminicliTokenManager.refreshToken(tokenData);
+          } catch (error) {
+            logger.error("[GeminiCLI] 刷新token失败:", error.message);
+            return res.status(400).json({
+              success: false,
+              message: "Google Token已过期且刷新失败，请重新登录Google账号",
+            });
+          }
+        }
+
+        if (forceRefresh) {
+          quotaData = null;
+        }
+
+        if (!quotaData) {
+          const quotas = await getGeminiCliQuotas(tokenData);
+          quotaManager.updateQuota(tokenId, quotas);
+          quotaData = quotaManager.getQuota(tokenId) || {
+            lastUpdated: Date.now(),
+            models: quotas,
+            requestCounts: {},
+          };
+        }
+      }
+
+      const modelsWithBeijingTime = {};
+      Object.entries(quotaData.models || {}).forEach(([modelId, quota]) => {
+        modelsWithBeijingTime[modelId] = {
+          remaining: quota.r,
+          resetTime: quotaManager.convertToBeijingTime(quota.t),
+          resetTimeRaw: quota.t,
+        };
+      });
+
+      res.json({
+        success: true,
+        data: {
+          lastUpdated: quotaData.lastUpdated,
+          models: modelsWithBeijingTime,
+          requestCounts: quotaData.requestCounts || {},
+        },
+      });
+    } catch (error) {
+      const status =
+        error.statusCode || error.status || error.response?.status || 500;
+      logger.error("[GeminiCLI] 获取额度失败:", error.message);
       res.status(status).json({ success: false, message: error.message });
     }
   },

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,19 +1,20 @@
-import express from 'express';
-import { generateToken, authMiddleware, verifyToken } from '../auth/jwt.js';
-import tokenManager from '../auth/token_manager.js';
-import geminicliTokenManager from '../auth/geminicli_token_manager.js';
-import quotaManager from '../auth/quota_manager.js';
-import oauthManager from '../auth/oauth_manager.js';
-import config, { getConfigJson, saveConfigJson } from '../config/config.js';
-import logger from '../utils/logger.js';
-import memoryManager from '../utils/memoryManager.js';
-import { parseEnvFile, updateEnvFile } from '../utils/envParser.js';
-import { reloadConfig } from '../utils/configReloader.js';
-import { deepMerge } from '../utils/deepMerge.js';
-import { getModelsWithQuotas } from '../api/client.js';
-import { getEnvPath } from '../utils/paths.js';
-import ipBlockManager from '../utils/ipBlockManager.js';
-import dotenv from 'dotenv';
+import dotenv from "dotenv";
+import express from "express";
+import { getModelsWithQuotas } from "../api/client.js";
+import geminicliTokenManager from "../auth/geminicli_token_manager.js";
+import { generateToken, verifyToken } from "../auth/jwt.js";
+import oauthManager from "../auth/oauth_manager.js";
+import quotaManager from "../auth/quota_manager.js";
+import tokenManager from "../auth/token_manager.js";
+import config, { getConfigJson, saveConfigJson } from "../config/config.js";
+import { reloadConfig } from "../utils/configReloader.js";
+import { deepMerge } from "../utils/deepMerge.js";
+import { parseEnvFile, updateEnvFile } from "../utils/envParser.js";
+import ipBlockManager from "../utils/ipBlockManager.js";
+import logger from "../utils/logger.js";
+import memoryManager from "../utils/memoryManager.js";
+import { getEnvPath } from "../utils/paths.js";
+import { normalizeProxyProtocol, parseProxyPool } from "../utils/proxyPool.js";
 
 const envPath = getEnvPath();
 
@@ -21,9 +22,12 @@ const router = express.Router();
 
 // 禁用缓存中间件，确保管理后台数据实时性
 router.use((req, res, next) => {
-  res.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-  res.set('Pragma', 'no-cache');
-  res.set('Expires', '0');
+  res.set(
+    "Cache-Control",
+    "no-store, no-cache, must-revalidate, proxy-revalidate",
+  );
+  res.set("Pragma", "no-cache");
+  res.set("Expires", "0");
   next();
 });
 
@@ -31,8 +35,8 @@ router.use((req, res, next) => {
 const COOKIE_OPTIONS = {
   httpOnly: true,
   // secure: process.env.NODE_ENV === 'production', // 移除静态配置，改为动态判断
-  sameSite: 'strict',
-  maxAge: 24 * 60 * 60 * 1000 // 24小时
+  sameSite: "strict",
+  maxAge: 24 * 60 * 60 * 1000, // 24小时
 };
 
 // 从 Cookie 或 Header 获取 JWT Token 的中间件
@@ -43,11 +47,11 @@ const cookieAuthMiddleware = (req, res, next) => {
   // 如果 Cookie 中没有，尝试从 Header 获取（兼容旧版本）
   if (!token) {
     const authHeader = req.headers.authorization;
-    token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
   }
 
   if (!token) {
-    return res.status(401).json({ error: 'Token required' });
+    return res.status(401).json({ error: "Token required" });
   }
 
   try {
@@ -56,61 +60,77 @@ const cookieAuthMiddleware = (req, res, next) => {
     next();
   } catch (error) {
     // 清除无效的 Cookie
-    res.clearCookie('authToken', {
+    res.clearCookie("authToken", {
       ...COOKIE_OPTIONS,
-      secure: req.secure || process.env.NODE_ENV === 'production'
+      secure: req.secure || process.env.NODE_ENV === "production",
     });
-    return res.status(401).json({ error: 'Invalid token' });
+    return res.status(401).json({ error: "Invalid token" });
   }
 };
 
 // 获取客户端 IP
 function getClientIP(req) {
-  return req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
-    req.headers['x-real-ip'] ||
+  return (
+    req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
+    req.headers["x-real-ip"] ||
     req.connection?.remoteAddress ||
     req.ip ||
-    'unknown';
+    "unknown"
+  );
 }
 
 // 登录接口
-router.post('/login', async (req, res) => {
+router.post("/login", async (req, res) => {
   const clientIP = getClientIP(req);
 
   // 使用统一的 IP 封禁管理器检查
   const blockStatus = ipBlockManager.check(clientIP);
   if (blockStatus.blocked) {
-    if (blockStatus.reason === 'permanent') {
-      return res.status(403).json({ success: false, message: '您的IP已被永久封禁' });
+    if (blockStatus.reason === "permanent") {
+      return res
+        .status(403)
+        .json({ success: false, message: "您的IP已被永久封禁" });
     }
-    const remainingMinutes = Math.ceil((blockStatus.expiresAt - Date.now()) / 60000);
+    const remainingMinutes = Math.ceil(
+      (blockStatus.expiresAt - Date.now()) / 60000,
+    );
     return res.status(429).json({
       success: false,
       message: `登录尝试过多，请 ${remainingMinutes} 分钟后重试`,
-      retryAfter: remainingMinutes * 60
+      retryAfter: remainingMinutes * 60,
     });
   }
 
   const { username, password } = req.body;
 
   // 验证输入
-  if (!username || !password || typeof username !== 'string' || typeof password !== 'string') {
-    return res.status(400).json({ success: false, message: '用户名和密码必填' });
+  if (
+    !username ||
+    !password ||
+    typeof username !== "string" ||
+    typeof password !== "string"
+  ) {
+    return res
+      .status(400)
+      .json({ success: false, message: "用户名和密码必填" });
   }
 
   // 限制输入长度防止 DoS
   if (username.length > 100 || password.length > 100) {
-    return res.status(400).json({ success: false, message: '输入过长' });
+    return res.status(400).json({ success: false, message: "输入过长" });
   }
 
-  if (username === config.admin.username && password === config.admin.password) {
-    const token = generateToken({ username, role: 'admin' });
+  if (
+    username === config.admin.username &&
+    password === config.admin.password
+  ) {
+    const token = generateToken({ username, role: "admin" });
 
     // 设置 HttpOnly Cookie
     // 动态设置 secure: 如果通过 https 访问 (req.secure) 或在生产环境，则启用 secure
-    res.cookie('authToken', token, {
+    res.cookie("authToken", token, {
       ...COOKIE_OPTIONS,
-      secure: req.secure || process.env.NODE_ENV === 'production'
+      secure: req.secure || process.env.NODE_ENV === "production",
     });
 
     // 同时返回 token（兼容旧版本前端）
@@ -118,19 +138,19 @@ router.post('/login', async (req, res) => {
     res.json({ success: true, token });
   } else {
     // 使用统一的 IP 封禁管理器记录违规
-    await ipBlockManager.recordViolation(clientIP, 'admin_login_fail');
+    await ipBlockManager.recordViolation(clientIP, "admin_login_fail");
     logger.warn(`管理员登录失败 IP: ${clientIP}`);
-    res.status(401).json({ success: false, message: '用户名或密码错误' });
+    res.status(401).json({ success: false, message: "用户名或密码错误" });
   }
 });
 
 // 登出接口
-router.post('/logout', (req, res) => {
-  res.clearCookie('authToken', {
+router.post("/logout", (req, res) => {
+  res.clearCookie("authToken", {
     ...COOKIE_OPTIONS,
-    secure: req.secure || process.env.NODE_ENV === 'production'
+    secure: req.secure || process.env.NODE_ENV === "production",
   });
-  res.json({ success: true, message: '已登出' });
+  res.json({ success: true, message: "已登出" });
 });
 
 // 验证密码（用于敏感操作）
@@ -139,20 +159,31 @@ function verifyPassword(password) {
 }
 
 // Token管理API - 需要JWT认证（使用 Cookie 优先）
-router.get('/tokens', cookieAuthMiddleware, async (req, res) => {
+router.get("/tokens", cookieAuthMiddleware, async (req, res) => {
   try {
     const tokens = await tokenManager.getTokenList();
     res.json({ success: true, data: tokens });
   } catch (error) {
-    logger.error('获取Token列表失败:', error.message);
+    logger.error("获取Token列表失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
-router.post('/tokens', cookieAuthMiddleware, async (req, res) => {
-  const { access_token, refresh_token, expires_in, timestamp, enable, projectId, email, sub } = req.body;
+router.post("/tokens", cookieAuthMiddleware, async (req, res) => {
+  const {
+    access_token,
+    refresh_token,
+    expires_in,
+    timestamp,
+    enable,
+    projectId,
+    email,
+    sub,
+  } = req.body;
   if (!access_token || !refresh_token) {
-    return res.status(400).json({ success: false, message: 'access_token和refresh_token必填' });
+    return res
+      .status(400)
+      .json({ success: false, message: "access_token和refresh_token必填" });
   }
   const tokenData = { access_token, refresh_token, expires_in, sub };
   if (timestamp) tokenData.timestamp = timestamp;
@@ -165,13 +196,13 @@ router.post('/tokens', cookieAuthMiddleware, async (req, res) => {
     logger.info(`添加新Token: ${access_token.substring(0, 8)}...`);
     res.json(result);
   } catch (error) {
-    logger.error('添加Token失败:', error.message);
+    logger.error("添加Token失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 使用 tokenId 替代 refreshToken
-router.put('/tokens/:tokenId', cookieAuthMiddleware, async (req, res) => {
+router.put("/tokens/:tokenId", cookieAuthMiddleware, async (req, res) => {
   const { tokenId } = req.params;
   const updates = req.body;
 
@@ -184,79 +215,91 @@ router.put('/tokens/:tokenId', cookieAuthMiddleware, async (req, res) => {
     logger.info(`更新Token: ${tokenId}`);
     res.json(result);
   } catch (error) {
-    logger.error('更新Token失败:', error.message);
+    logger.error("更新Token失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
-router.delete('/tokens/:tokenId', cookieAuthMiddleware, async (req, res) => {
+router.delete("/tokens/:tokenId", cookieAuthMiddleware, async (req, res) => {
   const { tokenId } = req.params;
   try {
     const result = await tokenManager.deleteTokenById(tokenId);
     logger.info(`删除Token: ${tokenId}`);
     res.json(result);
   } catch (error) {
-    logger.error('删除Token失败:', error.message);
+    logger.error("删除Token失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
-router.post('/tokens/reload', cookieAuthMiddleware, async (req, res) => {
+router.post("/tokens/reload", cookieAuthMiddleware, async (req, res) => {
   try {
     await tokenManager.reload();
-    logger.info('手动触发Token热重载');
-    res.json({ success: true, message: 'Token已热重载' });
+    logger.info("手动触发Token热重载");
+    res.json({ success: true, message: "Token已热重载" });
   } catch (error) {
-    logger.error('热重载失败:', error.message);
+    logger.error("热重载失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 刷新指定Token的access_token（使用 tokenId）
-router.post('/tokens/:tokenId/refresh', cookieAuthMiddleware, async (req, res) => {
-  const { tokenId } = req.params;
-  try {
-    const result = await tokenManager.refreshTokenById(tokenId);
-    logger.info(`手动刷新Token: ${tokenId}`);
-    res.json({ success: true, message: 'Token刷新成功', data: result });
-  } catch (error) {
-    logger.error('刷新Token失败:', error.message);
-    const status = error.statusCode || 500;
-    res.status(status).json({ success: false, message: error.message });
-  }
-});
+router.post(
+  "/tokens/:tokenId/refresh",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { tokenId } = req.params;
+    try {
+      const result = await tokenManager.refreshTokenById(tokenId);
+      logger.info(`手动刷新Token: ${tokenId}`);
+      res.json({ success: true, message: "Token刷新成功", data: result });
+    } catch (error) {
+      logger.error("刷新Token失败:", error.message);
+      const status = error.statusCode || 500;
+      res.status(status).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 手动获取指定Token的Project ID（使用 tokenId）
-router.post('/tokens/:tokenId/fetch-project-id', cookieAuthMiddleware, async (req, res) => {
-  const { tokenId } = req.params;
-  try {
-    const result = await tokenManager.fetchProjectIdForToken(tokenId);
-    logger.info(`手动获取ProjectId: ${tokenId} -> ${result.projectId}`);
-    res.json({ success: true, message: 'Project ID获取成功', projectId: result.projectId });
-  } catch (error) {
-    logger.error('获取ProjectId失败:', error.message);
-    const status = error.statusCode || 500;
-    res.status(status).json({ success: false, message: error.message });
-  }
-});
+router.post(
+  "/tokens/:tokenId/fetch-project-id",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { tokenId } = req.params;
+    try {
+      const result = await tokenManager.fetchProjectIdForToken(tokenId);
+      logger.info(`手动获取ProjectId: ${tokenId} -> ${result.projectId}`);
+      res.json({
+        success: true,
+        message: "Project ID获取成功",
+        projectId: result.projectId,
+      });
+    } catch (error) {
+      logger.error("获取ProjectId失败:", error.message);
+      const status = error.statusCode || 500;
+      res.status(status).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 导出所有 Token（需要密码验证）
-router.post('/tokens/export', cookieAuthMiddleware, async (req, res) => {
+router.post("/tokens/export", cookieAuthMiddleware, async (req, res) => {
   const { password } = req.body;
 
   if (!password || !verifyPassword(password)) {
-    return res.status(403).json({ success: false, message: '密码验证失败' });
+    return res.status(403).json({ success: false, message: "密码验证失败" });
   }
 
   try {
     const allTokens = await tokenManager.store.readAll();
 
     // 导出格式：包含完整的 token 数据
-    logger.info('导出所有Token数据');
+    logger.info("导出所有Token数据");
     const exportData = {
       version: 1,
       exportTime: new Date().toISOString(),
-      tokens: allTokens.map(token => ({
+      tokens: allTokens.map((token) => ({
         access_token: token.access_token,
         refresh_token: token.refresh_token,
         expires_in: token.expires_in,
@@ -264,20 +307,20 @@ router.post('/tokens/export', cookieAuthMiddleware, async (req, res) => {
         enable: token.enable,
         projectId: token.projectId,
         email: token.email,
-        hasQuota: token.hasQuota
-      }))
+        hasQuota: token.hasQuota,
+      })),
     };
 
     res.json({ success: true, data: exportData });
   } catch (error) {
-    logger.error('导出Token失败:', error.message);
+    logger.error("导出Token失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 智能查找字段值（不分大小写，包含匹配）
 function findFieldByKeyword(obj, keyword) {
-  if (!obj || typeof obj !== 'object') return undefined;
+  if (!obj || typeof obj !== "object") return undefined;
   const lowerKeyword = keyword.toLowerCase();
   for (const key of Object.keys(obj)) {
     if (key.toLowerCase().includes(lowerKeyword)) {
@@ -289,11 +332,11 @@ function findFieldByKeyword(obj, keyword) {
 
 // 智能解析单个 Token 对象
 function smartParseToken(rawToken) {
-  if (!rawToken || typeof rawToken !== 'object') return null;
+  if (!rawToken || typeof rawToken !== "object") return null;
 
   // 必需字段：包含 refresh 的认为是 refresh_token，包含 project 的认为是 projectId
-  const refresh_token = findFieldByKeyword(rawToken, 'refresh');
-  const projectId = findFieldByKeyword(rawToken, 'project');
+  const refresh_token = findFieldByKeyword(rawToken, "refresh");
+  const projectId = findFieldByKeyword(rawToken, "project");
 
   // 必须同时包含这两个字段
   if (!refresh_token || !projectId) return null;
@@ -302,19 +345,27 @@ function smartParseToken(rawToken) {
   const token = { refresh_token, projectId };
 
   // 可选字段自动获取
-  const access_token = findFieldByKeyword(rawToken, 'access');
-  const email = findFieldByKeyword(rawToken, 'email') || findFieldByKeyword(rawToken, 'mail');
-  const expires_in = findFieldByKeyword(rawToken, 'expire');
-  const enable = findFieldByKeyword(rawToken, 'enable');
-  const timestamp = findFieldByKeyword(rawToken, 'time') || findFieldByKeyword(rawToken, 'stamp');
-  const hasQuota = findFieldByKeyword(rawToken, 'quota');
+  const access_token = findFieldByKeyword(rawToken, "access");
+  const email =
+    findFieldByKeyword(rawToken, "email") ||
+    findFieldByKeyword(rawToken, "mail");
+  const expires_in = findFieldByKeyword(rawToken, "expire");
+  const enable = findFieldByKeyword(rawToken, "enable");
+  const timestamp =
+    findFieldByKeyword(rawToken, "time") ||
+    findFieldByKeyword(rawToken, "stamp");
+  const hasQuota = findFieldByKeyword(rawToken, "quota");
 
   if (access_token) token.access_token = access_token;
   if (email) token.email = email;
   if (expires_in !== undefined) token.expires_in = parseInt(expires_in) || 3599;
-  if (enable !== undefined) token.enable = enable === true || enable === 'true' || enable === 1;
-  if (timestamp) token.timestamp = typeof timestamp === 'number' ? timestamp : new Date(timestamp).getTime();
-  if (hasQuota !== undefined) token.hasQuota = hasQuota === true || hasQuota === 'true' || hasQuota === 1;
+  if (enable !== undefined)
+    token.enable = enable === true || enable === "true" || enable === 1;
+  if (timestamp)
+    token.timestamp =
+      typeof timestamp === "number" ? timestamp : new Date(timestamp).getTime();
+  if (hasQuota !== undefined)
+    token.hasQuota = hasQuota === true || hasQuota === "true" || hasQuota === 1;
 
   return token;
 }
@@ -329,9 +380,10 @@ function extractGeminiCliImportList(data) {
   // - 直接数组 [...]
   // - 单个凭证对象 { token/refresh_token/project_id/expiry/... }
   if (Array.isArray(data)) return data;
-  if (!data || typeof data !== 'object') return null;
+  if (!data || typeof data !== "object") return null;
 
-  const list = data.tokens || data.accounts || data.data?.tokens || data.data?.accounts;
+  const list =
+    data.tokens || data.accounts || data.data?.tokens || data.data?.accounts;
   if (Array.isArray(list)) return list;
 
   const hasRefresh = !!(data.refresh_token || data.refreshToken);
@@ -341,15 +393,16 @@ function extractGeminiCliImportList(data) {
 }
 
 function normalizeTruthyBoolean(value) {
-  return value === true || value === 'true' || value === 1;
+  return value === true || value === "true" || value === 1;
 }
 
 function parseGeminiCliEnable(rawToken) {
   // enable/enabled/disabled 兼容
-  let enable = findFieldByKeyword(rawToken, 'enable');
-  if (enable === undefined) enable = findFieldByKeyword(rawToken, 'enabled');
-  let disabled = findFieldByKeyword(rawToken, 'disable');
-  if (disabled === undefined) disabled = findFieldByKeyword(rawToken, 'disabled');
+  let enable = findFieldByKeyword(rawToken, "enable");
+  if (enable === undefined) enable = findFieldByKeyword(rawToken, "enabled");
+  let disabled = findFieldByKeyword(rawToken, "disable");
+  if (disabled === undefined)
+    disabled = findFieldByKeyword(rawToken, "disabled");
   if (enable === undefined && disabled !== undefined) {
     enable = !normalizeTruthyBoolean(disabled);
   }
@@ -364,13 +417,17 @@ function deriveExpiresInAndTimestamp({ expires_in, expiry, timestamp }) {
   const nowMs = Date.now();
 
   let finalExpiresIn = null;
-  if (expires_in !== undefined && expires_in !== null && String(expires_in).trim() !== '') {
+  if (
+    expires_in !== undefined &&
+    expires_in !== null &&
+    String(expires_in).trim() !== ""
+  ) {
     const n = parseInt(expires_in, 10);
     if (Number.isFinite(n) && n > 0) finalExpiresIn = n;
   }
 
   let finalTimestamp = undefined;
-  if (finalExpiresIn === null && typeof expiry === 'string' && expiry.trim()) {
+  if (finalExpiresIn === null && typeof expiry === "string" && expiry.trim()) {
     const expiryMs = Date.parse(expiry);
     if (Number.isFinite(expiryMs)) {
       finalExpiresIn = Math.max(1, Math.floor((expiryMs - nowMs) / 1000));
@@ -381,7 +438,10 @@ function deriveExpiresInAndTimestamp({ expires_in, expiry, timestamp }) {
 
   if (finalTimestamp === undefined) {
     if (timestamp) {
-      finalTimestamp = typeof timestamp === 'number' ? timestamp : new Date(timestamp).getTime();
+      finalTimestamp =
+        typeof timestamp === "number"
+          ? timestamp
+          : new Date(timestamp).getTime();
     } else {
       finalTimestamp = nowMs;
     }
@@ -389,31 +449,44 @@ function deriveExpiresInAndTimestamp({ expires_in, expiry, timestamp }) {
 
   return {
     expires_in: finalExpiresIn ?? 3599,
-    timestamp: finalTimestamp
+    timestamp: finalTimestamp,
   };
 }
 
 function smartParseGeminiCliToken(rawToken) {
-  if (!rawToken || typeof rawToken !== 'object') return null;
+  if (!rawToken || typeof rawToken !== "object") return null;
 
-  const refresh_token = findFieldByKeyword(rawToken, 'refresh');
+  const refresh_token = findFieldByKeyword(rawToken, "refresh");
   if (!refresh_token) return null;
 
   const token = { refresh_token };
 
   // gcli 常见字段：token（=access_token）
-  const access_token = findFieldByKeyword(rawToken, 'access') || rawToken.token;
-  const email = findFieldByKeyword(rawToken, 'email') || findFieldByKeyword(rawToken, 'mail');
-  const expires_in = findFieldByKeyword(rawToken, 'expires') || findFieldByKeyword(rawToken, 'expire');
-  const timestamp = findFieldByKeyword(rawToken, 'time') || findFieldByKeyword(rawToken, 'stamp') || findFieldByKeyword(rawToken, 'created');
-  const expiry = findFieldByKeyword(rawToken, 'expiry') || findFieldByKeyword(rawToken, 'expiresat');
-  const projectId = findFieldByKeyword(rawToken, 'project');
+  const access_token = findFieldByKeyword(rawToken, "access") || rawToken.token;
+  const email =
+    findFieldByKeyword(rawToken, "email") ||
+    findFieldByKeyword(rawToken, "mail");
+  const expires_in =
+    findFieldByKeyword(rawToken, "expires") ||
+    findFieldByKeyword(rawToken, "expire");
+  const timestamp =
+    findFieldByKeyword(rawToken, "time") ||
+    findFieldByKeyword(rawToken, "stamp") ||
+    findFieldByKeyword(rawToken, "created");
+  const expiry =
+    findFieldByKeyword(rawToken, "expiry") ||
+    findFieldByKeyword(rawToken, "expiresat");
+  const projectId = findFieldByKeyword(rawToken, "project");
 
   if (access_token) token.access_token = access_token;
   if (email) token.email = email;
   if (projectId) token.projectId = projectId;
 
-  const derived = deriveExpiresInAndTimestamp({ expires_in, expiry, timestamp });
+  const derived = deriveExpiresInAndTimestamp({
+    expires_in,
+    expiry,
+    timestamp,
+  });
   token.expires_in = derived.expires_in;
   token.timestamp = derived.timestamp;
   token.enable = parseGeminiCliEnable(rawToken);
@@ -422,15 +495,17 @@ function smartParseGeminiCliToken(rawToken) {
 }
 
 // 导入 Token（需要密码验证，支持智能字段映射）
-router.post('/tokens/import', cookieAuthMiddleware, async (req, res) => {
-  const { password, data, mode = 'merge' } = req.body;
+router.post("/tokens/import", cookieAuthMiddleware, async (req, res) => {
+  const { password, data, mode = "merge" } = req.body;
 
   if (!password || !verifyPassword(password)) {
-    return res.status(403).json({ success: false, message: '密码验证失败' });
+    return res.status(403).json({ success: false, message: "密码验证失败" });
   }
 
   if (!data || !data.tokens || !Array.isArray(data.tokens)) {
-    return res.status(400).json({ success: false, message: '无效的导入数据格式' });
+    return res
+      .status(400)
+      .json({ success: false, message: "无效的导入数据格式" });
   }
 
   try {
@@ -450,19 +525,23 @@ router.post('/tokens/import', cookieAuthMiddleware, async (req, res) => {
       }
     }
 
-    if (mode === 'replace') {
+    if (mode === "replace") {
       // 替换模式：清空现有数据，导入新数据
       await tokenManager.store.writeAll(parsedTokens);
       addedCount = parsedTokens.length;
     } else {
       // 合并模式：根据 refresh_token 去重
       const existingTokens = await tokenManager.store.readAll();
-      const existingRefreshTokens = new Set(existingTokens.map(t => t.refresh_token));
+      const existingRefreshTokens = new Set(
+        existingTokens.map((t) => t.refresh_token),
+      );
 
       for (const token of parsedTokens) {
         if (existingRefreshTokens.has(token.refresh_token)) {
           // 更新已存在的 token
-          const index = existingTokens.findIndex(t => t.refresh_token === token.refresh_token);
+          const index = existingTokens.findIndex(
+            (t) => t.refresh_token === token.refresh_token,
+          );
           if (index !== -1) {
             existingTokens[index] = { ...existingTokens[index], ...token };
             updatedCount++;
@@ -479,36 +558,47 @@ router.post('/tokens/import', cookieAuthMiddleware, async (req, res) => {
 
     await tokenManager.reload();
 
-    logger.info(`导入Token: 新增 ${addedCount}, 更新 ${updatedCount}, 跳过 ${skippedCount}`);
+    logger.info(
+      `导入Token: 新增 ${addedCount}, 更新 ${updatedCount}, 跳过 ${skippedCount}`,
+    );
     res.json({
       success: true,
       message: `导入完成：新增 ${addedCount} 个，更新 ${updatedCount} 个，跳过 ${skippedCount} 个`,
-      data: { added: addedCount, updated: updatedCount, skipped: skippedCount }
+      data: { added: addedCount, updated: updatedCount, skipped: skippedCount },
     });
   } catch (error) {
-    logger.error('导入Token失败:', error.message);
+    logger.error("导入Token失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
-router.post('/oauth/exchange', cookieAuthMiddleware, async (req, res) => {
-  const { code, port, mode = 'antigravity' } = req.body;
+router.post("/oauth/exchange", cookieAuthMiddleware, async (req, res) => {
+  const { code, port, mode = "antigravity" } = req.body;
   if (!code || !port) {
-    return res.status(400).json({ success: false, message: 'code和port必填' });
+    return res.status(400).json({ success: false, message: "code和port必填" });
   }
 
   try {
     const account = await oauthManager.authenticate(code, port, mode);
-    
-    if (mode === 'geminicli') {
+
+    if (mode === "geminicli") {
       // Gemini CLI 模式
-      res.json({ success: true, data: account, message: 'Gemini CLI Token添加成功' });
+      res.json({
+        success: true,
+        data: account,
+        message: "Gemini CLI Token添加成功",
+      });
     } else {
       // Antigravity 模式
       const message = account.hasQuota
-        ? 'Token添加成功'
-        : 'Token添加成功（该账号无资格，已自动使用随机ProjectId）';
-      res.json({ success: true, data: account, message, fallbackMode: !account.hasQuota });
+        ? "Token添加成功"
+        : "Token添加成功（该账号无资格，已自动使用随机ProjectId）";
+      res.json({
+        success: true,
+        data: account,
+        message,
+        fallbackMode: !account.hasQuota,
+      });
     }
   } catch (error) {
     logger.error(`[${mode}] 认证失败:`, error.message);
@@ -517,38 +607,61 @@ router.post('/oauth/exchange', cookieAuthMiddleware, async (req, res) => {
 });
 
 // 获取配置
-router.get('/config', cookieAuthMiddleware, (req, res) => {
+router.get("/config", cookieAuthMiddleware, (req, res) => {
   try {
     const envData = parseEnvFile(envPath);
     const jsonData = getConfigJson();
 
     res.json({ success: true, data: { env: envData, json: jsonData } });
   } catch (error) {
-    logger.error('读取配置失败:', error.message);
+    logger.error("读取配置失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 更新配置
-router.put('/config', cookieAuthMiddleware, (req, res) => {
+router.put("/config", cookieAuthMiddleware, (req, res) => {
   try {
     const { env: envUpdates, json: jsonUpdates, password } = req.body;
+
+    if (jsonUpdates?.other) {
+      const rawProxyPool = String(jsonUpdates.other.proxyPool || "")
+        .replace(/\r\n/g, "\n")
+        .replace(/\r/g, "\n")
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .join("\n");
+      const proxyProtocol = normalizeProxyProtocol(
+        jsonUpdates.other.proxyProtocol || "http",
+      );
+
+      jsonUpdates.other.proxyProtocol = proxyProtocol;
+      jsonUpdates.other.proxyPool = rawProxyPool;
+
+      if (rawProxyPool) {
+        parseProxyPool(rawProxyPool, proxyProtocol);
+      }
+    }
 
     // 安全检查：如果修改了官方系统提示词，必须验证密码
     if (envUpdates && envUpdates.OFFICIAL_SYSTEM_PROMPT !== undefined) {
       const currentEnv = parseEnvFile(envPath);
       // 正规化换行符后再比较（避免 \r\n 和 \n 不一致导致误判）
-      const normalizeNewlines = (str) => (str || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+      const normalizeNewlines = (str) =>
+        (str || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
       const newValue = normalizeNewlines(envUpdates.OFFICIAL_SYSTEM_PROMPT);
       const oldValue = normalizeNewlines(currentEnv.OFFICIAL_SYSTEM_PROMPT);
 
       // 只有当值真正改变时才检查
       if (newValue !== oldValue) {
         if (!password || !verifyPassword(password)) {
-          logger.warn(`尝试修改官方系统提示词但密码验证失败 IP: ${getClientIP(req)}`);
+          logger.warn(
+            `尝试修改官方系统提示词但密码验证失败 IP: ${getClientIP(req)}`,
+          );
           return res.status(403).json({
             success: false,
-            message: '修改官方系统提示词需要验证管理员密码'
+            message: "修改官方系统提示词需要验证管理员密码",
           });
         }
       }
@@ -563,36 +676,39 @@ router.put('/config', cookieAuthMiddleware, (req, res) => {
     // 应用可热更新的运行时配置
     memoryManager.setCleanupInterval(config.server.memoryCleanupInterval);
 
-    logger.info('系统配置已更新并热重载');
-    res.json({ success: true, message: '配置已保存并生效（端口/HOST修改需重启）' });
+    logger.info("系统配置已更新并热重载");
+    res.json({
+      success: true,
+      message: "配置已保存并生效（端口/HOST修改需重启）",
+    });
   } catch (error) {
-    logger.error('更新配置失败:', error.message);
+    logger.error("更新配置失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 获取轮询策略配置
-router.get('/rotation', cookieAuthMiddleware, (req, res) => {
+router.get("/rotation", cookieAuthMiddleware, (req, res) => {
   try {
     const rotationConfig = tokenManager.getRotationConfig();
     res.json({ success: true, data: rotationConfig });
   } catch (error) {
-    logger.error('获取轮询配置失败:', error.message);
+    logger.error("获取轮询配置失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 更新轮询策略配置
-router.put('/rotation', cookieAuthMiddleware, (req, res) => {
+router.put("/rotation", cookieAuthMiddleware, (req, res) => {
   try {
     const { strategy, requestCount } = req.body;
 
     // 验证策略值
-    const validStrategies = ['round_robin', 'quota_exhausted', 'request_count'];
+    const validStrategies = ["round_robin", "quota_exhausted", "request_count"];
     if (strategy && !validStrategies.includes(strategy)) {
       return res.status(400).json({
         success: false,
-        message: `无效的策略，可选值: ${validStrategies.join(', ')}`
+        message: `无效的策略，可选值: ${validStrategies.join(", ")}`,
       });
     }
 
@@ -609,10 +725,16 @@ router.put('/rotation', cookieAuthMiddleware, (req, res) => {
     // 重载配置到内存
     reloadConfig();
 
-    logger.info(`轮询策略已更新: ${strategy || '未变'}, 请求次数: ${requestCount || '未变'}`);
-    res.json({ success: true, message: '轮询策略已更新', data: tokenManager.getRotationConfig() });
+    logger.info(
+      `轮询策略已更新: ${strategy || "未变"}, 请求次数: ${requestCount || "未变"}`,
+    );
+    res.json({
+      success: true,
+      message: "轮询策略已更新",
+      data: tokenManager.getRotationConfig(),
+    });
   } catch (error) {
-    logger.error('更新轮询配置失败:', error.message);
+    logger.error("更新轮询配置失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
@@ -620,43 +742,43 @@ router.put('/rotation', cookieAuthMiddleware, (req, res) => {
 // ==================== 日志管理 API ====================
 
 // 获取日志列表
-router.get('/logs', cookieAuthMiddleware, (req, res) => {
+router.get("/logs", cookieAuthMiddleware, (req, res) => {
   try {
     const { level, search, limit, offset } = req.query;
     const options = {
-      level: level || 'all',
-      search: search || '',
+      level: level || "all",
+      search: search || "",
       limit: parseInt(limit) || 100,
-      offset: parseInt(offset) || 0
+      offset: parseInt(offset) || 0,
     };
 
     const result = logger.getLogs(options);
     res.json({ success: true, data: result });
   } catch (error) {
-    logger.error('获取日志失败:', error.message);
+    logger.error("获取日志失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 获取日志统计
-router.get('/logs/stats', cookieAuthMiddleware, (req, res) => {
+router.get("/logs/stats", cookieAuthMiddleware, (req, res) => {
   try {
     const stats = logger.getLogStats();
     res.json({ success: true, data: stats });
   } catch (error) {
-    logger.error('获取日志统计失败:', error.message);
+    logger.error("获取日志统计失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 清空日志
-router.delete('/logs', cookieAuthMiddleware, (req, res) => {
+router.delete("/logs", cookieAuthMiddleware, (req, res) => {
   try {
     logger.clearLogs();
-    logger.info('日志已清空');
-    res.json({ success: true, message: '日志已清空' });
+    logger.info("日志已清空");
+    res.json({ success: true, message: "日志已清空" });
   } catch (error) {
-    logger.error('清空日志失败:', error.message);
+    logger.error("清空日志失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
@@ -666,21 +788,24 @@ router.delete('/logs', cookieAuthMiddleware, (req, res) => {
 // ==================== Gemini CLI Token 管理 API ====================
 
 // 获取 Gemini CLI Token 列表
-router.get('/geminicli/tokens', cookieAuthMiddleware, async (req, res) => {
+router.get("/geminicli/tokens", cookieAuthMiddleware, async (req, res) => {
   try {
     const tokens = await geminicliTokenManager.getTokenList();
     res.json({ success: true, data: tokens });
   } catch (error) {
-    logger.error('[GeminiCLI] 获取Token列表失败:', error.message);
+    logger.error("[GeminiCLI] 获取Token列表失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 添加 Gemini CLI Token
-router.post('/geminicli/tokens', cookieAuthMiddleware, async (req, res) => {
-  const { access_token, refresh_token, expires_in, timestamp, enable, email } = req.body;
+router.post("/geminicli/tokens", cookieAuthMiddleware, async (req, res) => {
+  const { access_token, refresh_token, expires_in, timestamp, enable, email } =
+    req.body;
   if (!access_token || !refresh_token) {
-    return res.status(400).json({ success: false, message: 'access_token和refresh_token必填' });
+    return res
+      .status(400)
+      .json({ success: false, message: "access_token和refresh_token必填" });
   }
   const tokenData = { access_token, refresh_token, expires_in };
   if (timestamp) tokenData.timestamp = timestamp;
@@ -692,271 +817,321 @@ router.post('/geminicli/tokens', cookieAuthMiddleware, async (req, res) => {
     logger.info(`[GeminiCLI] 添加新Token: ${access_token.substring(0, 8)}...`);
     res.json(result);
   } catch (error) {
-    logger.error('[GeminiCLI] 添加Token失败:', error.message);
+    logger.error("[GeminiCLI] 添加Token失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 更新 Gemini CLI Token
-router.put('/geminicli/tokens/:tokenId', cookieAuthMiddleware, async (req, res) => {
-  const { tokenId } = req.params;
-  const updates = req.body;
+router.put(
+  "/geminicli/tokens/:tokenId",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { tokenId } = req.params;
+    const updates = req.body;
 
-  // 不允许通过 API 更新敏感字段
-  delete updates.access_token;
-  delete updates.refresh_token;
+    // 不允许通过 API 更新敏感字段
+    delete updates.access_token;
+    delete updates.refresh_token;
 
-  try {
-    const result = await geminicliTokenManager.updateTokenById(tokenId, updates);
-    logger.info(`[GeminiCLI] 更新Token: ${tokenId}`);
-    res.json(result);
-  } catch (error) {
-    logger.error('[GeminiCLI] 更新Token失败:', error.message);
-    res.status(500).json({ success: false, message: error.message });
-  }
-});
+    try {
+      const result = await geminicliTokenManager.updateTokenById(
+        tokenId,
+        updates,
+      );
+      logger.info(`[GeminiCLI] 更新Token: ${tokenId}`);
+      res.json(result);
+    } catch (error) {
+      logger.error("[GeminiCLI] 更新Token失败:", error.message);
+      res.status(500).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 删除 Gemini CLI Token
-router.delete('/geminicli/tokens/:tokenId', cookieAuthMiddleware, async (req, res) => {
-  const { tokenId } = req.params;
-  try {
-    const result = await geminicliTokenManager.deleteTokenById(tokenId);
-    logger.info(`[GeminiCLI] 删除Token: ${tokenId}`);
-    res.json(result);
-  } catch (error) {
-    logger.error('[GeminiCLI] 删除Token失败:', error.message);
-    res.status(500).json({ success: false, message: error.message });
-  }
-});
+router.delete(
+  "/geminicli/tokens/:tokenId",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { tokenId } = req.params;
+    try {
+      const result = await geminicliTokenManager.deleteTokenById(tokenId);
+      logger.info(`[GeminiCLI] 删除Token: ${tokenId}`);
+      res.json(result);
+    } catch (error) {
+      logger.error("[GeminiCLI] 删除Token失败:", error.message);
+      res.status(500).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 热重载 Gemini CLI Token
-router.post('/geminicli/tokens/reload', cookieAuthMiddleware, async (req, res) => {
-  try {
-    await geminicliTokenManager.reload();
-    logger.info('[GeminiCLI] 手动触发Token热重载');
-    res.json({ success: true, message: 'Gemini CLI Token已热重载' });
-  } catch (error) {
-    logger.error('[GeminiCLI] 热重载失败:', error.message);
-    res.status(500).json({ success: false, message: error.message });
-  }
-});
+router.post(
+  "/geminicli/tokens/reload",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    try {
+      await geminicliTokenManager.reload();
+      logger.info("[GeminiCLI] 手动触发Token热重载");
+      res.json({ success: true, message: "Gemini CLI Token已热重载" });
+    } catch (error) {
+      logger.error("[GeminiCLI] 热重载失败:", error.message);
+      res.status(500).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 刷新指定 Gemini CLI Token
-router.post('/geminicli/tokens/:tokenId/refresh', cookieAuthMiddleware, async (req, res) => {
-  const { tokenId } = req.params;
-  try {
-    const result = await geminicliTokenManager.refreshTokenById(tokenId);
-    logger.info(`[GeminiCLI] 手动刷新Token: ${tokenId}`);
-    res.json({ success: true, message: 'Token刷新成功', data: result });
-  } catch (error) {
-    logger.error('[GeminiCLI] 刷新Token失败:', error.message);
-    const status = error.statusCode || 500;
-    res.status(status).json({ success: false, message: error.message });
-  }
-});
+router.post(
+  "/geminicli/tokens/:tokenId/refresh",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { tokenId } = req.params;
+    try {
+      const result = await geminicliTokenManager.refreshTokenById(tokenId);
+      logger.info(`[GeminiCLI] 手动刷新Token: ${tokenId}`);
+      res.json({ success: true, message: "Token刷新成功", data: result });
+    } catch (error) {
+      logger.error("[GeminiCLI] 刷新Token失败:", error.message);
+      const status = error.statusCode || 500;
+      res.status(status).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 手动获取指定 Gemini CLI Token 的 Project ID
-router.post('/geminicli/tokens/:tokenId/fetch-project-id', cookieAuthMiddleware, async (req, res) => {
-  const { tokenId } = req.params;
-  try {
-    const result = await geminicliTokenManager.fetchProjectIdForToken(tokenId);
-    logger.info(`[GeminiCLI] 手动获取ProjectId: ${tokenId} -> ${result.projectId}`);
-    res.json({ success: true, message: 'Project ID获取成功', projectId: result.projectId });
-  } catch (error) {
-    logger.error('[GeminiCLI] 获取ProjectId失败:', error.message);
-    const status = error.statusCode || 500;
-    res.status(status).json({ success: false, message: error.message });
-  }
-});
+router.post(
+  "/geminicli/tokens/:tokenId/fetch-project-id",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { tokenId } = req.params;
+    try {
+      const result =
+        await geminicliTokenManager.fetchProjectIdForToken(tokenId);
+      logger.info(
+        `[GeminiCLI] 手动获取ProjectId: ${tokenId} -> ${result.projectId}`,
+      );
+      res.json({
+        success: true,
+        message: "Project ID获取成功",
+        projectId: result.projectId,
+      });
+    } catch (error) {
+      logger.error("[GeminiCLI] 获取ProjectId失败:", error.message);
+      const status = error.statusCode || 500;
+      res.status(status).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 导出 Gemini CLI Token（需要密码验证）
-router.post('/geminicli/tokens/export', cookieAuthMiddleware, async (req, res) => {
-  const { password } = req.body;
+router.post(
+  "/geminicli/tokens/export",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { password } = req.body;
 
-  if (!password || !verifyPassword(password)) {
-    return res.status(403).json({ success: false, message: '密码验证失败' });
-  }
+    if (!password || !verifyPassword(password)) {
+      return res.status(403).json({ success: false, message: "密码验证失败" });
+    }
 
-  try {
-    const allTokens = await geminicliTokenManager.store.readAll();
+    try {
+      const allTokens = await geminicliTokenManager.store.readAll();
 
-    logger.info('[GeminiCLI] 导出所有Token数据');
-    const exportData = {
-      version: 1,
-      exportTime: new Date().toISOString(),
-      tokens: allTokens.map(token => ({
-        access_token: token.access_token,
-        refresh_token: token.refresh_token,
-        expires_in: token.expires_in,
-        timestamp: token.timestamp,
-        enable: token.enable,
-        email: token.email,
-        projectId: token.projectId
-      }))
-    };
+      logger.info("[GeminiCLI] 导出所有Token数据");
+      const exportData = {
+        version: 1,
+        exportTime: new Date().toISOString(),
+        tokens: allTokens.map((token) => ({
+          access_token: token.access_token,
+          refresh_token: token.refresh_token,
+          expires_in: token.expires_in,
+          timestamp: token.timestamp,
+          enable: token.enable,
+          email: token.email,
+          projectId: token.projectId,
+        })),
+      };
 
-    res.json({ success: true, data: exportData });
-  } catch (error) {
-    logger.error('[GeminiCLI] 导出Token失败:', error.message);
-    res.status(500).json({ success: false, message: error.message });
-  }
-});
+      res.json({ success: true, data: exportData });
+    } catch (error) {
+      logger.error("[GeminiCLI] 导出Token失败:", error.message);
+      res.status(500).json({ success: false, message: error.message });
+    }
+  },
+);
 
 // 导入 Gemini CLI Token（需要密码验证）
-router.post('/geminicli/tokens/import', cookieAuthMiddleware, async (req, res) => {
-  const { password, data, mode = 'merge' } = req.body;
+router.post(
+  "/geminicli/tokens/import",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    const { password, data, mode = "merge" } = req.body;
 
-  if (!password || !verifyPassword(password)) {
-    return res.status(403).json({ success: false, message: '密码验证失败' });
-  }
-
-  const importList = extractGeminiCliImportList(data);
-
-  if (!Array.isArray(importList)) {
-    return res.status(400).json({ success: false, message: '无效的导入数据格式' });
-  }
-
-  try {
-    const importTokens = importList;
-    let addedCount = 0;
-    let skippedCount = 0;
-    let updatedCount = 0;
-
-    const parsedTokens = [];
-    for (const rawToken of importTokens) {
-      const parsed = smartParseGeminiCliToken(rawToken);
-      if (parsed) parsedTokens.push(parsed);
-      else skippedCount++;
+    if (!password || !verifyPassword(password)) {
+      return res.status(403).json({ success: false, message: "密码验证失败" });
     }
 
-    if (mode === 'replace') {
-      await geminicliTokenManager.store.writeAll(parsedTokens);
-      addedCount = parsedTokens.length;
-    } else {
-      const existingTokens = await geminicliTokenManager.store.readAll();
-      const existingRefreshTokens = new Set(existingTokens.map(t => t.refresh_token));
+    const importList = extractGeminiCliImportList(data);
 
-      for (const token of parsedTokens) {
-        if (existingRefreshTokens.has(token.refresh_token)) {
-          const index = existingTokens.findIndex(t => t.refresh_token === token.refresh_token);
-          if (index !== -1) {
-            existingTokens[index] = { ...existingTokens[index], ...token };
-            updatedCount++;
-          }
-        } else {
-          existingTokens.push(token);
-          addedCount++;
-        }
+    if (!Array.isArray(importList)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "无效的导入数据格式" });
+    }
+
+    try {
+      const importTokens = importList;
+      let addedCount = 0;
+      let skippedCount = 0;
+      let updatedCount = 0;
+
+      const parsedTokens = [];
+      for (const rawToken of importTokens) {
+        const parsed = smartParseGeminiCliToken(rawToken);
+        if (parsed) parsedTokens.push(parsed);
+        else skippedCount++;
       }
 
-      await geminicliTokenManager.store.writeAll(existingTokens);
+      if (mode === "replace") {
+        await geminicliTokenManager.store.writeAll(parsedTokens);
+        addedCount = parsedTokens.length;
+      } else {
+        const existingTokens = await geminicliTokenManager.store.readAll();
+        const existingRefreshTokens = new Set(
+          existingTokens.map((t) => t.refresh_token),
+        );
+
+        for (const token of parsedTokens) {
+          if (existingRefreshTokens.has(token.refresh_token)) {
+            const index = existingTokens.findIndex(
+              (t) => t.refresh_token === token.refresh_token,
+            );
+            if (index !== -1) {
+              existingTokens[index] = { ...existingTokens[index], ...token };
+              updatedCount++;
+            }
+          } else {
+            existingTokens.push(token);
+            addedCount++;
+          }
+        }
+
+        await geminicliTokenManager.store.writeAll(existingTokens);
+      }
+
+      await geminicliTokenManager.reload();
+
+      logger.info(
+        `[GeminiCLI] 导入Token: 新增 ${addedCount}, 更新 ${updatedCount}, 跳过 ${skippedCount}`,
+      );
+      res.json({
+        success: true,
+        message: `导入完成：新增 ${addedCount} 个，更新 ${updatedCount} 个，跳过 ${skippedCount} 个`,
+        data: {
+          added: addedCount,
+          updated: updatedCount,
+          skipped: skippedCount,
+        },
+      });
+    } catch (error) {
+      logger.error("[GeminiCLI] 导入Token失败:", error.message);
+      res.status(500).json({ success: false, message: error.message });
     }
-
-    await geminicliTokenManager.reload();
-
-    logger.info(`[GeminiCLI] 导入Token: 新增 ${addedCount}, 更新 ${updatedCount}, 跳过 ${skippedCount}`);
-    res.json({
-      success: true,
-      message: `导入完成：新增 ${addedCount} 个，更新 ${updatedCount} 个，跳过 ${skippedCount} 个`,
-      data: { added: addedCount, updated: updatedCount, skipped: skippedCount }
-    });
-  } catch (error) {
-    logger.error('[GeminiCLI] 导入Token失败:', error.message);
-    res.status(500).json({ success: false, message: error.message });
-  }
-});
+  },
+);
 
 // ==================== IP 封禁管理 API ====================
 
 // 获取封禁列表
-router.get('/blocked-ips', cookieAuthMiddleware, async (req, res) => {
+router.get("/blocked-ips", cookieAuthMiddleware, async (req, res) => {
   try {
     const list = await ipBlockManager.listBlocked();
     res.json({ success: true, data: list });
   } catch (error) {
-    logger.error('获取封禁列表失败:', error.message);
+    logger.error("获取封禁列表失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 解除IP封禁
-router.post('/unblock-ip', cookieAuthMiddleware, async (req, res) => {
+router.post("/unblock-ip", cookieAuthMiddleware, async (req, res) => {
   try {
     const { ip } = req.body;
     if (!ip) {
-      return res.status(400).json({ success: false, message: 'IP地址必填' });
+      return res.status(400).json({ success: false, message: "IP地址必填" });
     }
     const success = await ipBlockManager.unblock(ip);
     if (success) {
       res.json({ success: true, message: `IP ${ip} 已解除封禁` });
     } else {
-      res.status(404).json({ success: false, message: 'IP不在封禁列表中' });
+      res.status(404).json({ success: false, message: "IP不在封禁列表中" });
     }
   } catch (error) {
-    logger.error('解除封禁失败:', error.message);
+    logger.error("解除封禁失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 获取安全配置
-router.get('/security-config', cookieAuthMiddleware, async (req, res) => {
+router.get("/security-config", cookieAuthMiddleware, async (req, res) => {
   try {
     const config = ipBlockManager.getConfig();
     res.json({ success: true, data: config });
   } catch (error) {
-    logger.error('获取安全配置失败:', error.message);
+    logger.error("获取安全配置失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 更新安全配置
-router.put('/security-config', cookieAuthMiddleware, async (req, res) => {
+router.put("/security-config", cookieAuthMiddleware, async (req, res) => {
   try {
     const { config: updates } = req.body;
     const currentConfig = ipBlockManager.getConfig();
     const mergedConfig = deepMerge(currentConfig, updates);
     await ipBlockManager.updateConfig(mergedConfig);
-    res.json({ success: true, message: '安全配置已更新' });
+    res.json({ success: true, message: "安全配置已更新" });
   } catch (error) {
-    logger.error('更新安全配置失败:', error.message);
+    logger.error("更新安全配置失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 添加白名单IP
-router.post('/whitelist-ip', cookieAuthMiddleware, async (req, res) => {
+router.post("/whitelist-ip", cookieAuthMiddleware, async (req, res) => {
   try {
     const { ip } = req.body;
     if (!ip) {
-      return res.status(400).json({ success: false, message: 'IP地址必填' });
+      return res.status(400).json({ success: false, message: "IP地址必填" });
     }
     const success = await ipBlockManager.addWhitelistIP(ip);
     if (success) {
       res.json({ success: true, message: `IP ${ip} 已添加到白名单` });
     } else {
-      res.json({ success: false, message: 'IP已在白名单中' });
+      res.json({ success: false, message: "IP已在白名单中" });
     }
   } catch (error) {
-    logger.error('添加白名单失败:', error.message);
+    logger.error("添加白名单失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
 
 // 移除白名单IP
-router.delete('/whitelist-ip', cookieAuthMiddleware, async (req, res) => {
+router.delete("/whitelist-ip", cookieAuthMiddleware, async (req, res) => {
   try {
     const { ip } = req.body;
     if (!ip) {
-      return res.status(400).json({ success: false, message: 'IP地址必填' });
+      return res.status(400).json({ success: false, message: "IP地址必填" });
     }
     const success = await ipBlockManager.removeWhitelistIP(ip);
     if (success) {
       res.json({ success: true, message: `IP ${ip} 已从白名单移除` });
     } else {
-      res.status(404).json({ success: false, message: 'IP不在白名单中' });
+      res.status(404).json({ success: false, message: "IP不在白名单中" });
     }
   } catch (error) {
-    logger.error('移除白名单失败:', error.message);
+    logger.error("移除白名单失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
   }
 });
@@ -964,82 +1139,93 @@ router.delete('/whitelist-ip', cookieAuthMiddleware, async (req, res) => {
 // ==================== Token 额度 API ====================
 
 // 获取指定Token的模型额度（使用 tokenId）
-router.get('/tokens/:tokenId/quotas', cookieAuthMiddleware, async (req, res) => {
-  try {
-    const { tokenId } = req.params;
-    const forceRefresh = req.query.refresh === 'true';
+router.get(
+  "/tokens/:tokenId/quotas",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    try {
+      const { tokenId } = req.params;
+      const forceRefresh = req.query.refresh === "true";
 
-    // 通过 tokenId 查找完整的 token 数据
-    let tokenData = await tokenManager.findTokenById(tokenId);
+      // 通过 tokenId 查找完整的 token 数据
+      let tokenData = await tokenManager.findTokenById(tokenId);
 
-    if (!tokenData) {
-      return res.status(404).json({ success: false, message: 'Token不存在' });
-    }
-
-    // 检查 token 是否禁用
-    const isDisabled = tokenData.enable === false;
-
-    // 使用 tokenId 作为缓存键，优先获取缓存数据
-    let quotaData = quotaManager.getQuota(tokenId);
-
-    // 禁用的 token 只返回缓存数据，不刷新也不获取新数据
-    if (isDisabled) {
-      if (!quotaData) {
-        // 没有缓存数据，返回空数据
-        quotaData = { lastUpdated: null, models: {} };
+      if (!tokenData) {
+        return res.status(404).json({ success: false, message: "Token不存在" });
       }
-    } else {
-      // 启用的 token 正常处理
-      // 检查token是否过期，如果过期则刷新
-      if (tokenManager.isExpired(tokenData)) {
-        try {
-          tokenData = await tokenManager.refreshToken(tokenData);
-        } catch (error) {
-          logger.error('刷新token失败:', error.message);
-          // 使用 400 而不是 401，避免前端误认为 JWT 登录过期
-          return res.status(400).json({ success: false, message: 'Google Token已过期且刷新失败，请重新登录Google账号' });
+
+      // 检查 token 是否禁用
+      const isDisabled = tokenData.enable === false;
+
+      // 使用 tokenId 作为缓存键，优先获取缓存数据
+      let quotaData = quotaManager.getQuota(tokenId);
+
+      // 禁用的 token 只返回缓存数据，不刷新也不获取新数据
+      if (isDisabled) {
+        if (!quotaData) {
+          // 没有缓存数据，返回空数据
+          quotaData = { lastUpdated: null, models: {} };
+        }
+      } else {
+        // 启用的 token 正常处理
+        // 检查token是否过期，如果过期则刷新
+        if (tokenManager.isExpired(tokenData)) {
+          try {
+            tokenData = await tokenManager.refreshToken(tokenData);
+          } catch (error) {
+            logger.error("刷新token失败:", error.message);
+            // 使用 400 而不是 401，避免前端误认为 JWT 登录过期
+            return res.status(400).json({
+              success: false,
+              message: "Google Token已过期且刷新失败，请重新登录Google账号",
+            });
+          }
+        }
+
+        // 强制刷新时清除缓存
+        if (forceRefresh) {
+          quotaData = null;
+        }
+
+        if (!quotaData) {
+          // 缓存未命中或强制刷新，从API获取
+          const quotas = await getModelsWithQuotas(tokenData);
+          quotaManager.updateQuota(tokenId, quotas);
+          // 从缓存中获取完整数据（包含 requestCounts），而不是构造不完整的对象
+          quotaData = quotaManager.getQuota(tokenId) || {
+            lastUpdated: Date.now(),
+            models: quotas,
+            requestCounts: {},
+          };
         }
       }
 
-      // 强制刷新时清除缓存
-      if (forceRefresh) {
-        quotaData = null;
-      }
+      // 转换时间为北京时间
+      const modelsWithBeijingTime = {};
+      Object.entries(quotaData.models).forEach(([modelId, quota]) => {
+        modelsWithBeijingTime[modelId] = {
+          remaining: quota.r,
+          resetTime: quotaManager.convertToBeijingTime(quota.t),
+          resetTimeRaw: quota.t,
+        };
+      });
 
-      if (!quotaData) {
-        // 缓存未命中或强制刷新，从API获取
-        const quotas = await getModelsWithQuotas(tokenData);
-        quotaManager.updateQuota(tokenId, quotas);
-        // 从缓存中获取完整数据（包含 requestCounts），而不是构造不完整的对象
-        quotaData = quotaManager.getQuota(tokenId) || { lastUpdated: Date.now(), models: quotas, requestCounts: {} };
-      }
+      // 获取请求计数
+      const requestCounts = quotaData.requestCounts || {};
+
+      res.json({
+        success: true,
+        data: {
+          lastUpdated: quotaData.lastUpdated,
+          models: modelsWithBeijingTime,
+          requestCounts, // 返回请求计数供前端计算预估
+        },
+      });
+    } catch (error) {
+      logger.error("获取额度失败:", error.message);
+      res.status(500).json({ success: false, message: error.message });
     }
-
-    // 转换时间为北京时间
-    const modelsWithBeijingTime = {};
-    Object.entries(quotaData.models).forEach(([modelId, quota]) => {
-      modelsWithBeijingTime[modelId] = {
-        remaining: quota.r,
-        resetTime: quotaManager.convertToBeijingTime(quota.t),
-        resetTimeRaw: quota.t
-      };
-    });
-
-    // 获取请求计数
-    const requestCounts = quotaData.requestCounts || {};
-
-    res.json({
-      success: true,
-      data: {
-        lastUpdated: quotaData.lastUpdated,
-        models: modelsWithBeijingTime,
-        requestCounts // 返回请求计数供前端计算预估
-      }
-    });
-  } catch (error) {
-    logger.error('获取额度失败:', error.message);
-    res.status(500).json({ success: false, message: error.message });
-  }
-});
+  },
+);
 
 export default router;

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1006,7 +1006,9 @@ router.put(
         if (result.success) {
           logger.info(`[GeminiCLI] 启用Token(已验证): ${tokenId}`);
         } else {
-          logger.warn(`[GeminiCLI] 启用Token验证失败: ${tokenId} - ${result.message}`);
+          logger.warn(
+            `[GeminiCLI] 启用Token验证失败: ${tokenId} - ${result.message}`,
+          );
         }
         res.json(result);
       } else {
@@ -1085,7 +1087,7 @@ router.post(
       const result =
         await geminicliTokenManager.fetchProjectIdForToken(tokenId);
       logger.info(
-        `[GeminiCLI] 手动获取ProjectId: ${tokenId} -> ${result.projectId} (tier: ${result.tier || 'unknown'})`,
+        `[GeminiCLI] 手动获取ProjectId: ${tokenId} -> ${result.projectId} (tier: ${result.tier || "unknown"})`,
       );
       res.json({
         success: true,
@@ -1096,6 +1098,29 @@ router.post(
     } catch (error) {
       logger.error("[GeminiCLI] 获取ProjectId失败:", error.message);
       const status = error.statusCode || 500;
+      res.status(status).json({ success: false, message: error.message });
+    }
+  },
+);
+
+// 批量获取所有已启用 Gemini CLI Token 的 Project ID
+router.post(
+  "/geminicli/tokens/batch-fetch-project-ids",
+  cookieAuthMiddleware,
+  async (req, res) => {
+    try {
+      const result = await geminicliTokenManager.batchFetchProjectIds();
+      logger.info(
+        `[GeminiCLI] 批量获取ProjectId完成: 成功 ${result.successCount} 个，失败 ${result.failCount} 个，共 ${result.total} 个`,
+      );
+      res.json({
+        success: true,
+        message: `批量获取完成: 成功 ${result.successCount} 个，失败 ${result.failCount} 个`,
+        ...result,
+      });
+    } catch (error) {
+      logger.error("[GeminiCLI] 批量获取ProjectId失败:", error.message);
+      const status = error.statusCode || error.status || 500;
       res.status(status).json({ success: false, message: error.message });
     }
   },

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -205,6 +205,36 @@ router.get("/tokens", cookieAuthMiddleware, async (req, res) => {
   }
 });
 
+router.get(
+  "/token-summary",
+  cookieOrPasswordAuthMiddleware,
+  async (req, res) => {
+    try {
+      const [antigravityTokens, geminicliTokens] = await Promise.all([
+        tokenManager.getTokenList(),
+        geminicliTokenManager.getTokenList(),
+      ]);
+
+      const buildSummary = (tokens) => ({
+        total: tokens.length,
+        enabled: tokens.filter((token) => token.enable).length,
+        disabled: tokens.filter((token) => !token.enable).length,
+      });
+
+      res.json({
+        success: true,
+        data: {
+          antigravity: buildSummary(antigravityTokens),
+          geminicli: buildSummary(geminicliTokens),
+        },
+      });
+    } catch (error) {
+      logger.error("获取Token统计失败:", error.message);
+      res.status(500).json({ success: false, message: error.message });
+    }
+  },
+);
+
 router.post("/tokens", cookieAuthMiddleware, async (req, res) => {
   const {
     access_token,

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -612,11 +612,36 @@ router.post(
   "/oauth/exchange",
   cookieOrPasswordAuthMiddleware,
   async (req, res) => {
-    const { code, port, mode = "antigravity" } = req.body;
+    const {
+      callbackUrl,
+      code: rawCode,
+      port: rawPort,
+      mode = "antigravity",
+    } = req.body;
+
+    let code = rawCode;
+    let port = rawPort;
+
+    if (callbackUrl && (!code || !port)) {
+      try {
+        const parsedUrl = new URL(String(callbackUrl));
+        code = code || parsedUrl.searchParams.get("code");
+        port =
+          port ||
+          new URL(parsedUrl.origin).port ||
+          (parsedUrl.protocol === "https:" ? 443 : 80);
+      } catch (error) {
+        return res
+          .status(400)
+          .json({ success: false, message: "callbackUrl格式无效" });
+      }
+    }
+
     if (!code || !port) {
-      return res
-        .status(400)
-        .json({ success: false, message: "code和port必填" });
+      return res.status(400).json({
+        success: false,
+        message: "code和port必填，或提供完整callbackUrl",
+      });
     }
 
     try {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -278,9 +278,21 @@ router.put("/tokens/:tokenId", cookieAuthMiddleware, async (req, res) => {
   delete updates.refresh_token;
 
   try {
-    const result = await tokenManager.updateTokenById(tokenId, updates);
-    logger.info(`更新Token: ${tokenId}`);
-    res.json(result);
+    // 如果是从禁用状态启用，且请求中包含 enableWithTest 标志，则先测试可用性
+    if (updates.enable === true && updates.enableWithTest) {
+      delete updates.enableWithTest; // 不传递给底层
+      const result = await tokenManager.enableTokenById(tokenId);
+      if (result.success) {
+        logger.info(`启用Token(已验证): ${tokenId}`);
+      } else {
+        logger.warn(`启用Token验证失败: ${tokenId} - ${result.message}`);
+      }
+      res.json(result);
+    } else {
+      const result = await tokenManager.updateTokenById(tokenId, updates);
+      logger.info(`更新Token: ${tokenId}`);
+      res.json(result);
+    }
   } catch (error) {
     logger.error("更新Token失败:", error.message);
     res.status(500).json({ success: false, message: error.message });
@@ -987,12 +999,24 @@ router.put(
     delete updates.refresh_token;
 
     try {
-      const result = await geminicliTokenManager.updateTokenById(
-        tokenId,
-        updates,
-      );
-      logger.info(`[GeminiCLI] 更新Token: ${tokenId}`);
-      res.json(result);
+      // 如果是从禁用状态启用，且请求中包含 enableWithTest 标志，则先测试可用性
+      if (updates.enable === true && updates.enableWithTest) {
+        delete updates.enableWithTest;
+        const result = await geminicliTokenManager.enableTokenById(tokenId);
+        if (result.success) {
+          logger.info(`[GeminiCLI] 启用Token(已验证): ${tokenId}`);
+        } else {
+          logger.warn(`[GeminiCLI] 启用Token验证失败: ${tokenId} - ${result.message}`);
+        }
+        res.json(result);
+      } else {
+        const result = await geminicliTokenManager.updateTokenById(
+          tokenId,
+          updates,
+        );
+        logger.info(`[GeminiCLI] 更新Token: ${tokenId}`);
+        res.json(result);
+      }
     } catch (error) {
       logger.error("[GeminiCLI] 更新Token失败:", error.message);
       res.status(500).json({ success: false, message: error.message });

--- a/src/utils/httpClient.js
+++ b/src/utils/httpClient.js
@@ -91,7 +91,11 @@ export function buildAxiosRequestConfig({
   useChunked = false,
   proxy = null,
 }) {
-  const proxyConfig = proxy ? getNextProxyConfig(proxy) : null;
+  const effectiveProxy =
+    proxy || (config.proxy?.allRequests ? config.proxy : null);
+  const proxyConfig = effectiveProxy
+    ? getNextProxyConfig(effectiveProxy)
+    : null;
   const agents = proxyConfig
     ? getProxyAgents(proxyConfig)
     : { httpAgent, httpsAgent };

--- a/src/utils/httpClient.js
+++ b/src/utils/httpClient.js
@@ -89,9 +89,9 @@ export function buildAxiosRequestConfig({
   timeout = config.timeout,
   responseType,
   useChunked = false,
-  proxy = undefined,
+  proxy = null,
 }) {
-  const proxyConfig = getNextProxyConfig(proxy);
+  const proxyConfig = proxy ? getNextProxyConfig(proxy) : null;
   const agents = proxyConfig
     ? getProxyAgents(proxyConfig)
     : { httpAgent, httpsAgent };

--- a/src/utils/httpClient.js
+++ b/src/utils/httpClient.js
@@ -7,7 +7,8 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 import { SocksProxyAgent } from "socks-proxy-agent";
 import { Readable } from "stream";
 import config from "../config/config.js";
-import { getNextProxyConfig } from "./proxyPool.js";
+import logger from "./logger.js";
+import { formatProxyRequestInfo, getNextProxyConfig } from "./proxyPool.js";
 
 // ==================== DNS & 代理统一配置 ====================
 
@@ -94,6 +95,10 @@ export function buildAxiosRequestConfig({
   const agents = proxyConfig
     ? getProxyAgents(proxyConfig)
     : { httpAgent, httpsAgent };
+
+  if (proxyConfig?.isPool) {
+    logger.info(`[ProxyPool] ${formatProxyRequestInfo(proxyConfig, url)}`);
+  }
 
   const axiosConfig = {
     method,

--- a/src/utils/httpClient.js
+++ b/src/utils/httpClient.js
@@ -1,9 +1,13 @@
-import axios from 'axios';
-import dns from 'dns';
-import http from 'http';
-import https from 'https';
-import { Readable } from 'stream';
-import config from '../config/config.js';
+import axios from "axios";
+import dns from "dns";
+import http from "http";
+import { HttpProxyAgent } from "http-proxy-agent";
+import https from "https";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { SocksProxyAgent } from "socks-proxy-agent";
+import { Readable } from "stream";
+import config from "../config/config.js";
+import { getNextProxyConfig } from "./proxyPool.js";
 
 // ==================== DNS & 代理统一配置 ====================
 
@@ -13,78 +17,105 @@ function customLookup(hostname, options, callback) {
     if (!err4 && address4) {
       return callback(null, address4, family4);
     }
-    dns.lookup(hostname, { ...options, family: 6 }, (err6, address6, family6) => {
-      if (!err6 && address6) {
-        return callback(null, address6, family6);
-      }
-      callback(err4 || err6);
-    });
+    dns.lookup(
+      hostname,
+      { ...options, family: 6 },
+      (err6, address6, family6) => {
+        if (!err6 && address6) {
+          return callback(null, address6, family6);
+        }
+        callback(err4 || err6);
+      },
+    );
   });
 }
 
 // 使用自定义 DNS 解析的 Agent（优先 IPv4，失败则 IPv6）
 const httpAgent = new http.Agent({
   lookup: customLookup,
-  keepAlive: true
+  keepAlive: true,
 });
 
 const httpsAgent = new https.Agent({
   lookup: customLookup,
-  keepAlive: true
+  keepAlive: true,
 });
 
-// 统一构建代理配置
-function buildProxyConfig() {
-  if (!config.proxy) return false;
-  try {
-    const proxyUrl = new URL(config.proxy);
-    return {
-      protocol: proxyUrl.protocol.replace(':', ''),
-      host: proxyUrl.hostname,
-      port: parseInt(proxyUrl.port, 10)
-    };
-  } catch {
-    return false;
+const proxyAgentCache = new Map();
+
+function getProxyAgents(proxyConfig) {
+  const cacheKey = proxyConfig.url;
+  if (proxyAgentCache.has(cacheKey)) {
+    return proxyAgentCache.get(cacheKey);
   }
+
+  let agents;
+  if (proxyConfig.protocol === "socks5") {
+    const agent = new SocksProxyAgent(proxyConfig.url);
+    agents = {
+      httpAgent: agent,
+      httpsAgent: agent,
+    };
+  } else if (proxyConfig.protocol === "https") {
+    const agent = new HttpsProxyAgent(proxyConfig.url);
+    agents = {
+      httpAgent: agent,
+      httpsAgent: agent,
+    };
+  } else {
+    agents = {
+      httpAgent: new HttpProxyAgent(proxyConfig.url),
+      httpsAgent: new HttpsProxyAgent(proxyConfig.url),
+    };
+  }
+
+  proxyAgentCache.set(cacheKey, agents);
+  return agents;
 }
 
 // 将数据转换为流以启用 chunked 编码
 function createChunkedStream(data) {
-  const jsonStr = typeof data === 'string' ? data : JSON.stringify(data);
+  const jsonStr = typeof data === "string" ? data : JSON.stringify(data);
   return Readable.from([jsonStr]);
 }
 
 // 为 axios 构建统一请求配置
 export function buildAxiosRequestConfig({
-  method = 'POST',
+  method = "POST",
   url,
   headers,
   data = null,
   timeout = config.timeout,
   responseType,
-  useChunked = false
+  useChunked = false,
+  proxy = undefined,
 }) {
+  const proxyConfig = getNextProxyConfig(proxy);
+  const agents = proxyConfig
+    ? getProxyAgents(proxyConfig)
+    : { httpAgent, httpsAgent };
+
   const axiosConfig = {
     method,
     url,
     headers: { ...headers },
     timeout,
-    httpAgent,
-    httpsAgent,
-    proxy: buildProxyConfig(),
+    httpAgent: agents.httpAgent,
+    httpsAgent: agents.httpsAgent,
+    proxy: false,
     // 禁用自动设置 Content-Length，让 axios 使用 Transfer-Encoding: chunked
     maxContentLength: Infinity,
-    maxBodyLength: Infinity
+    maxBodyLength: Infinity,
   };
 
   if (responseType) axiosConfig.responseType = responseType;
-  
+
   if (data !== null) {
     if (useChunked) {
       // 使用流式数据以启用 chunked 编码
       axiosConfig.data = createChunkedStream(data);
       // 删除 Content-Length 头，强制使用 chunked
-      delete axiosConfig.headers['Content-Length'];
+      delete axiosConfig.headers["Content-Length"];
     } else {
       axiosConfig.data = data;
     }
@@ -95,14 +126,20 @@ export function buildAxiosRequestConfig({
 // 简单封装 axios 调用，方便后续统一扩展（重试、打点等）
 export async function httpRequest(configOverrides) {
   // 默认启用 chunked 编码以匹配官方客户端行为
-  const axiosConfig = buildAxiosRequestConfig({ ...configOverrides, useChunked: true });
+  const axiosConfig = buildAxiosRequestConfig({
+    ...configOverrides,
+    useChunked: true,
+  });
   return axios(axiosConfig);
 }
 
 // 流式请求封装
 export async function httpStreamRequest(configOverrides) {
   // 默认启用 chunked 编码以匹配官方客户端行为
-  const axiosConfig = buildAxiosRequestConfig({ ...configOverrides, useChunked: true });
-  axiosConfig.responseType = 'stream';
+  const axiosConfig = buildAxiosRequestConfig({
+    ...configOverrides,
+    useChunked: true,
+  });
+  axiosConfig.responseType = "stream";
   return axios(axiosConfig);
 }

--- a/src/utils/proxyPool.js
+++ b/src/utils/proxyPool.js
@@ -1,0 +1,232 @@
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import config from "../config/config.js";
+import logger from "./logger.js";
+import { getDataDir } from "./paths.js";
+
+const PROXY_ROTATION_STATE_FILE = "proxy_rotation.json";
+
+export function normalizeProxyProtocol(protocol = "http") {
+  const normalized = String(protocol || "http")
+    .trim()
+    .toLowerCase();
+
+  if (
+    normalized === "socket5" ||
+    normalized === "socks" ||
+    normalized === "socks5"
+  ) {
+    return "socks5";
+  }
+
+  if (normalized === "https") {
+    return "https";
+  }
+
+  return "http";
+}
+
+function normalizeLines(value = "") {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
+function splitPoolLines(poolRaw = "") {
+  return normalizeLines(poolRaw)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function buildProxyUrl({ protocol, host, port, username = "", password = "" }) {
+  const auth = username
+    ? `${encodeURIComponent(username)}:${encodeURIComponent(password || "")}@`
+    : "";
+
+  return `${protocol}://${auth}${host}:${port}`;
+}
+
+function parseProxyUrl(proxyUrl) {
+  const rawValue = String(proxyUrl).trim();
+  if (!rawValue.includes("://")) {
+    return null;
+  }
+
+  try {
+    const parsedUrl = new URL(rawValue);
+    const protocol = normalizeProxyProtocol(
+      parsedUrl.protocol.replace(":", ""),
+    );
+
+    return {
+      raw: rawValue,
+      protocol,
+      host: parsedUrl.hostname,
+      port: Number.parseInt(parsedUrl.port, 10) || undefined,
+      username: decodeURIComponent(parsedUrl.username || ""),
+      password: decodeURIComponent(parsedUrl.password || ""),
+      url: rawValue,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseProxyPoolLine(line, protocol) {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  const urlProxy = parseProxyUrl(trimmed);
+  if (urlProxy) {
+    return urlProxy;
+  }
+
+  const segments = trimmed.split(":");
+  if (segments.length < 2) {
+    throw new Error(`代理格式无效: ${trimmed}`);
+  }
+
+  const [host, portRaw, usernameRaw = "", ...passwordParts] = segments;
+  const port = Number.parseInt(portRaw, 10);
+  if (!host || !Number.isInteger(port) || port <= 0) {
+    throw new Error(`代理格式无效: ${trimmed}`);
+  }
+
+  const username = usernameRaw || "";
+  const password = passwordParts.join(":");
+
+  return {
+    raw: trimmed,
+    protocol,
+    host,
+    port,
+    username,
+    password,
+    url: buildProxyUrl({ protocol, host, port, username, password }),
+  };
+}
+
+export function parseProxyPool(poolRaw = "", protocol = "http") {
+  const normalizedProtocol = normalizeProxyProtocol(protocol);
+  return splitPoolLines(poolRaw)
+    .map((line) => parseProxyPoolLine(line, normalizedProtocol))
+    .filter(Boolean);
+}
+
+function getRotationStatePath() {
+  const dataDir = getDataDir();
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+
+  return path.join(dataDir, PROXY_ROTATION_STATE_FILE);
+}
+
+function loadRotationState() {
+  try {
+    const statePath = getRotationStatePath();
+    if (!fs.existsSync(statePath)) {
+      return { poolKey: null, nextIndex: 0 };
+    }
+
+    const raw = fs.readFileSync(statePath, "utf8");
+    const parsed = JSON.parse(raw);
+
+    return {
+      poolKey: typeof parsed.poolKey === "string" ? parsed.poolKey : null,
+      nextIndex: Number.isInteger(parsed.nextIndex) ? parsed.nextIndex : 0,
+    };
+  } catch (error) {
+    logger.warn(`读取代理轮询状态失败: ${error.message}`);
+    return { poolKey: null, nextIndex: 0 };
+  }
+}
+
+function saveRotationState({ poolKey, nextIndex, updatedAt = Date.now() }) {
+  try {
+    const statePath = getRotationStatePath();
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({ poolKey, nextIndex, updatedAt }, null, 2),
+      "utf8",
+    );
+  } catch (error) {
+    logger.warn(`保存代理轮询状态失败: ${error.message}`);
+  }
+}
+
+function buildPoolKey(protocol, poolRaw) {
+  return crypto
+    .createHash("sha1")
+    .update(`${normalizeProxyProtocol(protocol)}\n${normalizeLines(poolRaw)}`)
+    .digest("hex");
+}
+
+function resolveProxyEntries(proxyConfig) {
+  if (!proxyConfig) return [];
+
+  if (typeof proxyConfig === "string") {
+    const parsedUrl = parseProxyUrl(proxyConfig);
+    if (parsedUrl) return [parsedUrl];
+    return parseProxyPool(proxyConfig, "http");
+  }
+
+  if (typeof proxyConfig !== "object" || proxyConfig.enabled === false) {
+    return [];
+  }
+
+  if (proxyConfig.poolRaw) {
+    return parseProxyPool(proxyConfig.poolRaw, proxyConfig.protocol);
+  }
+
+  if (proxyConfig.url) {
+    const parsedUrl = parseProxyUrl(proxyConfig.url);
+    if (parsedUrl) return [parsedUrl];
+    return parseProxyPool(proxyConfig.url, proxyConfig.protocol);
+  }
+
+  return [];
+}
+
+export function getNextProxyConfig(proxyOverride = undefined) {
+  const effectiveProxy =
+    proxyOverride !== undefined ? proxyOverride : config.proxy;
+  const entries = resolveProxyEntries(effectiveProxy);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  if (entries.length === 1) {
+    return entries[0];
+  }
+
+  const protocol = normalizeProxyProtocol(
+    typeof effectiveProxy === "object"
+      ? effectiveProxy.protocol
+      : entries[0].protocol,
+  );
+  const poolRaw =
+    typeof effectiveProxy === "object" && effectiveProxy.poolRaw
+      ? effectiveProxy.poolRaw
+      : entries.map((entry) => entry.raw).join("\n");
+
+  const poolKey = buildPoolKey(protocol, poolRaw);
+  const state = loadRotationState();
+  const nextIndex = state.poolKey === poolKey ? state.nextIndex : 0;
+  const index =
+    ((nextIndex % entries.length) + entries.length) % entries.length;
+  const selected = entries[index];
+
+  saveRotationState({
+    poolKey,
+    nextIndex: (index + 1) % entries.length,
+  });
+
+  return {
+    ...selected,
+    index,
+  };
+}

--- a/src/utils/proxyPool.js
+++ b/src/utils/proxyPool.js
@@ -200,7 +200,12 @@ export function getNextProxyConfig(proxyOverride = undefined) {
   }
 
   if (entries.length === 1) {
-    return entries[0];
+    return {
+      ...entries[0],
+      index: 0,
+      poolSize: 1,
+      isPool: false,
+    };
   }
 
   const protocol = normalizeProxyProtocol(
@@ -228,5 +233,18 @@ export function getNextProxyConfig(proxyOverride = undefined) {
   return {
     ...selected,
     index,
+    poolSize: entries.length,
+    isPool: true,
   };
+}
+
+export function formatProxyRequestInfo(proxyConfig, targetUrl = "") {
+  if (!proxyConfig) return "";
+
+  const proxyLabel = proxyConfig.isPool
+    ? `代理池[${(proxyConfig.index ?? 0) + 1}/${proxyConfig.poolSize || 1}]`
+    : "代理";
+  const targetLabel = targetUrl ? ` -> ${targetUrl}` : "";
+
+  return `${proxyLabel} ${proxyConfig.url}${targetLabel}`;
 }

--- a/src/utils/proxyPool.js
+++ b/src/utils/proxyPool.js
@@ -83,6 +83,33 @@ function parseProxyPoolLine(line, protocol) {
     return urlProxy;
   }
 
+  if (trimmed.includes("@")) {
+    const [authPart, hostPart] = trimmed.split("@");
+    const authSegments = authPart.split(":");
+    const hostSegments = hostPart.split(":");
+
+    if (authSegments.length >= 2 && hostSegments.length >= 2) {
+      const username = authSegments.shift() || "";
+      const password = authSegments.join(":");
+      const host = hostSegments.shift() || "";
+      const port = Number.parseInt(hostSegments.join(":"), 10);
+
+      if (!host || !username || !Number.isInteger(port) || port <= 0) {
+        throw new Error(`代理格式无效: ${trimmed}`);
+      }
+
+      return {
+        raw: trimmed,
+        protocol,
+        host,
+        port,
+        username,
+        password,
+        url: buildProxyUrl({ protocol, host, port, username, password }),
+      };
+    }
+  }
+
   const segments = trimmed.split(":");
   if (segments.length < 2) {
     throw new Error(`代理格式无效: ${trimmed}`);

--- a/开发者.md
+++ b/开发者.md
@@ -73,7 +73,33 @@ window.__STATIC_VERSION__ = "20260328-2";
 2. 服务器是否已重启到新代码
 3. 浏览器加载的 JS / CSS URL 是否已带新 `?v=` 参数
 
-## 4. 文档分工
+## 4. Antigravity User-Agent 位置
+
+Antigravity 的 `User-Agent` 不是散落在请求代码里单独写死，而是统一在配置层生成。
+
+### 配置入口
+
+- [`getActiveApiConfig()`](src/config/config.js:353)
+- [`config.api.userAgent`](src/config/config.js:371)
+
+当前生成格式：
+
+```js
+antigravity/${jsonConfig.api?.version || "1.19.5"} windows/amd64
+```
+
+### 实际使用位置
+
+- 主 API 请求头：[`buildHeaders()`](src/api/client.js:182)
+- 请求头字段：[`'User-Agent': config.api.userAgent`](src/api/client.js:185)
+- Token 管理相关请求同样复用该值：[`config.api.userAgent`](src/auth/token_manager.js:283)
+
+### 相关说明
+
+- 如果更新了 Antigravity 版本，`User-Agent` 会跟随 [`config.api.version`](src/config/config.js:371) 一起变化
+- Gemini CLI 使用的是另一套 `User-Agent`，默认定义在 [`DEFAULT_GEMINICLI_API_CONFIG.userAgent`](src/config/config.js:345)，不要与 Antigravity 混淆
+
+## 5. 文档分工
 
 - [`README.md`](README.md)：安装、部署、使用说明
 - [`API.md`](API.md)：接口调用说明

--- a/开发者.md
+++ b/开发者.md
@@ -1,0 +1,81 @@
+# 开发者说明
+
+本文档只保留相对 [`README.md`](README.md) 的增量内容，主要记录开发维护时容易遗漏的入口、OAuth 改造点和前端缓存策略。
+
+## 1. 关键入口索引
+
+### 服务端入口
+
+- [`src/server/index.js`](src/server/index.js)：主服务入口、静态资源托管、路由挂载
+- [`src/routes/admin.js`](src/routes/admin.js)：管理后台接口，含 OAuth 交换接口 [`/admin/oauth/exchange`](src/routes/admin.js:575)
+- [`src/auth/oauth_manager.js`](src/auth/oauth_manager.js)：统一 OAuth URL 生成与授权码换 token
+
+### 前端关键文件
+
+- [`public/index.html`](public/index.html)：管理页入口与静态资源版本号入口
+- [`public/js/auth.js`](public/js/auth.js)：普通 OAuth、登录态处理
+- [`public/js/geminicli.js`](public/js/geminicli.js)：Gemini CLI OAuth 与 Token 管理
+- [`public/style.css`](public/style.css)：管理页与 OAuth 弹窗样式
+
+## 2. OAuth 改造要点
+
+### 普通 OAuth
+
+关键函数：
+
+- [`getOAuthUrls()`](public/js/auth.js:74)：批量生成授权链接
+- [`generateOAuthUrlList()`](public/js/auth.js:166)：在弹窗中展示链接
+- [`processOAuthCallbackModal()`](public/js/auth.js:174)：按行处理回调 URL
+
+### Gemini CLI OAuth
+
+关键函数：
+
+- [`getGeminiCliOAuthUrls()`](public/js/geminicli.js:28)：批量生成授权链接
+- [`generateGeminiCliOAuthUrlList()`](public/js/geminicli.js:120)：在弹窗中展示链接
+- [`processGeminiCliOAuthCallback()`](public/js/geminicli.js:137)：按行处理回调 URL
+
+### 当前约定
+
+- 普通 OAuth 和 Gemini CLI OAuth 共用交换接口 [`/admin/oauth/exchange`](src/routes/admin.js:575)
+- 前端支持“批量生成授权 URL + 多行粘贴回调 URL”
+- 展示区支持单条复制与全部复制
+
+## 3. 前端静态资源版本号
+
+为避免浏览器缓存旧版前端资源，统一版本号定义在 [`window.__STATIC_VERSION__`](public/index.html:13)。
+
+### 何时需要更新
+
+只要修改了下列文件之一，就应同步更新版本号：
+
+- [`public/style.css`](public/style.css)
+- [`public/index.html`](public/index.html)
+- [`public/js/auth.js`](public/js/auth.js)
+- [`public/js/geminicli.js`](public/js/geminicli.js)
+- 其他 [`public/js/*.js`](public/js/README.md)
+
+### 更新方式
+
+直接修改 [`window.__STATIC_VERSION__`](public/index.html:13)，例如：
+
+```html
+window.__STATIC_VERSION__ = "20260328-2";
+```
+
+建议格式：`日期-发布序号`。
+
+### 发布检查项
+
+发布前端改动时，最少检查：
+
+1. [`window.__STATIC_VERSION__`](public/index.html:13) 是否已递增
+2. 服务器是否已重启到新代码
+3. 浏览器加载的 JS / CSS URL 是否已带新 `?v=` 参数
+
+## 4. 文档分工
+
+- [`README.md`](README.md)：安装、部署、使用说明
+- [`API.md`](API.md)：接口调用说明
+- [`public/js/README.md`](public/js/README.md)：前端模块职责
+- [`开发者.md`](开发者.md)：开发维护约定、关键入口与增量变更说明


### PR DESCRIPTION
# 添加版本号
index.html添加了window.__STATIC_VERSION__  以修改版本号去除缓存

# 代理池变动
添加http/https/socket5 代理池选项.
允许代理池的多行输入,自动进行轮询.
添加一个全模式代理开关(默认为关闭状态): 
- 在关闭状态下,仅LLM请求使用代理,而日常频繁请求时不使用代理. 以减少过于频繁切换代理的情况.
- 在开启状态下,全部包裹获取额度,获取token都通过代理池进行
# 添加批量获取认证url的按钮
在前端可以批量生成认证url. 以减少直接新建标签页 复制url到其他浏览器环境下,登录出现异常的情况.
并允许粘贴多个url..

# 创建开发者.md
以指向部分接口文件,便于后续开放.

# 修改日志显示逻辑.
暴露请求时指向的url和使用的代理以提供代理请求检查.
显示逻辑位于. src\utils\proxyPool.js

由于代码是肘的gpt.  所以出现了大量行数变动,主要为代码格式换行变动. 
麻烦检阅了.