### PR TITLE
docs: 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liuw1535/antigravity2api-nodejs&type=Date)](https://www.star-history.com/#liuw1535/antigravity2api-nodejs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liuw1535/antigravity2api-nodejs&type=Date)](https://star-history.dera.page/#liuw1535/antigravity2api-nodejs&Date)
 
 ## 功能特性
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已失效，原因是 GitHub stargazer API 的限制导致原有图表无法正常加载。本 PR 将图表更新到新的数据源，恢复 Star History 图表的正常展示。