### PR TITLE
fix(requester): keep non-stream timeout active after headers

### DIFF
--- a/src/requester.js
+++ b/src/requester.js
@@ -52,6 +52,7 @@ class FingerprintRequester {
     this.binDir = options.binDir || this._detectBinDir();
     this.binaryPath = options.binaryPath || this._detectBinary();
     this.configPath = options.configPath || join(__dirname, 'bin', 'config.json');
+    this.spawnProcess = options.spawnProcess || spawn;
     this.defaults = {
       timeout: options.timeout || 30, // seconds
       proxy: options.proxy || null,
@@ -165,7 +166,7 @@ class FingerprintRequester {
     }
 
     return new Promise((resolve, reject) => {
-      const proc = spawn(this.binaryPath);
+      const proc = this.spawnProcess(this.binaryPath);
       this.activeProcesses.add(proc);
       let headersParsed = false;
       let responseHeaders = {};
@@ -227,8 +228,11 @@ class FingerprintRequester {
             headersParsed = true;
             headerBuffer = null; // 释放内存
 
-            // Clear timeout for streaming responses
-            clearTimeout(timeoutId);
+            // Streaming responses manage their lifetime through the stream consumer.
+            // Non-stream requests keep the overall watchdog until the child exits.
+            if (onDownloadProgress) {
+              clearTimeout(timeoutId);
+            }
 
             // Process body part after headers
             if (bodyPart.length > 0) {
@@ -288,7 +292,7 @@ class FingerprintRequester {
 
         try {
           let bodyBuffer = Buffer.concat(bodyChunks);
-          
+
           // 检查是否需要解压（gzip / br / deflate）
           const contentEncoding = (responseHeaders['content-encoding'] || '').toLowerCase();
           if (!skipGzipDecompress && contentEncoding) {
@@ -301,10 +305,10 @@ class FingerprintRequester {
               try { bodyBuffer = await decompressDeflate(bodyBuffer); } catch { /* 解压失败保留原始数据 */ }
             }
           }
-          
+
           const body = bodyBuffer.toString('utf8');
           let parsedData = body;
-          
+
           if (responseType === 'json') {
             try {
               parsedData = JSON.parse(body);
@@ -320,7 +324,7 @@ class FingerprintRequester {
             headers: responseHeaders,
             config,
           };
-          
+
           if (!validateStatus(responseStatus)) {
             const error = new Error(`Request failed with status code ${responseStatus}`);
             error.code = responseStatus >= 500 ? 'ERR_BAD_RESPONSE' : 'ERR_BAD_REQUEST';
@@ -328,7 +332,7 @@ class FingerprintRequester {
             error.config = config;
             return reject(error);
           }
-          
+
           resolve(response);
         } catch (err) {
           const error = new Error(`Response processing failed: ${err.message}`);
@@ -417,7 +421,7 @@ class FingerprintRequester {
     const config = this._buildConfigFromOptions(url, options, false);
 
     const response = await this.request(config);
-    
+
     // 返回兼容 AntigravityRequester 的响应对象
     return {
       ok: response.status >= 200 && response.status < 300,

--- a/test/test-requester-nonstream-timeout.js
+++ b/test/test-requester-nonstream-timeout.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import requesterModule from '../src/requester.js';
+
+const { FingerprintRequester } = requesterModule;
+
+class StalledChildProcess extends EventEmitter {
+  constructor() {
+    super();
+    this.stdout = new EventEmitter();
+    this.stderr = new EventEmitter();
+    this.stdin = {
+      write() {},
+      end() {},
+    };
+    this.killed = false;
+  }
+
+  kill() {
+    if (this.killed) return false;
+    this.killed = true;
+    setImmediate(() => this.emit('close', null));
+    return true;
+  }
+}
+
+const child = new StalledChildProcess();
+const requester = new FingerprintRequester({
+  binaryPath: '/unused/fingerprint',
+  configPath: '/unused/config.json',
+  timeout: 0.02,
+  spawnProcess: () => child,
+});
+
+const pending = requester.get('https://example.test/non-stream');
+queueMicrotask(() => {
+  child.stdout.emit('data', Buffer.from(
+    'HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n'
+  ));
+});
+
+const outcome = await Promise.race([
+  pending.then(
+    () => ({ type: 'resolved' }),
+    error => ({ type: 'rejected', error })
+  ),
+  new Promise(resolve => setTimeout(() => resolve({ type: 'hung' }), 150)),
+]);
+
+assert.notEqual(
+  outcome.type,
+  'hung',
+  'non-stream request should retain its watchdog after response headers'
+);
+assert.equal(outcome.type, 'rejected');
+assert.equal(outcome.error.code, 'ECONNABORTED');
+assert.equal(child.killed, true);
+
+await new Promise(resolve => setImmediate(resolve));
+assert.equal(requester.activeProcesses.size, 0);
+
+console.log('PASS requester non-stream timeout remains active after headers');


### PR DESCRIPTION
## Summary

- keep the overall request watchdog active for non-stream responses after headers arrive
- preserve the existing behavior for streaming responses, which intentionally clear the watchdog once streaming starts
- make child-process spawning injectable for deterministic lifecycle tests
- add a regression test for a child that emits response headers and then stalls forever

## Root cause

`FingerprintRequester.request()` unconditionally cleared `timeoutId` as soon as it parsed `\r\n\r\n`. That is appropriate for long-lived streaming responses, but it also disabled the only JavaScript-side watchdog for normal requests. If the fingerprint child or upstream sent headers and then stopped producing a body without exiting, the Promise could remain pending indefinitely.

The timeout is now cleared after headers only when `onDownloadProgress` identifies the streaming path. Non-stream requests retain the watchdog until the child exits.

## Verification

- deterministic fake-child regression: headers are emitted, the body stalls, and the request rejects with `ECONNABORTED` instead of hanging
- focused harness passed on Node.js 22
- branch is based on current upstream `main` (`849deac8`)

Refs #159
Refs #175